### PR TITLE
test: add Technitium v15 compatibility matrix

### DIFF
--- a/.github/workflows/technitium-v15-compatibility.yml
+++ b/.github/workflows/technitium-v15-compatibility.yml
@@ -1,0 +1,91 @@
+name: Verify Technitium v15 Compatibility
+
+on:
+  pull_request:
+    branches:
+      - next
+    paths:
+      - ".github/workflows/technitium-v15-compatibility.yml"
+      - "apps/backend/**"
+      - "package.json"
+      - "package-lock.json"
+      - "docs/features/TECHNITIUM_VERSION_COMPATIBILITY.md"
+  push:
+    branches:
+      - next
+    paths:
+      - ".github/workflows/technitium-v15-compatibility.yml"
+      - "apps/backend/**"
+      - "package.json"
+      - "package-lock.json"
+      - "docs/features/TECHNITIUM_VERSION_COMPATIBILITY.md"
+  schedule:
+    - cron: "17 9 * * 1"
+  workflow_dispatch:
+    inputs:
+      latest_v15_tag:
+        description: Official technitium/dns-server tag for the latest v15 release
+        required: false
+        type: string
+        default: "15.4.0"
+
+jobs:
+  compatibility:
+    name: Technitium ${{ matrix.track }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        track:
+          - minimum-v15.3
+          - latest-v15
+
+    services:
+      technitium:
+        image: technitium/dns-server:${{ matrix.track == 'minimum-v15.3' && '15.3.0' || (inputs.latest_v15_tag || vars.TECHNITIUM_LATEST_V15_TAG || '15.4.0') }}
+        env:
+          DNS_SERVER_DOMAIN: compatibility.test.invalid
+          DNS_SERVER_ADMIN_PASSWORD: admin
+        ports:
+          - 5380:5380
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Wait for Technitium DNS
+        shell: bash
+        run: |
+          set -euo pipefail
+          for attempt in {1..30}; do
+            if curl --fail --silent --show-error \
+              "http://127.0.0.1:5380/api/user/login?user=admin&pass=admin" \
+              >/dev/null; then
+              exit 0
+            fi
+
+            echo "Technitium DNS is not ready yet (attempt ${attempt}/30)."
+            sleep 2
+          done
+
+          echo "Technitium DNS did not become ready in time." >&2
+          exit 1
+
+      - name: Run Companion compatibility suite
+        env:
+          TECHNITIUM_TEST_BASE_URL: http://127.0.0.1:5380
+          TECHNITIUM_TEST_EXPECTED_VERSION: ${{ matrix.track == 'minimum-v15.3' && '15.3.0' || (inputs.latest_v15_tag || vars.TECHNITIUM_LATEST_V15_TAG || '15.4.0') }}
+          TECHNITIUM_TEST_USERNAME: admin
+          TECHNITIUM_TEST_PASSWORD: admin
+        run: npm run test:technitium:v15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Live Technitium v15 compatibility matrix.** A new opt-in Nest integration suite and GitHub Actions workflow exercise Companion login, status, settings/version, zone listing, and cluster discovery against the v15.3 minimum and latest supported v15 container.
+
 ### Changed
 
 - **Technitium DNS v14 and earlier are now deprecated.** Companion 1.x keeps existing deployments functional on a best-effort basis and surfaces an actionable Overview warning. Companion 2.0 will require Technitium DNS v15.3 or later, with removal planned no earlier than late October 2026.

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -17,6 +17,7 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
+    "test:technitium:v15": "cross-env RUN_TECHNITIUM_V15_TESTS=true ALLOW_TECHNITIUM_HTTP_IN_TESTS=true jest --config ./test/jest-technitium-v15.json --runInBand --detectOpenHandles",
     "test:benchmark": "cross-env RUN_BENCHMARK_TESTS=true ALLOW_TECHNITIUM_HTTP_IN_TESTS=true jest benchmark --runInBand --detectOpenHandles"
   },
   "dependencies": {

--- a/apps/backend/test/jest-technitium-v15.json
+++ b/apps/backend/test/jest-technitium-v15.json
@@ -1,0 +1,10 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": ".",
+  "testEnvironment": "node",
+  "testRegex": "technitium-v15\\.integration-spec\\.ts$",
+  "testTimeout": 30000,
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  }
+}

--- a/apps/backend/test/technitium-v15.integration-spec.ts
+++ b/apps/backend/test/technitium-v15.integration-spec.ts
@@ -1,0 +1,124 @@
+import { type INestApplication } from "@nestjs/common";
+import { Test, type TestingModule } from "@nestjs/testing";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type App } from "supertest/types";
+import request from "supertest";
+
+import { AppModule } from "../src/app.module";
+import { enableSecureProxyForE2e } from "./e2e-auth";
+
+const runCompatibilityTests = process.env.RUN_TECHNITIUM_V15_TESTS === "true";
+const describeCompatibility = runCompatibilityTests ? describe : describe.skip;
+
+describeCompatibility("Technitium DNS v15 compatibility", () => {
+  let app: INestApplication<App>;
+  let sessionCookie: string;
+  let tempDir: string | undefined;
+
+  const baseUrl = process.env.TECHNITIUM_TEST_BASE_URL;
+  const expectedVersion = process.env.TECHNITIUM_TEST_EXPECTED_VERSION;
+  const username = process.env.TECHNITIUM_TEST_USERNAME;
+  const password = process.env.TECHNITIUM_TEST_PASSWORD;
+
+  beforeAll(async () => {
+    if (!baseUrl || !expectedVersion || !username || !password) {
+      throw new Error(
+        "TECHNITIUM_TEST_BASE_URL, TECHNITIUM_TEST_EXPECTED_VERSION, " +
+          "TECHNITIUM_TEST_USERNAME, and TECHNITIUM_TEST_PASSWORD are required.",
+      );
+    }
+
+    process.env.ALLOW_TECHNITIUM_HTTP_IN_TESTS = "true";
+    process.env.TRUST_PROXY = "true";
+    tempDir = mkdtempSync(join(tmpdir(), "tdc-v15-compatibility-"));
+    process.env.COMPANION_DB_PATH = join(tempDir, "companion.sqlite");
+    process.env.TECHNITIUM_NODES = "compatibility";
+    process.env.TECHNITIUM_COMPATIBILITY_NAME = "Compatibility Node";
+    process.env.TECHNITIUM_COMPATIBILITY_BASE_URL = baseUrl;
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix("api");
+    enableSecureProxyForE2e(app);
+    await app.init();
+
+    const loginResponse = await request(app.getHttpServer())
+      .post("/api/auth/login")
+      .set("X-Forwarded-Proto", "https")
+      .send({ username, password })
+      .expect(201);
+
+    const cookies = loginResponse.headers["set-cookie"] as string[] | undefined;
+    const cookie = cookies?.[0]?.split(";", 1)[0];
+    if (!cookie) {
+      throw new Error("Companion login did not return a session cookie.");
+    }
+    sessionCookie = cookie;
+  });
+
+  afterAll(async () => {
+    await app?.close();
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  function authenticatedGet(path: string) {
+    return request(app.getHttpServer())
+      .get(path)
+      .set("X-Forwarded-Proto", "https")
+      .set("Cookie", sessionCookie);
+  }
+
+  it("establishes a Companion session with the Technitium login token", async () => {
+    const response = await authenticatedGet("/api/auth/me").expect(200);
+
+    expect(response.body).toMatchObject({
+      authenticated: true,
+      nodeIds: ["compatibility"],
+    });
+  });
+
+  it("reads the v15 status endpoint", async () => {
+    const response = await authenticatedGet(
+      "/api/nodes/compatibility/status",
+    ).expect(200);
+
+    expect(response.body.nodeId).toBe("compatibility");
+    expect(response.body.data.status).toBe("ok");
+  });
+
+  it("reads settings-backed version data through the node overview", async () => {
+    const response = await authenticatedGet(
+      "/api/nodes/compatibility/overview",
+    ).expect(200);
+
+    expect(response.body.version).toBe(expectedVersion?.replace(/\.0$/, ""));
+  });
+
+  it("lists authoritative zones", async () => {
+    const response = await authenticatedGet(
+      "/api/nodes/compatibility/zones",
+    ).expect(200);
+
+    expect(response.body.nodeId).toBe("compatibility");
+    expect(response.body.data.zones).toEqual(expect.any(Array));
+  });
+
+  it("discovers an unclustered v15 node as standalone", async () => {
+    const response = await authenticatedGet(
+      "/api/nodes/compatibility/cluster/state",
+    ).expect(200);
+
+    expect(response.body).toMatchObject({
+      initialized: false,
+      type: "Standalone",
+    });
+    expect(response.body.health).not.toBe("Unreachable");
+  });
+});

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -26,6 +26,13 @@ This project uses **Vitest** for unit testing and **Playwright** for E2E testing
 - Designed for fast “does the app load/render” validation
 - Located in `apps/frontend/e2e/smoke.spec.ts`
 
+### Technitium v15 Compatibility Tests (Jest + Docker)
+
+- Opt-in tests against real, disposable Technitium DNS containers
+- Exercise Companion's login, status, settings/version, zone-list, and cluster-discovery paths
+- CI matrix covers the v15.3 minimum and the latest validated v15 release
+- Located in `apps/backend/test/technitium-v15.integration-spec.ts`
+
 ## Setup
 
 ### Installation
@@ -140,6 +147,25 @@ E2E_USE_EXISTING_SERVER=true npm run test:smoke:chromium
 Notes:
 
 - By default the smoke test expects the app title to include “Technitium” and the top nav to render.
+
+### Technitium v15 Compatibility Tests
+
+Start a disposable Technitium DNS v15 container on loopback port 5380, then
+provide its expected image version and disposable credentials:
+
+```bash
+TECHNITIUM_TEST_BASE_URL=http://127.0.0.1:5380 \
+TECHNITIUM_TEST_EXPECTED_VERSION=15.3.0 \
+TECHNITIUM_TEST_USERNAME=admin \
+TECHNITIUM_TEST_PASSWORD=your-disposable-test-password \
+npm run test:technitium:v15
+```
+
+The command enables real Technitium HTTP requests only for this dedicated Jest
+configuration. Never point it at a production DNS server. GitHub Actions runs
+the same suite against official `15.3.0` and latest-v15 service containers; the
+latest tag can be overridden with the `TECHNITIUM_LATEST_V15_TAG` repository
+variable or the manual workflow input.
 
 ## Test Files
 

--- a/docs/features/TECHNITIUM_VERSION_COMPATIBILITY.md
+++ b/docs/features/TECHNITIUM_VERSION_COMPATIBILITY.md
@@ -45,9 +45,20 @@ Backend contract tests verify that:
   HTTP 404;
 - other status failures are not hidden by the compatibility fallback.
 
-These are mocked API-contract tests. The planned live integration matrix will
-target the v15.3 minimum and latest v15 release rather than expanding v14 test
-infrastructure during its deprecation period.
+The live compatibility matrix complements those mocked contracts by starting
+official Technitium DNS containers and exercising Companion's real login and
+authenticated request flow. It currently covers:
+
+- the v15.3 minimum (`technitium/dns-server:15.3.0`);
+- the latest validated v15 release (`15.4.0` at the time of this update);
+- Companion session establishment, `/api/status`, settings-backed version
+  detection, zone listing, and standalone cluster discovery.
+
+The workflow runs for relevant pull requests and `next` pushes, on a weekly
+schedule, and on demand. Set the `TECHNITIUM_LATEST_V15_TAG` repository variable
+or the manual workflow input when a newer v15 image should join the matrix.
+This matrix intentionally does not expand v14 integration infrastructure
+during its deprecation period.
 
 ## Removal plan for Companion 2.0
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "npm run lint --workspaces --if-present",
     "build": "npm run build --workspaces --if-present",
     "test": "npm run test --workspaces --if-present",
+    "test:technitium:v15": "npm run test:technitium:v15 --workspace apps/backend",
     "prepare": "git config core.hooksPath .githooks 2>/dev/null || true"
   },
   "overrides": {


### PR DESCRIPTION
## Summary

- add an opt-in Nest integration suite that exercises Companion against a real Technitium DNS server
- add a GitHub Actions service-container matrix for the v15.3 minimum and latest validated v15 release
- document local execution, CI cadence, and the override used when a newer v15 image is available

## Why

Companion's v15 API behavior was previously covered by mocked contract tests only. The live matrix verifies the actual session-authenticated integration boundary before v15-specific behavior is adopted more broadly.

## Impact

The new suite verifies Companion login, status, settings-backed version detection, zone listing, and standalone cluster discovery. It is isolated from the default unit suite and runs only through its dedicated command and workflow.

The latest-v15 image defaults to `15.4.0` and can be updated through a repository variable or manual workflow input without editing the test implementation.

## Validation

- live `technitium/dns-server:15.3.0`: 5 tests passed
- live `technitium/dns-server:15.4.0`: 5 tests passed
- `npm run build`
- `npm test` (backend: 374 passed, 9 skipped; frontend: 752 passed, 43 todo)
- Prettier checks
- workflow YAML parse
- `git diff --check`
