### PR TITLE
docs: expand v1.2.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,23 +13,12 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Support for Technitium AdvancedBlockingApp v10+ refresh interval minutes via `blockListUrlUpdateIntervalMinutes`.
-- UI inputs for list source refresh interval in hours + mins.
-
-### Fixed
-
-- List source refresh interval no longer appears stuck due to a cached reload after saving.
-- Minutes input UX: allows clearing the default `0` while typing (prevents "0" from snapping back mid-edit).
-- Added frontend regression test for the minutes input editing behavior.
-
-## [1.2.0] - 2025-12-16
-
-### Added
-
 - Optional session-based authentication behind `AUTH_SESSION_ENABLED=true`, using HttpOnly cookies and server-side session storage.
 - Dedicated `TECHNITIUM_BACKGROUND_TOKEN` support so background PTR/hostname work can run safely in session-auth mode.
 - Guided migration from `TECHNITIUM_CLUSTER_TOKEN` → `TECHNITIUM_BACKGROUND_TOKEN`, including token creation + validation.
 - Backend Jest tests and frontend Vitest/RTL tests covering the new auth + migration flows.
+- Support for Technitium AdvancedBlockingApp v10+ refresh interval minutes via `blockListUrlUpdateIntervalMinutes`.
+- UI inputs for list source refresh interval in hours + mins.
 
 ### Changed
 
@@ -39,6 +28,9 @@ All notable changes to this project will be documented in this file.
 
 - Reduced/no-op behavior for background PTR warming when it cannot run (e.g., no request/session context), preventing noisy failures.
 - Request-context middleware registration to avoid intermittent auth/session issues across routes.
+- List source refresh interval no longer appears stuck due to a cached reload after saving.
+- Minutes input UX: allows clearing the default `0` while typing (prevents "0" from snapping back mid-edit).
+- Added frontend regression test for the minutes input editing behavior.
 
 ### Security
 
@@ -131,7 +123,7 @@ All notable changes to this project will be documented in this file.
 - Initial public release of Technitium DNS Companion with responsive React frontend, NestJS backend, and multi-node Technitium DNS management.
 
 [Unreleased]: https://github.com/Fail-Safe/Technitium-DNS-Companion/compare/v1.2.1...HEAD
-[1.2.0]: https://github.com/Fail-Safe/Technitium-DNS-Companion/compare/v1.1.6...v1.2.0
+[1.2.1]: https://github.com/Fail-Safe/Technitium-DNS-Companion/compare/v1.1.6...v1.2.1
 [1.1.6]: https://github.com/Fail-Safe/Technitium-DNS-Companion/compare/v1.1.5...v1.1.6
 [1.1.5]: https://github.com/Fail-Safe/Technitium-DNS-Companion/compare/v1.1.4...v1.1.5
 [1.1.4]: https://github.com/Fail-Safe/Technitium-DNS-Companion/compare/v1.1.3...v1.1.4


### PR DESCRIPTION
Expands the v1.2.1 changelog section to include the authentication/session and background-token migration work that shipped with v1.2.1, so the repository changelog matches the GitHub Release notes.

- Moves auth/session/migration/security bullets into the 1.2.1 section
- Removes the unused 1.2.0 section/link (no v1.2.0 tag exists)
- Adds a correct 1.2.1 compare link