### PR TITLE
feat: add AUTH_ALLOW_INSECURE_HTTP bypass option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,6 +120,12 @@ TECHNITIUM_NODE2_BASE_URL=http://192.168.1.11:5380
 # - Set to 2 for: CDN/LB (e.g., Cloudflare) -> reverse proxy -> Companion
 # - Do NOT enable TRUST_PROXY unless you control/trust the proxy chain; otherwise clients can spoof forwarded headers.
 
+# Insecure HTTP bypass (NOT RECOMMENDED)
+# Allows session auth over plain HTTP without TLS. Credentials and cookies will be sent in plain text.
+# Only use this in isolated/trusted networks (e.g., homelab behind a firewall with no untrusted users).
+#
+# AUTH_ALLOW_INSECURE_HTTP=true
+
 ## Background Token (read-only, for background jobs) - OPTIONAL
 #
 # NOTE (planned change): As of v1.3, TECHNITIUM_BACKGROUND_TOKEN is expected to be REQUIRED

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -49,6 +49,7 @@ async function bootstrap() {
   const httpsEnabled = process.env.HTTPS_ENABLED === "true";
   const sessionAuthEnabled = process.env.AUTH_SESSION_ENABLED === "true";
   const trustProxyEnabled = process.env.TRUST_PROXY === "true";
+  const allowInsecureHttp = process.env.AUTH_ALLOW_INSECURE_HTTP === "true";
   const clusterTokenConfigured =
     (process.env.TECHNITIUM_CLUSTER_TOKEN ?? "").trim().length > 0;
   const trustProxyHops = Number.parseInt(
@@ -59,16 +60,31 @@ async function bootstrap() {
     Number.isFinite(trustProxyHops) && trustProxyHops > 0 ? trustProxyHops : 1;
 
   if (sessionAuthEnabled && !httpsEnabled && !trustProxyEnabled) {
-    logger.error(
-      "AUTH_SESSION_ENABLED=true requires HTTPS to protect session cookies and login credentials.",
-    );
-    logger.error(
-      "Option A (recommended): Enable built-in HTTPS by setting HTTPS_ENABLED=true and configuring certificate paths.",
-    );
-    logger.error(
-      "Option B: Terminate TLS in a reverse proxy and set TRUST_PROXY=true so the backend can detect HTTPS via X-Forwarded-Proto.",
-    );
-    process.exit(1);
+    if (allowInsecureHttp) {
+      logger.warn(
+        "⚠️  AUTH_ALLOW_INSECURE_HTTP=true: Session auth running over HTTP without TLS.",
+      );
+      logger.warn(
+        "⚠️  Credentials and session cookies will be transmitted in plain text.",
+      );
+      logger.warn(
+        "⚠️  Only use this in isolated/trusted networks. NOT recommended for production.",
+      );
+    } else {
+      logger.error(
+        "AUTH_SESSION_ENABLED=true requires HTTPS to protect session cookies and login credentials.",
+      );
+      logger.error(
+        "Enable built-in HTTPS by setting HTTPS_ENABLED=true and configuring certificate paths.",
+      );
+      logger.error(
+        "Or terminate TLS in a reverse proxy and set TRUST_PROXY=true so the backend can detect HTTPS via X-Forwarded-Proto.",
+      );
+      logger.error(
+        "Or set AUTH_ALLOW_INSECURE_HTTP=true to bypass this check entirely (credentials sent in plain text, not recommended).",
+      );
+      process.exit(1);
+    }
   }
 
   if (clusterTokenConfigured) {


### PR DESCRIPTION
## Summary

Adds `AUTH_ALLOW_INSECURE_HTTP=true` to bypass the HTTPS requirement for session auth.

## Use Case

Addresses #30 — homelab users on isolated networks who want session auth without setting up TLS infrastructure.

## Changes

- New env var: `AUTH_ALLOW_INSECURE_HTTP=true`
- When set, allows session auth over plain HTTP with prominent warnings
- Logs clear warnings about credentials being transmitted in plain text

## Usage

```env
AUTH_SESSION_ENABLED=true
AUTH_ALLOW_INSECURE_HTTP=true
```

---

**Note:** This is one of two complementary PRs for #30. See also the self-signed HTTPS PR (#34).

These can be merged independently, together, or neither. If both are merged, they could potentially be combined into saner defaults in the future — for example, always generating a self-signed cert by default (like Traefik does) and optionally exposing an insecure HTTP entrypoint for those who explicitly need it.