### PR TITLE
Fix DHCP Scopes page rendering on small screens

### DIFF
--- a/apps/frontend/src/App.css
+++ b/apps/frontend/src/App.css
@@ -5162,7 +5162,9 @@ button.danger:disabled {
   background: var(--color-bg-secondary);
   padding: 0.5rem;
   max-width: 100%;
-  min-width: 960px;
+  min-width: 0;
+  width: 100%;
+  overflow-x: auto;
   -webkit-overflow-scrolling: touch;
   border-radius: 0.75rem;
   margin-bottom: 1rem;

--- a/apps/frontend/src/components/dhcp/DhcpSnapshotDrawer.css
+++ b/apps/frontend/src/components/dhcp/DhcpSnapshotDrawer.css
@@ -335,13 +335,15 @@
 
 @media (max-width: 768px) {
   .drawer-pull {
-    top: auto;
-    bottom: 16px;
-    right: 12px;
-    writing-mode: horizontal-tb;
-    text-orientation: initial;
-    padding: 10px 14px;
-    border-radius: 16px;
+    /* Keep the same pinned, vertical affordance on mobile (matches desktop) */
+    top: 50%;
+    right: 0;
+    bottom: auto;
+    transform: translateY(-50%);
+    writing-mode: vertical-rl;
+    text-orientation: mixed;
+    padding: 10px 9px;
+    border-radius: 12px 0 0 12px;
   }
 }
 


### PR DESCRIPTION
Adjustments to the CSS ensure the DHCP Scopes page renders correctly on small screens by modifying width properties and enhancing mobile layout.

Fixes #18