### PR TITLE
feat: add Docker secrets _FILE suffix support for environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,28 @@ TECHNITIUM_CLUSTER_TOKEN=your-shared-cluster-token
 #  Note: starting in v1.4, the UI will require Technitium login/RBAC; env-token mode is
 #  intended only for legacy/migration.
 
+## Docker Secrets / File-based Secrets Support - OPTIONAL
+#
+#  For sensitive environment variables, you can use the `_FILE` suffix pattern
+#  common in Docker containers. When `VAR_FILE` is set, the application reads
+#  the secret value from that file path instead of expecting `VAR` directly.
+#
+#  This is useful for:
+#    - Docker Swarm secrets (mounted at /run/secrets/)
+#    - Kubernetes secrets (mounted as files)
+#    - Any file-based secrets management
+#
+#  Supported variables:
+#    TECHNITIUM_CLUSTER_TOKEN_FILE     -> reads TECHNITIUM_CLUSTER_TOKEN from file
+#    TECHNITIUM_BACKGROUND_TOKEN_FILE  -> reads TECHNITIUM_BACKGROUND_TOKEN from file
+#    TECHNITIUM_<NODE>_TOKEN_FILE      -> reads per-node token from file
+#
+#  Example (Docker Swarm):
+#    TECHNITIUM_CLUSTER_TOKEN_FILE=/run/secrets/technitium_cluster_token
+#    TECHNITIUM_BACKGROUND_TOKEN_FILE=/run/secrets/technitium_background_token
+#
+#  The _FILE variant takes precedence if both are set.
+
 ## Base URL for each node - REQUIRED
 #
 #  For BASE_URL, use the URL including port number that you use to access

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -6,6 +6,10 @@ import { NextFunction, Request, Response } from "express";
 import { existsSync, readFileSync, readdirSync } from "fs";
 import { basename, dirname, join, resolve } from "path";
 import { AppModule } from "./app.module";
+import { resolveEnvFileVariables } from "./utils/env-file";
+
+// Resolve _FILE environment variables early, before any module reads process.env
+resolveEnvFileVariables();
 
 const ONE_YEAR_IN_SECONDS = 60 * 60 * 24 * 365;
 

--- a/apps/backend/src/utils/env-file.spec.ts
+++ b/apps/backend/src/utils/env-file.spec.ts
@@ -1,0 +1,132 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { getEnvOrFile, resolveEnvFileVariables } from "./env-file";
+
+describe("env-file utilities", () => {
+  const testDir = join(tmpdir(), "tdc-env-file-test");
+
+  beforeAll(() => {
+    if (!existsSync(testDir)) {
+      mkdirSync(testDir, { recursive: true });
+    }
+  });
+
+  afterAll(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    // Clean up env vars before each test
+    delete process.env.TEST_VAR;
+    delete process.env.TEST_VAR_FILE;
+    delete process.env.TECHNITIUM_CLUSTER_TOKEN;
+    delete process.env.TECHNITIUM_CLUSTER_TOKEN_FILE;
+    delete process.env.TECHNITIUM_BACKGROUND_TOKEN;
+    delete process.env.TECHNITIUM_BACKGROUND_TOKEN_FILE;
+    delete process.env.TECHNITIUM_NODES;
+    delete process.env.TECHNITIUM_NODE1_TOKEN;
+    delete process.env.TECHNITIUM_NODE1_TOKEN_FILE;
+  });
+
+  describe("getEnvOrFile", () => {
+    it("should return direct env value when no _FILE variant is set", () => {
+      process.env.TEST_VAR = "direct-value";
+
+      const result = getEnvOrFile("TEST_VAR");
+
+      expect(result).toBe("direct-value");
+    });
+
+    it("should return undefined when neither variant is set", () => {
+      const result = getEnvOrFile("TEST_VAR");
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should read file contents when _FILE variant is set", () => {
+      const filePath = join(testDir, "test-secret.txt");
+      writeFileSync(filePath, "file-secret-value");
+      process.env.TEST_VAR_FILE = filePath;
+
+      const result = getEnvOrFile("TEST_VAR");
+
+      expect(result).toBe("file-secret-value");
+    });
+
+    it("should trim whitespace from file contents", () => {
+      const filePath = join(testDir, "test-whitespace.txt");
+      writeFileSync(filePath, "  secret-with-whitespace  \n\n");
+      process.env.TEST_VAR_FILE = filePath;
+
+      const result = getEnvOrFile("TEST_VAR");
+
+      expect(result).toBe("secret-with-whitespace");
+    });
+
+    it("should prefer _FILE variant over direct env value", () => {
+      const filePath = join(testDir, "test-priority.txt");
+      writeFileSync(filePath, "file-value");
+      process.env.TEST_VAR = "direct-value";
+      process.env.TEST_VAR_FILE = filePath;
+
+      const result = getEnvOrFile("TEST_VAR");
+
+      expect(result).toBe("file-value");
+    });
+
+    it("should return undefined when _FILE points to non-existent file", () => {
+      process.env.TEST_VAR_FILE = "/non/existent/path.txt";
+
+      const result = getEnvOrFile("TEST_VAR");
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("resolveEnvFileVariables", () => {
+    it("should resolve TECHNITIUM_CLUSTER_TOKEN from file", () => {
+      const filePath = join(testDir, "cluster-token.txt");
+      writeFileSync(filePath, "my-cluster-token");
+      process.env.TECHNITIUM_CLUSTER_TOKEN_FILE = filePath;
+
+      resolveEnvFileVariables();
+
+      expect(process.env.TECHNITIUM_CLUSTER_TOKEN).toBe("my-cluster-token");
+    });
+
+    it("should resolve TECHNITIUM_BACKGROUND_TOKEN from file", () => {
+      const filePath = join(testDir, "background-token.txt");
+      writeFileSync(filePath, "my-background-token");
+      process.env.TECHNITIUM_BACKGROUND_TOKEN_FILE = filePath;
+
+      resolveEnvFileVariables();
+
+      expect(process.env.TECHNITIUM_BACKGROUND_TOKEN).toBe(
+        "my-background-token",
+      );
+    });
+
+    it("should resolve per-node tokens from files", () => {
+      const filePath = join(testDir, "node1-token.txt");
+      writeFileSync(filePath, "node1-secret-token");
+      process.env.TECHNITIUM_NODES = "node1";
+      process.env.TECHNITIUM_NODE1_TOKEN_FILE = filePath;
+
+      resolveEnvFileVariables();
+
+      expect(process.env.TECHNITIUM_NODE1_TOKEN).toBe("node1-secret-token");
+    });
+
+    it("should not overwrite existing env values", () => {
+      const filePath = join(testDir, "should-not-use.txt");
+      writeFileSync(filePath, "file-value");
+      process.env.TECHNITIUM_CLUSTER_TOKEN = "existing-value";
+      process.env.TECHNITIUM_CLUSTER_TOKEN_FILE = filePath;
+
+      resolveEnvFileVariables();
+
+      expect(process.env.TECHNITIUM_CLUSTER_TOKEN).toBe("existing-value");
+    });
+  });
+});

--- a/apps/backend/src/utils/env-file.ts
+++ b/apps/backend/src/utils/env-file.ts
@@ -1,0 +1,120 @@
+import { existsSync, readFileSync } from "fs";
+import { Logger } from "@nestjs/common";
+
+const logger = new Logger("EnvFile");
+
+/**
+ * Reads an environment variable with support for Docker secrets / file-based secrets.
+ *
+ * For any environment variable `VAR`, this function first checks if `VAR_FILE` is set.
+ * If `VAR_FILE` is set and points to a readable file, the file contents are returned
+ * (with trailing whitespace trimmed). Otherwise, the value of `VAR` is returned.
+ *
+ * This pattern is commonly used with Docker Swarm secrets and Kubernetes secret mounts
+ * where sensitive values are stored in files (e.g., `/run/secrets/my_token`).
+ *
+ * @example
+ * // With TECHNITIUM_TOKEN_FILE=/run/secrets/token
+ * const token = getEnvOrFile("TECHNITIUM_TOKEN");
+ * // Returns contents of /run/secrets/token
+ *
+ * @example
+ * // With TECHNITIUM_TOKEN=my-api-token (no _FILE variant set)
+ * const token = getEnvOrFile("TECHNITIUM_TOKEN");
+ * // Returns "my-api-token"
+ *
+ * @param envVar - The base environment variable name (without _FILE suffix)
+ * @param options - Optional configuration
+ * @param options.required - If true, logs a warning when neither VAR nor VAR_FILE is set
+ * @returns The value from the file (if VAR_FILE is set) or from the environment variable, or undefined
+ */
+export function getEnvOrFile(
+  envVar: string,
+  options?: { required?: boolean },
+): string | undefined {
+  const fileEnvVar = `${envVar}_FILE`;
+  const filePath = process.env[fileEnvVar];
+
+  // If _FILE variant is set, read from file
+  if (filePath) {
+    if (!existsSync(filePath)) {
+      logger.error(
+        `${fileEnvVar} is set to "${filePath}" but the file does not exist`,
+      );
+      return undefined;
+    }
+
+    try {
+      const content = readFileSync(filePath, "utf-8").trim();
+      logger.debug(
+        `Loaded ${envVar} from file specified by ${fileEnvVar} (${filePath})`,
+      );
+      return content;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      logger.error(`Failed to read file for ${fileEnvVar}: ${message}`);
+      return undefined;
+    }
+  }
+
+  // Fall back to direct environment variable
+  const directValue = process.env[envVar];
+
+  if (directValue === undefined && options?.required) {
+    logger.warn(
+      `Neither ${envVar} nor ${fileEnvVar} is set (expected for this configuration)`,
+    );
+  }
+
+  return directValue;
+}
+
+/**
+ * Resolves all _FILE environment variables at startup and populates process.env.
+ *
+ * This should be called early in application bootstrap, before dotenv/config or
+ * any module that reads environment variables.
+ *
+ * Supported variables:
+ * - TECHNITIUM_CLUSTER_TOKEN
+ * - TECHNITIUM_BACKGROUND_TOKEN
+ * - TECHNITIUM_<NODE>_TOKEN (for each node in TECHNITIUM_NODES)
+ *
+ * @example
+ * // In main.ts, call before other imports
+ * resolveEnvFileVariables();
+ */
+export function resolveEnvFileVariables(): void {
+  const sensitiveVars = [
+    "TECHNITIUM_CLUSTER_TOKEN",
+    "TECHNITIUM_BACKGROUND_TOKEN",
+  ];
+
+  // Resolve statically-known sensitive variables
+  for (const envVar of sensitiveVars) {
+    const value = getEnvOrFile(envVar);
+    if (value !== undefined && process.env[envVar] === undefined) {
+      process.env[envVar] = value;
+      logger.log(`Loaded ${envVar} from ${envVar}_FILE`);
+    }
+  }
+
+  // Resolve per-node tokens if TECHNITIUM_NODES is configured
+  const nodes = process.env.TECHNITIUM_NODES;
+  if (nodes) {
+    const nodeIds = nodes
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+
+    for (const nodeId of nodeIds) {
+      const sanitizedKey = nodeId.replace(/[^A-Za-z0-9]/g, "").toUpperCase();
+      const tokenVar = `TECHNITIUM_${sanitizedKey}_TOKEN`;
+      const value = getEnvOrFile(tokenVar);
+      if (value !== undefined && process.env[tokenVar] === undefined) {
+        process.env[tokenVar] = value;
+        logger.log(`Loaded ${tokenVar} from ${tokenVar}_FILE`);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds support for Docker secrets via the standard `_FILE` suffix pattern.

## Changes
- New utility (`env-file.ts`) that resolves `VAR_FILE` → reads file → sets `VAR`
- Runs at bootstrap before any module reads `process.env`
- Supports: `TECHNITIUM_CLUSTER_TOKEN_FILE`, `TECHNITIUM_BACKGROUND_TOKEN_FILE`, `TECHNITIUM_<NODE>_TOKEN_FILE`

## Usage
```yaml
secrets:
  background_token:
    external: true

services:
  technitium-dns-companion:
    environment:
      TECHNITIUM_BACKGROUND_TOKEN_FILE: /run/secrets/background_token
    secrets:
      - background_token