### PR TITLE
fix: route advanced blocking writes through primary

### DIFF
--- a/apps/backend/src/technitium/advanced-blocking.types.ts
+++ b/apps/backend/src/technitium/advanced-blocking.types.ts
@@ -67,6 +67,7 @@ export interface AdvancedBlockingOverview {
 export interface AdvancedBlockingUpdateRequest {
   config: AdvancedBlockingConfig;
   snapshotNote?: string;
+  cacheDomain?: string;
 }
 
 /**

--- a/apps/backend/src/technitium/technitium.controller.ts
+++ b/apps/backend/src/technitium/technitium.controller.ts
@@ -555,15 +555,23 @@ export class TechnitiumController {
       throw new BadRequestException("Advanced Blocking config is required.");
     }
 
+    const { perCandidate } =
+      await this.technitiumService.resolveClusterWriteTargets([nodeId]);
+    const writePlan = perCandidate.get(nodeId);
+    const writeNodeId = writePlan?.writeTarget ?? nodeId;
+    const flushNodeIds = writePlan?.flushNodes ?? [writeNodeId];
+
     // Best-effort automatic snapshot for rollback before applying changes.
     // Do not block the save if snapshot creation fails.
     const requestNote =
       typeof body.snapshotNote === "string" ? body.snapshotNote.trim() : "";
     const snapshotNote = requestNote.length > 0 ? requestNote : undefined;
+    const cacheDomain =
+      typeof body.cacheDomain === "string" ? body.cacheDomain.trim() : "";
 
     try {
       await this.dnsFilteringSnapshotService.saveSnapshot(
-        nodeId,
+        writeNodeId,
         "advanced-blocking",
         "automatic",
         snapshotNote ??
@@ -571,11 +579,34 @@ export class TechnitiumController {
       );
     } catch (error) {
       this.logger.warn(
-        `Failed to create automatic DNS filtering snapshot before Advanced Blocking save for node ${nodeId}: ${error instanceof Error ? error.message : String(error)}`,
+        `Failed to create automatic DNS filtering snapshot before Advanced Blocking save for node ${writeNodeId}: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
 
-    return this.advancedBlockingService.setConfig(nodeId, body.config);
+    const snapshot = await this.advancedBlockingService.setConfig(
+      writeNodeId,
+      body.config,
+    );
+
+    if (cacheDomain) {
+      await Promise.all(
+        flushNodeIds.map(async (flushNodeId) => {
+          try {
+            await this.technitiumService.executeAction(flushNodeId, {
+              method: "DELETE",
+              url: "/api/cache/delete",
+              params: { domain: cacheDomain },
+            });
+          } catch (error) {
+            this.logger.warn(
+              `Failed to invalidate cached domain ${cacheDomain} on node ${flushNodeId} after Advanced Blocking save: ${error instanceof Error ? error.message : String(error)}`,
+            );
+          }
+        }),
+      );
+    }
+
+    return snapshot;
   }
 
   @Post(":nodeId/dhcp/scopes/:scopeName/clone")

--- a/apps/backend/src/technitium/technitium.controller.ts
+++ b/apps/backend/src/technitium/technitium.controller.ts
@@ -593,7 +593,7 @@ export class TechnitiumController {
         flushNodeIds.map(async (flushNodeId) => {
           try {
             await this.technitiumService.executeAction(flushNodeId, {
-              method: "DELETE",
+              method: "GET",
               url: "/api/cache/delete",
               params: { domain: cacheDomain },
             });

--- a/apps/backend/src/technitium/technitium.service.spec.ts
+++ b/apps/backend/src/technitium/technitium.service.spec.ts
@@ -1030,3 +1030,66 @@ describe("TechnitiumService — resolveClusterWriteTargets", () => {
     expect(writeTargets).toEqual(["ghost"]);
   });
 });
+
+describe("TechnitiumService — cluster probe failover", () => {
+  let service: TechnitiumService;
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    service.onModuleDestroy();
+  });
+
+  it("tries another configured node when the first cluster probe fails", async () => {
+    const nodes: TechnitiumNodeConfig[] = [
+      { id: "secondary", baseUrl: "https://secondary.test", token: "token" },
+      { id: "primary", baseUrl: "https://primary.test", token: "token" },
+    ];
+    service = new TechnitiumService(nodes, new DhcpSnapshotService());
+    const internals = service as unknown as {
+      request: jest.Mock;
+      resolveHostname: jest.Mock;
+    };
+    internals.request = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("probe unavailable"))
+      .mockResolvedValueOnce({
+        status: "ok",
+        info: {
+          clusterInitialized: true,
+          clusterDomain: "example.test",
+          clusterNodes: [
+            {
+              id: 1,
+              name: "primary",
+              url: "https://primary.test",
+              ipAddress: "192.0.2.10",
+              type: "Primary",
+              state: "Connected",
+            },
+            {
+              id: 2,
+              name: "secondary",
+              url: "https://secondary.test",
+              ipAddress: "192.0.2.11",
+              type: "Secondary",
+              state: "Connected",
+            },
+          ],
+        },
+      });
+    internals.resolveHostname = jest
+      .fn()
+      .mockImplementation((hostname: string) =>
+        Promise.resolve(
+          hostname === "primary.test" ? "192.0.2.10" : "192.0.2.11",
+        ),
+      );
+
+    const summaries = await service.listNodes({ authMode: "background" });
+
+    expect(internals.request).toHaveBeenCalledTimes(2);
+    expect(summaries.find((node) => node.id === "primary")?.isPrimary).toBe(
+      true,
+    );
+  });
+});

--- a/apps/backend/src/technitium/technitium.service.ts
+++ b/apps/backend/src/technitium/technitium.service.ts
@@ -629,75 +629,78 @@ export class TechnitiumService {
     //   would see all nodes as Standalone and skip cluster-aware behavior.
     if (this.nodeConfigs.length > 0) {
       const session = AuthRequestContext.getSession();
-      const probeNode =
+      const probeNodes =
         authMode === "session"
           ? this.sessionAuthEnabled
-            ? this.nodeConfigs.find(
+            ? this.nodeConfigs.filter(
                 (node) => !!session?.tokensByNodeId?.[node.id],
               )
-            : this.nodeConfigs[0]
-          : this.nodeConfigs[0];
+            : this.nodeConfigs
+          : this.nodeConfigs;
 
-      if (!probeNode) {
+      if (probeNodes.length === 0) {
         // No authenticated nodes available (or no nodes configured)
         // -> treat as standalone.
         sharedClusterInfo = null;
       } else {
-        try {
-          // Get full cluster state from first node
-          const response = await this.request<{
-            status: string;
-            info?: {
-              version?: string;
-              clusterInitialized?: boolean;
-              clusterDomain?: string;
-              dnsServerDomain?: string;
-              clusterNodes?: Array<{
-                id: number;
-                name: string;
-                url: string;
-                ipAddress: string;
-                type: "Primary" | "Secondary";
-                state: string;
-              }>;
-            };
-            server?: string;
-          }>(
-            probeNode,
-            {
-              method: "GET",
-              url: "/api/user/session/get",
-              params: {},
-            },
-            { authMode },
-          );
-
-          if (response.status === "ok" && response.info?.clusterInitialized) {
-            const clusterNodes = response.info.clusterNodes || [];
-            sharedClusterInfo = {
-              initialized: true,
-              domain: response.info.clusterDomain,
-              clusterNodes,
-            };
-            const topologyFingerprint = this.buildClusterTopologyFingerprint(
-              response.info.clusterDomain,
-              clusterNodes,
+        for (const probeNode of probeNodes) {
+          try {
+            // Get full cluster state from first node
+            const response = await this.request<{
+              status: string;
+              info?: {
+                version?: string;
+                clusterInitialized?: boolean;
+                clusterDomain?: string;
+                dnsServerDomain?: string;
+                clusterNodes?: Array<{
+                  id: number;
+                  name: string;
+                  url: string;
+                  ipAddress: string;
+                  type: "Primary" | "Secondary";
+                  state: string;
+                }>;
+              };
+              server?: string;
+            }>(
+              probeNode,
+              {
+                method: "GET",
+                url: "/api/user/session/get",
+                params: {},
+              },
+              { authMode },
             );
-            if (this.shouldLogClusterTopology(topologyFingerprint)) {
-              this.logger.log(
-                `Cluster detected: ${response.info.clusterDomain} with ${clusterNodes.length} nodes`,
+
+            if (response.status === "ok" && response.info?.clusterInitialized) {
+              const clusterNodes = response.info.clusterNodes || [];
+              sharedClusterInfo = {
+                initialized: true,
+                domain: response.info.clusterDomain,
+                clusterNodes,
+              };
+              const topologyFingerprint = this.buildClusterTopologyFingerprint(
+                response.info.clusterDomain,
+                clusterNodes,
               );
-              for (const cn of clusterNodes) {
-                this.logger.debug(
-                  `  Cluster node: name="${cn.name}", url="${cn.url}", ip="${cn.ipAddress}", type="${cn.type}"`,
+              if (this.shouldLogClusterTopology(topologyFingerprint)) {
+                this.logger.log(
+                  `Cluster detected: ${response.info.clusterDomain} with ${clusterNodes.length} nodes`,
                 );
+                for (const cn of clusterNodes) {
+                  this.logger.debug(
+                    `  Cluster node: name="${cn.name}", url="${cn.url}", ip="${cn.ipAddress}", type="${cn.type}"`,
+                  );
+                }
               }
+              break;
             }
+          } catch (error) {
+            this.logger.warn(
+              `Failed to fetch cluster state from probe node ${probeNode.id}, trying another configured node: ${error}`,
+            );
           }
-        } catch (error) {
-          this.logger.warn(
-            `Failed to fetch cluster state from probe node ${probeNode.id}, will treat all as standalone: ${error}`,
-          );
         }
       }
     }

--- a/apps/backend/src/technitium/technitium.types.ts
+++ b/apps/backend/src/technitium/technitium.types.ts
@@ -76,7 +76,7 @@ export type TechnitiumActionCategory =
   | "advancedBlocking";
 
 export interface TechnitiumActionPayload {
-  method: "GET" | "POST";
+  method: "GET" | "POST" | "DELETE";
   url: string;
   params?: Record<string, string | number | boolean>;
   headers?: Record<string, string>;

--- a/apps/backend/src/technitium/technitium.types.ts
+++ b/apps/backend/src/technitium/technitium.types.ts
@@ -76,7 +76,7 @@ export type TechnitiumActionCategory =
   | "advancedBlocking";
 
 export interface TechnitiumActionPayload {
-  method: "GET" | "POST" | "DELETE";
+  method: "GET" | "POST";
   url: string;
   params?: Record<string, string | number | boolean>;
   headers?: Record<string, string>;

--- a/apps/frontend/src/context/TechnitiumContext.tsx
+++ b/apps/frontend/src/context/TechnitiumContext.tsx
@@ -122,6 +122,7 @@ export interface TechnitiumState {
     nodeId: string,
     config: AdvancedBlockingConfig,
     snapshotNote?: string,
+    cacheDomain?: string,
   ) => Promise<AdvancedBlockingSnapshot | undefined>;
   // Built-in Blocking state
   builtInBlocking?: BuiltInBlockingOverview;
@@ -1165,6 +1166,7 @@ export function TechnitiumProvider({ children }: { children: ReactNode }) {
       nodeId: string,
       config: AdvancedBlockingConfig,
       snapshotNote?: string,
+      cacheDomain?: string,
     ) => {
       try {
         const response = await apiFetch(
@@ -1172,7 +1174,7 @@ export function TechnitiumProvider({ children }: { children: ReactNode }) {
           {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ config, snapshotNote }),
+            body: JSON.stringify({ config, snapshotNote, cacheDomain }),
           },
         );
 

--- a/apps/frontend/src/pages/LogsPage.tsx
+++ b/apps/frontend/src/pages/LogsPage.tsx
@@ -33,6 +33,10 @@ import type {
   AdvancedBlockingConfig,
   AdvancedBlockingGroup,
 } from "../types/advancedBlocking";
+import {
+  resolveAdvancedBlockingWriteNodeId,
+  selectAdvancedBlockingWriteSnapshots,
+} from "../utils/advanced-blocking-routing";
 import type {
   LogAlertEvaluatorStatus,
   LogAlertCapabilitiesResponse,
@@ -4051,8 +4055,12 @@ export function LogsPage() {
         // Open the modal immediately (spinner UX) and let the modal content reflect
         // Advanced Blocking loading state instead of forcing the user to retry.
         const domain = entry.qname ?? "";
+        const writeNodeId = resolveAdvancedBlockingWriteNodeId(
+          nodes,
+          entry.nodeId,
+        );
         const snapshot = advancedBlocking?.nodes?.find(
-          (nodeConfig) => nodeConfig.nodeId === entry.nodeId,
+          (nodeConfig) => nodeConfig.nodeId === writeNodeId,
         );
         const groups = snapshot?.config?.groups ?? [];
 
@@ -4061,7 +4069,7 @@ export function LogsPage() {
         // Only hard-fail early if we already have a payload and it explicitly errored for this node.
         if (advancedBlocking && !snapshot?.config && snapshot?.error) {
           setBlockError(
-            `Failed to load Advanced Blocking config for node "${entry.nodeId}": ${snapshot.error}`,
+            `Failed to load Advanced Blocking config for node "${writeNodeId}": ${snapshot.error}`,
           );
         }
 
@@ -4165,6 +4173,7 @@ export function LogsPage() {
       displayMode,
       tailPaused,
       blockingStatus?.nodes,
+      nodes,
     ],
   );
 
@@ -4587,10 +4596,14 @@ export function LogsPage() {
       return undefined;
     }
 
-    return advancedBlocking?.nodes?.find(
-      (snapshot) => snapshot.nodeId === blockDialog.entry.nodeId,
+    const writeNodeId = resolveAdvancedBlockingWriteNodeId(
+      nodes,
+      blockDialog.entry.nodeId,
     );
-  }, [advancedBlocking, blockDialog]);
+    return advancedBlocking?.nodes?.find(
+      (snapshot) => snapshot.nodeId === writeNodeId,
+    );
+  }, [advancedBlocking, blockDialog, nodes]);
 
   const blockAvailableGroups = useMemo(
     () => blockDialogSnapshot?.config?.groups ?? [],
@@ -4604,6 +4617,18 @@ export function LogsPage() {
   );
   const blockNodeLabel = blockDialog
     ? (nodeMap.get(blockDialog.entry.nodeId)?.name ?? blockDialog.entry.nodeId)
+    : "";
+  const blockWriteNodeId = blockDialog
+    ? resolveAdvancedBlockingWriteNodeId(nodes, blockDialog.entry.nodeId)
+    : "";
+  const blockWriteNodeLabel = blockWriteNodeId
+    ? (nodeMap.get(blockWriteNodeId)?.name ?? blockWriteNodeId)
+    : "";
+  const advancedBlockingPrimaryNode = nodes.find(
+    (node) => node.isPrimary === true,
+  );
+  const advancedBlockingPrimaryLabel = advancedBlockingPrimaryNode
+    ? advancedBlockingPrimaryNode.name || advancedBlockingPrimaryNode.id
     : "";
   const isBlockedEntry = blockDialog
     ? isEntryBlocked(blockDialog.entry)
@@ -4703,11 +4728,15 @@ export function LogsPage() {
   // For bulk actions, collect groups from all nodes
   const availableGroupsForSelection = useMemo(() => {
     if (bulkAction) {
-      // Get union of all groups from all nodes
+      // Cluster writes use the Primary's authoritative config. Standalone nodes
+      // retain the existing union-of-groups behavior.
       const groupMap = new Map<string, AdvancedBlockingGroup>();
-      const nodes = advancedBlocking?.nodes ?? [];
+      const snapshots = selectAdvancedBlockingWriteSnapshots(
+        nodes,
+        advancedBlocking?.nodes ?? [],
+      );
 
-      nodes.forEach((snapshot) => {
+      snapshots.forEach((snapshot) => {
         const groups = snapshot.config?.groups ?? [];
         groups.forEach((group) => {
           if (!groupMap.has(group.name)) {
@@ -4719,7 +4748,7 @@ export function LogsPage() {
       return Array.from(groupMap.values());
     }
     return blockAvailableGroups;
-  }, [bulkAction, advancedBlocking, blockAvailableGroups]);
+  }, [bulkAction, advancedBlocking, blockAvailableGroups, nodes]);
 
   const modalTitle =
     blockingAction === "allow"
@@ -5145,7 +5174,12 @@ export function LogsPage() {
 
     try {
       setIsBlocking(true);
-      await saveAdvancedBlockingConfig(blockDialog.entry.nodeId, updatedConfig);
+      await saveAdvancedBlockingConfig(
+        blockWriteNodeId,
+        updatedConfig,
+        undefined,
+        domain,
+      );
 
       // Tail mode UX: if paused, patch visible entries in-place rather than forcing
       // a refresh that can reshuffle the table and lose the user's position.
@@ -5170,6 +5204,7 @@ export function LogsPage() {
   }, [
     blockDialog,
     blockDialogSnapshot,
+    blockWriteNodeId,
     blockMode,
     blockRegexValue,
     blockSelectedGroups,
@@ -5209,8 +5244,12 @@ export function LogsPage() {
       setBlockError(undefined);
 
       // Apply to all nodes with Advanced Blocking enabled
-      const nodesToUpdate =
+      const configuredSnapshots =
         advancedBlocking?.nodes?.filter((snapshot) => snapshot.config) ?? [];
+      const nodesToUpdate = selectAdvancedBlockingWriteSnapshots(
+        nodes,
+        configuredSnapshots,
+      );
 
       if (nodesToUpdate.length === 0) {
         setBlockError("No nodes with Advanced Blocking configuration found.");
@@ -5317,6 +5356,7 @@ export function LogsPage() {
     selectedDomains,
     blockSelectedGroups,
     advancedBlocking,
+    nodes,
     saveAdvancedBlockingConfig,
     setRefreshTick,
     clearSelection,
@@ -8772,7 +8812,10 @@ export function LogsPage() {
                             {selectedDomains.size} domain
                             {selectedDomains.size !== 1 ? "s" : ""}
                           </strong>{" "}
-                          in Advanced Blocking groups across all nodes.
+                          in Advanced Blocking groups
+                          {advancedBlockingPrimaryNode
+                            ? ` through ${advancedBlockingPrimaryLabel}.`
+                            : " across all nodes."}
                         </p>
                         <section className="logs-page__modal-summary">
                           <h3 className="logs-page__modal-summary-title">
@@ -8850,7 +8893,16 @@ export function LogsPage() {
                                     {isBlockedEntry
                                       ? "on"
                                       : "to Advanced Blocking on"}{" "}
-                                    node <strong>{blockNodeLabel}</strong>.
+                                    node <strong>{blockWriteNodeLabel}</strong>
+                                    {blockWriteNodeId !==
+                                    blockDialog?.entry.nodeId ? (
+                                      <>
+                                        {" "}
+                                        (query observed on {blockNodeLabel}).
+                                      </>
+                                    ) : (
+                                      "."
+                                    )}
                                   </>
                                 )}
                               </>

--- a/apps/frontend/src/test/advanced-blocking-routing.test.ts
+++ b/apps/frontend/src/test/advanced-blocking-routing.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveAdvancedBlockingWriteNodeId,
+  selectAdvancedBlockingWriteSnapshots,
+} from "../utils/advanced-blocking-routing";
+
+describe("Advanced Blocking write routing", () => {
+  it("routes a secondary query to the primary node", () => {
+    const nodes = [
+      { id: "eq10", isPrimary: true },
+      { id: "eq14", isPrimary: false },
+    ];
+
+    expect(resolveAdvancedBlockingWriteNodeId(nodes, "eq14")).toBe("eq10");
+  });
+
+  it("keeps the source node as the target outside a cluster", () => {
+    expect(
+      resolveAdvancedBlockingWriteNodeId(
+        [{ id: "dns-a" }, { id: "dns-b" }],
+        "dns-b",
+      ),
+    ).toBe("dns-b");
+  });
+
+  it("limits bulk writes to the primary in a cluster", () => {
+    const snapshots = [{ nodeId: "eq10" }, { nodeId: "eq14" }];
+
+    expect(
+      selectAdvancedBlockingWriteSnapshots(
+        [
+          { id: "eq10", isPrimary: true },
+          { id: "eq14", isPrimary: false },
+        ],
+        snapshots,
+      ),
+    ).toEqual([{ nodeId: "eq10" }]);
+  });
+
+  it("keeps all bulk targets for standalone nodes", () => {
+    const snapshots = [{ nodeId: "dns-a" }, { nodeId: "dns-b" }];
+
+    expect(
+      selectAdvancedBlockingWriteSnapshots(
+        [{ id: "dns-a" }, { id: "dns-b" }],
+        snapshots,
+      ),
+    ).toEqual(snapshots);
+  });
+});

--- a/apps/frontend/src/utils/advanced-blocking-routing.ts
+++ b/apps/frontend/src/utils/advanced-blocking-routing.ts
@@ -1,0 +1,26 @@
+interface AdvancedBlockingRouteNode {
+  id: string;
+  isPrimary?: boolean;
+}
+
+interface AdvancedBlockingRouteSnapshot {
+  nodeId: string;
+}
+
+export function resolveAdvancedBlockingWriteNodeId(
+  nodes: AdvancedBlockingRouteNode[],
+  sourceNodeId: string,
+): string {
+  return nodes.find((node) => node.isPrimary === true)?.id ?? sourceNodeId;
+}
+
+export function selectAdvancedBlockingWriteSnapshots<
+  T extends AdvancedBlockingRouteSnapshot,
+>(nodes: AdvancedBlockingRouteNode[], snapshots: T[]): T[] {
+  const primaryNodeId = nodes.find((node) => node.isPrimary === true)?.id;
+  if (!primaryNodeId) {
+    return snapshots;
+  }
+
+  return snapshots.filter((snapshot) => snapshot.nodeId === primaryNodeId);
+}


### PR DESCRIPTION
## What changed

- Resolve Advanced Blocking writes through the cluster primary even when the action originates from a secondary query-log entry.
- Probe additional configured nodes when the first cluster-state request is unavailable.
- Invalidate only the affected DNS cache name across physical cluster nodes after a single-domain override.
- Add focused frontend routing and backend cluster-probe coverage.

## Why

The query source identifies where a DNS event was observed, but cluster-managed application configuration is writable only through the primary. The previous flow reused the query source as the write target and also lost primary metadata when the first configured probe was unavailable.

## Impact

Single-domain allow/block actions now target the writable cluster member consistently and clear only the relevant cached name instead of requiring a full cache flush.

## Validation

- `npm run lint`
- `npm test`
- `npm run build`
