### PR TITLE
fix: reduce DNS lookups during Query Logs polling

### DIFF
--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -21,6 +21,11 @@ import type {
 export class AuthService {
   private readonly logger = new Logger(AuthService.name);
 
+  private readonly httpsAgent = new https.Agent({
+    rejectUnauthorized: false,
+    keepAlive: true,
+  });
+
   private async verifyTokenForNode(args: {
     nodeId: string;
     baseUrl: string;
@@ -31,7 +36,7 @@ export class AuthService {
         params: { token: args.token },
         timeout: 15_000,
         maxRedirects: 0,
-        httpsAgent: new https.Agent({ rejectUnauthorized: false }),
+        httpsAgent: this.httpsAgent,
       });
 
       const status =
@@ -148,7 +153,7 @@ export class AuthService {
           params: { user: username, pass: password, ...(totp ? { totp } : {}) },
           timeout: 30_000,
           maxRedirects: 0,
-          httpsAgent: new https.Agent({ rejectUnauthorized: false }),
+          httpsAgent: this.httpsAgent,
         });
 
         const status =
@@ -248,7 +253,7 @@ export class AuthService {
         await axios.get(`${node.baseUrl}/api/user/logout`, {
           params: { token },
           timeout: 15_000,
-          httpsAgent: new https.Agent({ rejectUnauthorized: false }),
+          httpsAgent: this.httpsAgent,
         });
       } catch (error) {
         const message =


### PR DESCRIPTION
Fixes #23.

Query Logs tail mode can refresh every 1–3 seconds; with multiple nodes configured that can lead to frequent outbound calls.

This change reduces DNS lookup churn by:
- Reusing a keep-alive HTTPS agent for Technitium API calls (instead of creating a new agent per request)
- Adding a small TTL cache around cluster hostname resolution (dns.resolve4) used during node/cluster mapping

Backend tests: `npm -w apps/backend test`