### PR TITLE
fix: persist DNS override precedence note dismissal

### DIFF
--- a/apps/frontend/src/pages/AutomationPage.tsx
+++ b/apps/frontend/src/pages/AutomationPage.tsx
@@ -35,6 +35,10 @@ import type {
   LogAlertsSmtpStatus,
   RunDnsScheduleEvaluatorResponse,
 } from "../types/dnsSchedules";
+import {
+  isDnsOverridesPrecedenceNoteDismissed,
+  rememberDnsOverridesPrecedenceNoteDismissed,
+} from "../utils/dns-overrides-precedence-note";
 
 // ── Constants ───────────────────────────────────────────────────────────────
 
@@ -2267,7 +2271,9 @@ export function AutomationPage() {
   const [lastRunResult, setLastRunResult] =
     useState<RunDnsScheduleEvaluatorResponse | null>(null);
   const [showRunResult, setShowRunResult] = useState(false);
-  const [showPrecedenceNote, setShowPrecedenceNote] = useState(true);
+  const [showPrecedenceNote, setShowPrecedenceNote] = useState(
+    () => !isDnsOverridesPrecedenceNoteDismissed(),
+  );
   const visibleRunResults =
     lastRunResult?.results.filter(shouldDisplayRunResult) ?? [];
 
@@ -3073,7 +3079,10 @@ export function AutomationPage() {
           <button
             type="button"
             className="dns-overrides__behavior-note-dismiss"
-            onClick={() => setShowPrecedenceNote(false)}
+            onClick={() => {
+              setShowPrecedenceNote(false);
+              rememberDnsOverridesPrecedenceNoteDismissed();
+            }}
             aria-label="Dismiss precedence note"
             title="Dismiss"
           >

--- a/apps/frontend/src/test/dns-overrides-precedence-note.test.ts
+++ b/apps/frontend/src/test/dns-overrides-precedence-note.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  isDnsOverridesPrecedenceNoteDismissed,
+  rememberDnsOverridesPrecedenceNoteDismissed,
+} from "../utils/dns-overrides-precedence-note";
+
+describe("DNS Overrides precedence note", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("shows the note when no dismissal has been saved", () => {
+    expect(isDnsOverridesPrecedenceNoteDismissed()).toBe(false);
+  });
+
+  it("remembers a dismissal across reads", () => {
+    rememberDnsOverridesPrecedenceNoteDismissed();
+
+    expect(isDnsOverridesPrecedenceNoteDismissed()).toBe(true);
+  });
+
+  it("does not treat unrelated stored values as a dismissal", () => {
+    window.localStorage.setItem("dnsOverridesPrecedenceNoteDismissed", "false");
+
+    expect(isDnsOverridesPrecedenceNoteDismissed()).toBe(false);
+  });
+
+  it("keeps the note available when browser storage cannot be read", () => {
+    vi.spyOn(window.localStorage, "getItem").mockImplementation(() => {
+      throw new Error("storage unavailable");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    expect(isDnsOverridesPrecedenceNoteDismissed()).toBe(false);
+  });
+});

--- a/apps/frontend/src/utils/dns-overrides-precedence-note.ts
+++ b/apps/frontend/src/utils/dns-overrides-precedence-note.ts
@@ -1,0 +1,27 @@
+const PRECEDENCE_NOTE_DISMISSED_KEY =
+  "dnsOverridesPrecedenceNoteDismissed";
+
+export function isDnsOverridesPrecedenceNoteDismissed(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  try {
+    return window.localStorage.getItem(PRECEDENCE_NOTE_DISMISSED_KEY) === "true";
+  } catch (error) {
+    console.warn("Failed to load precedence note dismissed state", error);
+    return false;
+  }
+}
+
+export function rememberDnsOverridesPrecedenceNoteDismissed(): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(PRECEDENCE_NOTE_DISMISSED_KEY, "true");
+  } catch (error) {
+    console.warn("Failed to save precedence note dismissed state", error);
+  }
+}


### PR DESCRIPTION
## Summary

- persist the DNS Overrides precedence-note dismissal in browser storage
- restore the saved preference when the Automation page initializes
- keep the note available if browser storage cannot be read

## Why

The dismissal previously lived only in React state, so the precedence note reappeared after navigation or reload.

## Impact

The preference is browser-local and does not change backend configuration or server state.

## Validation

- focused Vitest suite: 4 passed
- focused ESLint check: production files clean
- repository build and test suites passed before the change was isolated into its branch
