### PR TITLE
feat: deprecate Technitium DNS v14 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- **Technitium DNS v14 and earlier are now deprecated.** Companion 1.x keeps existing deployments functional on a best-effort basis and surfaces an actionable Overview warning. Companion 2.0 will require Technitium DNS v15.3 or later, with removal planned no earlier than late October 2026.
+
 ## [1.8.2] - 2026-07-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ Docs: [docs/features/SESSION_AUTH_AND_TOKEN_MIGRATION.md](docs/features/SESSION_
 
 - **Docker, OrbStack, or Podman (or similar)** (recommended for easiest deployment)
 - **OR Node.js 22+** (for running directly without Docker)
-- Access to one or more Technitium DNS servers (v13.6 or v14.0+)
+- Access to one or more Technitium DNS servers (v15.3+ recommended; v14 and
+  earlier are deprecated but remain best-effort compatible throughout
+  Companion 1.x)
 - For **session auth (required for interactive UI in v1.4+)**: a Technitium user account to sign in with (run Companion over HTTPS)
 - For **legacy env-token mode**: admin API token(s) from your Technitium DNS server(s)
 
@@ -96,11 +98,14 @@ For manual docker run or compose instructions, head to [DOCKER.md](DOCKER.md).
 
 ## Configuration
 
-Technitium-DNS-Companion supports both **v13.6 (standalone)** and **v14.0+ (clustering)** configurations.
+Technitium-DNS-Companion's forward-looking baseline is **v15.3+**. Technitium
+DNS v14 and earlier remain functional on a best-effort basis in Companion 1.x,
+but are deprecated and will be removed in Companion 2.0 no earlier than late
+October 2026.
 
-#### Technitium DNS v14.0+ with Clustering (Recommended)
+#### Technitium DNS v15.3+ with Clustering (Recommended)
 
-When clustering is enabled in Technitium DNS v14.0+, the recommended setup is session auth for interactive UI access:
+When clustering is enabled in Technitium DNS v15.3+, the recommended setup is session auth for interactive UI access:
 
 ```bash
 TECHNITIUM_NODES=primary,secondary1,secondary2
@@ -113,7 +118,7 @@ TECHNITIUM_SECONDARY2_BASE_URL=https://secondary2.home.arpa:53443
 # TECHNITIUM_BACKGROUND_TOKEN=your-low-privilege-token
 ```
 
-**Example config:** See [`configs/.env.example.v14`](https://github.com/Fail-Safe/Technitium-DNS-Companion/blob/main/configs/.env.example.v14)
+**Example config:** See [`configs/.env.example.v14`](https://github.com/Fail-Safe/Technitium-DNS-Companion/blob/main/configs/.env.example.v14) (legacy filename; the same node layout applies to v15).
 
 **Cluster Features:**
 
@@ -123,9 +128,10 @@ TECHNITIUM_SECONDARY2_BASE_URL=https://secondary2.home.arpa:53443
 - Automatic cluster role change detection (every 30 seconds)
 - Sync tab hidden (not needed with native clustering)
 
-#### Technitium DNS v13.6 (Standalone Nodes)
+#### Legacy v14 and Earlier Deployments (Deprecated)
 
-For v13.6 or nodes without clustering, per-node env tokens are legacy-only (Technitium DNS < v14):
+For pre-v15 deployments or nodes without clustering, per-node environment
+tokens remain available for migration compatibility:
 
 ```bash
 # Each node has its OWN unique token
@@ -199,7 +205,7 @@ These features write data to disk and are disabled unless explicitly enabled/con
 ### User Experience
 
 - **Responsive UI** - Mobile-friendly interface built with React and TailwindCSS
-- **Cluster Support** - Automatic detection and support for Technitium DNS v14+ clustering
+- **Cluster Support** - Automatic detection and support for Technitium DNS v15 clustering
 - **Touch-Optimized** - Designed for easy use on smartphones and tablets
 
 ## License

--- a/apps/frontend/src/components/common/TechnitiumVersionDeprecationBanner.css
+++ b/apps/frontend/src/components/common/TechnitiumVersionDeprecationBanner.css
@@ -1,0 +1,59 @@
+.technitium-version-deprecation-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 1rem;
+  background: var(--color-warning-bg);
+  border: 1px solid var(--color-warning);
+  border-radius: 0.75rem;
+  color: var(--color-warning-dark);
+}
+
+.technitium-version-deprecation-banner__content {
+  flex: 1;
+  min-width: 0;
+}
+
+.technitium-version-deprecation-banner h2 {
+  margin: 0 0 0.35rem;
+  font-size: 1rem;
+  color: inherit;
+}
+
+.technitium-version-deprecation-banner p {
+  margin: 0;
+  line-height: 1.5;
+  color: inherit;
+}
+
+.technitium-version-deprecation-banner .technitium-version-deprecation-banner__nodes {
+  margin-top: 0.35rem;
+  font-size: 0.875rem;
+  overflow-wrap: anywhere;
+}
+
+.technitium-version-deprecation-banner__link {
+  flex-shrink: 0;
+  padding: 0.55rem 0.75rem;
+  border: 1px solid currentcolor;
+  border-radius: 0.5rem;
+  color: inherit;
+  font-size: 0.875rem;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.technitium-version-deprecation-banner__link:hover {
+  background: var(--color-warning);
+}
+
+@media (max-width: 767px) {
+  .technitium-version-deprecation-banner {
+    flex-direction: column;
+  }
+
+  .technitium-version-deprecation-banner__link {
+    width: 100%;
+    text-align: center;
+  }
+}

--- a/apps/frontend/src/components/common/TechnitiumVersionDeprecationBanner.tsx
+++ b/apps/frontend/src/components/common/TechnitiumVersionDeprecationBanner.tsx
@@ -1,0 +1,52 @@
+import { FUTURE_MINIMUM_TECHNITIUM_VERSION } from "../../utils/technitium-version-support";
+import "./TechnitiumVersionDeprecationBanner.css";
+
+export interface DeprecatedTechnitiumNode {
+  id: string;
+  name: string;
+  version: string;
+}
+
+export function TechnitiumVersionDeprecationBanner({
+  nodes,
+}: {
+  nodes: DeprecatedTechnitiumNode[];
+}) {
+  if (nodes.length === 0) {
+    return null;
+  }
+
+  const nodeSummary = nodes
+    .map((node) => `${node.name} (${node.version})`)
+    .join(", ");
+
+  return (
+    <aside
+      className="technitium-version-deprecation-banner"
+      role="alert"
+      aria-labelledby="technitium-version-deprecation-title"
+    >
+      <div className="technitium-version-deprecation-banner__content">
+        <h2 id="technitium-version-deprecation-title">
+          Technitium DNS upgrade required before Companion 2.0
+        </h2>
+        <p>
+          Support for Technitium DNS v14 and earlier is deprecated. Upgrade all
+          nodes in a cluster together to v{FUTURE_MINIMUM_TECHNITIUM_VERSION} or
+          later; the latest Technitium release is recommended.
+        </p>
+        <p className="technitium-version-deprecation-banner__nodes">
+          Affected nodes: {nodeSummary}
+        </p>
+      </div>
+      <a
+        className="technitium-version-deprecation-banner__link"
+        href="https://github.com/TechnitiumSoftware/DnsServer/blob/master/CHANGELOG.md"
+        target="_blank"
+        rel="noreferrer"
+      >
+        Review upgrade notes
+      </a>
+    </aside>
+  );
+}

--- a/apps/frontend/src/pages/OverviewPage.tsx
+++ b/apps/frontend/src/pages/OverviewPage.tsx
@@ -1,14 +1,28 @@
 import { useCallback, useEffect, useMemo } from "react";
 import { PullToRefreshIndicator } from "../components/common/PullToRefreshIndicator";
+import { TechnitiumVersionDeprecationBanner } from "../components/common/TechnitiumVersionDeprecationBanner";
 import { NodeStatusCard } from "../components/nodes/NodeStatusCard";
 import { NodeStatusCardSkeleton } from "../components/nodes/NodeStatusCardSkeleton";
 import { useTechnitiumState } from "../context/useTechnitiumState";
 import { usePullToRefresh } from "../hooks/usePullToRefresh";
 import { sortOverviewNodes } from "../utils/overviewNodeOrdering";
+import { isDeprecatedTechnitiumVersion } from "../utils/technitium-version-support";
 
 export default function OverviewPage() {
   const { nodes, fetchNodeOverviews } = useTechnitiumState();
   const orderedNodes = useMemo(() => sortOverviewNodes(nodes), [nodes]);
+  const deprecatedNodes = useMemo(
+    () =>
+      orderedNodes.flatMap((node) => {
+        const version = node.overview?.version;
+        if (!version || !isDeprecatedTechnitiumVersion(version)) {
+          return [];
+        }
+
+        return [{ id: node.id, name: node.name, version }];
+      }),
+    [orderedNodes],
+  );
 
   // Fetch node overviews once nodes are available
   useEffect(() => {
@@ -50,19 +64,24 @@ export default function OverviewPage() {
           </div>
         </header>
 
-        {orderedNodes.length === 0 ?
+        <TechnitiumVersionDeprecationBanner nodes={deprecatedNodes} />
+
+        {orderedNodes.length === 0 ? (
           <p className="dashboard__empty-state">
             No nodes configured. Please configure your Technitium DNS nodes via
             environment variables on the backend server.
           </p>
-        : <section className="dashboard__grid">
+        ) : (
+          <section className="dashboard__grid">
             {orderedNodes.map((node) =>
-              node.overview ?
+              node.overview ? (
                 <NodeStatusCard key={node.id} node={node} />
-              : <NodeStatusCardSkeleton key={node.id} />,
+              ) : (
+                <NodeStatusCardSkeleton key={node.id} />
+              ),
             )}
           </section>
-        }
+        )}
       </section>
     </>
   );

--- a/apps/frontend/src/test/technitium-version-deprecation.test.tsx
+++ b/apps/frontend/src/test/technitium-version-deprecation.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { TechnitiumVersionDeprecationBanner } from "../components/common/TechnitiumVersionDeprecationBanner";
+import {
+  isDeprecatedTechnitiumVersion,
+  parseTechnitiumVersion,
+} from "../utils/technitium-version-support";
+
+describe("Technitium version deprecation", () => {
+  it("parses common Technitium version formats", () => {
+    expect(parseTechnitiumVersion("14.3")).toEqual({ major: 14, minor: 3 });
+    expect(parseTechnitiumVersion("v15.4.0")).toEqual({
+      major: 15,
+      minor: 4,
+    });
+  });
+
+  it("classifies pre-v15 releases as deprecated", () => {
+    expect(isDeprecatedTechnitiumVersion("13.6")).toBe(true);
+    expect(isDeprecatedTechnitiumVersion("14.3")).toBe(true);
+    expect(isDeprecatedTechnitiumVersion("15.0")).toBe(false);
+    expect(isDeprecatedTechnitiumVersion("Unknown")).toBe(false);
+  });
+
+  it("lists affected nodes and the future minimum version", () => {
+    render(
+      <TechnitiumVersionDeprecationBanner
+        nodes={[
+          { id: "node-a", name: "Node A", version: "14.3" },
+          { id: "node-b", name: "Node B", version: "13.6" },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByText("Technitium DNS upgrade required before Companion 2.0"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/v15\.3 or later/)).toBeInTheDocument();
+    expect(
+      screen.getByText("Affected nodes: Node A (14.3), Node B (13.6)"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders nothing when all nodes meet the current policy", () => {
+    const { container } = render(
+      <TechnitiumVersionDeprecationBanner nodes={[]} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/frontend/src/utils/technitium-version-support.ts
+++ b/apps/frontend/src/utils/technitium-version-support.ts
@@ -1,0 +1,27 @@
+export interface TechnitiumVersion {
+  major: number;
+  minor: number;
+}
+
+export const FUTURE_MINIMUM_TECHNITIUM_VERSION = "15.3";
+
+export function parseTechnitiumVersion(
+  value: string | undefined,
+): TechnitiumVersion | undefined {
+  const match = /^v?(\d+)(?:\.(\d+))?/i.exec(value?.trim() ?? "");
+  if (!match) {
+    return undefined;
+  }
+
+  return {
+    major: Number.parseInt(match[1], 10),
+    minor: Number.parseInt(match[2] ?? "0", 10),
+  };
+}
+
+export function isDeprecatedTechnitiumVersion(
+  value: string | undefined,
+): boolean {
+  const version = parseTechnitiumVersion(value);
+  return version !== undefined && version.major < 15;
+}

--- a/docs/features/TECHNITIUM_VERSION_COMPATIBILITY.md
+++ b/docs/features/TECHNITIUM_VERSION_COMPATIBILITY.md
@@ -6,11 +6,21 @@ Technitium DNS upgrade guide.
 
 ## Supported baseline
 
-- Technitium DNS v14 remains the minimum supported clustered deployment.
-- Technitium DNS v15.3+ uses the current status endpoint and Bearer-token API
-  convention.
+- Technitium DNS v15.3+ is the forward-looking supported baseline; operators
+  should run the latest available v15 release for upstream security fixes.
+- Technitium DNS v14 and earlier are deprecated. Companion 1.x keeps them
+  functional on a best-effort basis, but no new v14-specific features or
+  integration-test infrastructure will be added.
+- Companion 2.0 will require Technitium DNS v15.3 or later. Removal is planned
+  no earlier than late October 2026, providing at least a 60–90 day migration
+  window from the deprecation announcement.
 - Companion keeps the legacy token query parameter alongside the Bearer header
-  so the same request path remains compatible with v14.
+  during the 1.x deprecation period so existing v14 deployments continue to
+  work.
+
+The Overview page identifies connected pre-v15 nodes and shows an upgrade
+warning. The warning is advisory in Companion 1.x and does not disable reads or
+writes.
 
 ## v14-to-v15 API audit
 
@@ -35,8 +45,20 @@ Backend contract tests verify that:
   HTTP 404;
 - other status failures are not hidden by the compatibility fallback.
 
-These are mocked API-contract tests. Running the integration suite against real
-v14 and v15 containers is still an open roadmap item.
+These are mocked API-contract tests. The planned live integration matrix will
+target the v15.3 minimum and latest v15 release rather than expanding v14 test
+infrastructure during its deprecation period.
+
+## Removal plan for Companion 2.0
+
+Companion 2.0 will remove the v14 compatibility paths:
+
+- duplicate query-token authentication on requests that use a Bearer token;
+- the `/api/status` HTTP 404 fallback to `/api/user/session/get`;
+- documentation and examples that present pre-v15 deployments as supported.
+
+Before that removal, Companion 1.x will retain the existing compatibility
+tests and provide an actionable warning without blocking operators.
 
 ## Upgrade notes
 


### PR DESCRIPTION
## Summary

- mark Technitium DNS v14 and earlier as deprecated while retaining best-effort compatibility throughout Companion 1.x
- add an Overview warning that identifies connected pre-v15 nodes and recommends upgrading the cluster together
- establish v15.3 as the forward-looking baseline and document the Companion 2.0 removal plan

## Impact

Existing v14 deployments continue to operate in Companion 1.x. Operators receive an advisory warning, while Companion 2.0 is documented to require Technitium DNS v15.3 or later no earlier than late October 2026.

The warning reuses version data already loaded by the Overview page and does not add backend API calls.

## Validation

- `npm run build`
- `npm test` (backend: 374 passed, 9 skipped; frontend: 752 passed, 43 todo)
- ESLint on changed frontend production files
- `git diff --check`
