### PR TITLE
ci(docker): fix major.minor tag derivation quoting

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Derive major.minor version tag
         id: package-version-minor
-        run: echo "major_minor=$(node -p \"const [major,minor]=require('./package.json').version.split('.'); `${major}.${minor}`\")" >> $GITHUB_OUTPUT
+        run: echo "major_minor=$(node -p \"const [major,minor]=require('./package.json').version.split('.'); major + '.' + minor\")" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Summary
- fix shell quoting bug in major.minor tag derivation step
- restores successful docker-publish workflow on main

## Root cause
- template-literal backticks in the node expression were interpreted by the shell in GitHub Actions

## Scope
- one-line change in 
