### PR TITLE
ci(docker): add tag digest consistency guard

### DIFF
--- a/.github/workflows/docker-tag-consistency.yml
+++ b/.github/workflows/docker-tag-consistency.yml
@@ -1,0 +1,64 @@
+name: Verify Docker Tag Consistency
+
+on:
+  workflow_run:
+    workflows:
+      - Build and Push Docker Image
+    types:
+      - completed
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  IMAGE: ghcr.io/fail-safe/technitium-dns-companion
+
+jobs:
+  verify-tags:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Derive version tags
+        id: version
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "major_minor=${version%.*}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify digest alignment for required tags
+        shell: bash
+        run: |
+          set -euo pipefail
+          tags=(main latest "${{ steps.version.outputs.major_minor }}" "${{ steps.version.outputs.version }}")
+          baseline_digest=""
+
+          for tag in "${tags[@]}"; do
+            digest="$(docker buildx imagetools inspect "$IMAGE:$tag" 2>/dev/null | awk '/^Digest:/ {print $2; exit}')"
+
+            if [[ -z "$digest" ]]; then
+              echo "❌ Unable to resolve digest for tag '$tag' from $IMAGE"
+              exit 1
+            fi
+
+            echo "Tag '$tag' -> $digest"
+
+            if [[ -z "$baseline_digest" ]]; then
+              baseline_digest="$digest"
+              continue
+            fi
+
+            if [[ "$digest" != "$baseline_digest" ]]; then
+              echo "❌ Tag digest mismatch detected"
+              echo "Expected: $baseline_digest"
+              echo "Actual  : $digest (tag: $tag)"
+              exit 1
+            fi
+          done
+
+          echo "✅ All required tags are aligned at $baseline_digest"


### PR DESCRIPTION
## Summary
- add a dedicated workflow to verify GHCR tag consistency for `main`, `latest`, `X.Y`, and `X.Y.Z`
- trigger automatically after successful `Build and Push Docker Image` runs on `main`
- support manual `workflow_dispatch` for on-demand verification

## Why
- prevents silent drift between tags that should always point to the same image digest
- enforces the new consistency policy continuously

## Validation
- workflow resolves and compares top-level digests using `docker buildx imagetools inspect`
- fails the run if any required tag digest differs
