### PR TITLE
ci(docker): keep main/latest/semver tags aligned

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,6 +38,10 @@ jobs:
         id: package-version
         run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
+      - name: Derive major.minor version tag
+        id: package-version-minor
+        run: echo "major_minor=$(node -p \"const [major,minor]=require('./package.json').version.split('.'); `${major}.${minor}`\")" >> $GITHUB_OUTPUT
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -58,15 +62,19 @@ jobs:
             org.opencontainers.image.title=Technitium DNS Companion
             org.opencontainers.image.description=Web UI to manage and sync multiple Technitium DNS servers (Technitium DNS Companion)
           tags: |
-            # Always tag release images as latest
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
-            # Keep a moving tag for current main branch image
+            # Keep `main` as the moving branch tag
             type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
+            # Keep `latest` aligned with main branch images for consistency
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            # Keep semver tags aligned with main branch image based on package.json version
+            type=raw,value=${{ steps.package-version.outputs.version }},enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=${{ steps.package-version-minor.outputs.major_minor }},enable=${{ github.ref == 'refs/heads/main' }}
             # Provide a non-pushed tag for manual builds (helps avoid empty-tag edge cases)
             type=raw,value=manual,enable=${{ github.event_name == 'workflow_dispatch' }}
             # Manual runs: include a unique sha tag (safe for optional pushing)
             type=sha,enable=${{ github.event_name == 'workflow_dispatch' }}
-            # Tag with git tag (v1.0.0)
+            # Also tag with git tag (v1.0.0) for release events
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
             type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/') }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/') }}
 


### PR DESCRIPTION
## Summary
- align Docker tags on `main` pushes so the same image digest is published as:
  - `main`
  - `latest`
  - `<major>.<minor>` from `package.json`
  - `<major>.<minor>.<patch>` from `package.json`
- preserve release-tag behavior (`v*`) for semver and `latest` tagging

## Why
- ensures users pulling `main`, `latest`, or semver tags receive the same image
- removes digest drift confusion between branch and release tags

## Scope
- one file: `.github/workflows/docker-publish.yml`
- one commit cherry-picked from `next`: `172c8a5`
