### PR TITLE
Release v1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.9.1] - 2026-07-22
+
+### Changed
+
+- **DNS Logs table settings are easier to dismiss on mobile.** The settings sheet now has a persistent close button, keyboard focus management, Escape-key dismissal, and an explicit dialog relationship with its trigger.
+- **Installed PWAs check for updates while in use.** The service worker checks when the app returns to the foreground and periodically while it remains open so deployed fixes are discovered without requiring a manual cache reset.
+
+### Fixed
+
+- **Mobile and installed-PWA content respects device safe areas.** Headers, banners, dialogs, drawers, toasts, and floating controls now use browser-provided cutout and home-indicator insets instead of overlapping iPhone status indicators or screen edges.
+- **The application header remains visible during iOS overscroll and pinch zoom.** The fixed header tracks the visual viewport while preserving safe-area and offline-banner offsets.
+- **DNS Logs settings no longer trigger pull-to-refresh.** Opening the settings dialog disables the page-level refresh gesture and prevents modal-originated touches from arming it.
+
 ## [1.9.0] - 2026-07-19
 
 ### Upgrade notes

--- a/apps/frontend/src/App.css
+++ b/apps/frontend/src/App.css
@@ -75,13 +75,11 @@ html {
 }
 
 /* Safe area insets for notched devices (iPhone X+) */
-@supports (padding: env(safe-area-inset-top)) {
-  body {
-    padding-top: env(safe-area-inset-top);
-    padding-bottom: env(safe-area-inset-bottom);
-    padding-left: env(safe-area-inset-left);
-    padding-right: env(safe-area-inset-right);
-  }
+body {
+  padding-top: 0;
+  padding-bottom: var(--safe-area-bottom);
+  padding-left: var(--safe-area-left);
+  padding-right: var(--safe-area-right);
 }
 
 /* === Global Width Constraints === */
@@ -316,7 +314,10 @@ html {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 1rem;
+  padding: calc(1rem + var(--safe-area-top))
+    calc(1rem + var(--safe-area-right))
+    calc(1rem + var(--safe-area-bottom))
+    calc(1rem + var(--safe-area-left));
   background: rgba(15, 23, 42, 0.45);
   backdrop-filter: blur(3px);
   -webkit-backdrop-filter: blur(3px);
@@ -381,7 +382,10 @@ html {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 1rem;
+  padding: calc(1rem + var(--safe-area-top))
+    calc(1rem + var(--safe-area-right))
+    calc(1rem + var(--safe-area-bottom))
+    calc(1rem + var(--safe-area-left));
   background: rgba(15, 23, 42, 0.5);
   backdrop-filter: blur(3px);
   -webkit-backdrop-filter: blur(3px);
@@ -759,8 +763,8 @@ html {
 /* === Toast Notifications === */
 .toast-stack {
   position: fixed;
-  top: 2rem;
-  right: 2rem;
+  top: calc(2rem + var(--safe-area-top));
+  right: calc(2rem + var(--safe-area-right));
   display: grid;
   gap: 0.75rem;
   width: min(320px, calc(100% - 2rem));
@@ -816,9 +820,9 @@ html {
 
 @media (max-width: 600px) {
   .toast-stack {
-    left: 0.75rem;
-    right: 0.75rem;
-    top: 1rem;
+    left: calc(0.75rem + var(--safe-area-left));
+    right: calc(0.75rem + var(--safe-area-right));
+    top: calc(1rem + var(--safe-area-top));
     width: auto;
   }
 }
@@ -828,6 +832,7 @@ html {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  padding-top: var(--app-header-height);
   background: var(--color-bg-primary);
   color: var(--color-text-primary);
 }
@@ -975,14 +980,23 @@ html {
 }
 
 .app-header {
+  --app-header-base-top: 0px;
+
   display: flex;
   align-items: center;
   gap: 2rem;
-  padding: 1rem 2rem;
+  padding: calc(1rem + var(--safe-area-top))
+    calc(2rem + var(--safe-area-right)) 1rem
+    calc(2rem + var(--safe-area-left));
   background: var(--color-bg-secondary);
   border-bottom: 1px solid var(--color-border);
-  position: sticky;
-  top: 0;
+  position: fixed;
+  top: calc(
+    var(--app-header-base-top) + var(--visual-viewport-offset-top, 0px)
+  );
+  right: auto;
+  left: var(--visual-viewport-offset-left, 0px);
+  width: var(--visual-viewport-width, 100vw);
   z-index: 100;
   box-shadow: var(--shadow-sm);
   transition: box-shadow 0.3s ease;
@@ -1391,7 +1405,9 @@ html {
 
 @media (max-width: 968px) {
   .app-header {
-    padding: 0.75rem 1rem;
+    padding: calc(0.75rem + var(--safe-area-top))
+      calc(1rem + var(--safe-area-right)) 0.75rem
+      calc(1rem + var(--safe-area-left));
     gap: 0.75rem;
   }
 
@@ -1428,7 +1444,9 @@ html {
     background: var(--color-bg-secondary);
     flex-direction: column;
     padding: 0;
-    padding-top: env(safe-area-inset-top, 0);
+    padding-top: var(--safe-area-top);
+    padding-right: var(--safe-area-right);
+    padding-bottom: var(--safe-area-bottom);
     gap: 0;
     box-shadow: -8px 0 32px rgba(0, 0, 0, 0.2);
     transform: translateX(100%);
@@ -4075,8 +4093,8 @@ button.secondary:disabled,
 /* Floating Live Toggle Button */
 .logs-page__floating-live-toggle {
   position: fixed;
-  bottom: 2rem;
-  right: 2rem;
+  bottom: calc(2rem + var(--safe-area-bottom));
+  right: calc(2rem + var(--safe-area-right));
   width: 56px;
   height: 56px;
   border-radius: 50%;
@@ -4189,8 +4207,8 @@ button.secondary:disabled,
 /* Mobile adjustments */
 @media (max-width: 768px) {
   .logs-page__floating-live-toggle {
-    bottom: 1.5rem;
-    right: 1.5rem;
+    bottom: calc(1.5rem + var(--safe-area-bottom));
+    right: calc(1.5rem + var(--safe-area-right));
     width: 48px;
     height: 48px;
   }
@@ -4204,8 +4222,8 @@ button.secondary:disabled,
 /* Ensure it doesn't interfere with mobile browser UI */
 @media (max-width: 768px) and (max-height: 600px) {
   .logs-page__floating-live-toggle {
-    bottom: 1rem;
-    right: 1rem;
+    bottom: calc(1rem + var(--safe-area-bottom));
+    right: calc(1rem + var(--safe-area-right));
   }
 }
 
@@ -4939,6 +4957,53 @@ button.secondary:disabled,
   max-width: 500px;
   max-height: 80vh;
   overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.logs-page__settings-header {
+  position: sticky;
+  top: -1.25rem;
+  z-index: 2;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin: -1.25rem -1.25rem 0;
+  padding: 1.25rem;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-bg-secondary);
+}
+
+.logs-page__settings-header-copy {
+  min-width: 0;
+}
+
+.logs-page__settings-close {
+  width: 44px;
+  height: 44px;
+  flex: 0 0 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: -0.5rem -0.5rem -0.5rem 0;
+  padding: 0;
+  border: 1px solid var(--color-border);
+  border-radius: 0.75rem;
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  font-size: 1.1rem;
+  cursor: pointer;
+}
+
+.logs-page__settings-close:hover {
+  border-color: var(--color-primary);
+  background: var(--color-primary-light);
+  color: var(--color-primary);
+}
+
+.logs-page__settings-close:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--color-primary) 35%, transparent);
+  outline-offset: 2px;
 }
 
 /* Popup aligns to left edge of button (default) */
@@ -5701,7 +5766,10 @@ button.secondary:disabled,
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 2rem 1.5rem;
+  padding: calc(2rem + var(--safe-area-top))
+    calc(1.5rem + var(--safe-area-right))
+    calc(2rem + var(--safe-area-bottom))
+    calc(1.5rem + var(--safe-area-left));
   z-index: 1000;
 }
 
@@ -7565,6 +7633,9 @@ button.danger:disabled {
   right: 0;
   z-index: 100;
   margin-top: 0;
+  padding-right: calc(2rem + var(--safe-area-right));
+  padding-bottom: calc(1rem + var(--safe-area-bottom));
+  padding-left: calc(2rem + var(--safe-area-left));
   box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.08);
 }
 
@@ -7670,7 +7741,9 @@ button.danger:disabled {
   align-items: center;
   background: var(--color-bg-secondary);
   border-top: 1px solid var(--color-border);
-  padding: 1rem 2rem;
+  padding: 1rem calc(2rem + var(--safe-area-right))
+    calc(1rem + var(--safe-area-bottom))
+    calc(2rem + var(--safe-area-left));
   box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.08);
 }
 
@@ -8547,7 +8620,9 @@ button.danger:disabled {
     }
 
     .app-header {
-      padding: 1rem;
+      padding: calc(1rem + var(--safe-area-top))
+        calc(1rem + var(--safe-area-right)) 1rem
+        calc(1rem + var(--safe-area-left));
     }
 
     .app-header__nav {
@@ -9833,6 +9908,10 @@ button.danger:disabled {
   align-items: center;
   justify-content: center;
   z-index: 1000;
+  padding: calc(1rem + var(--safe-area-top))
+    calc(1rem + var(--safe-area-right))
+    calc(1rem + var(--safe-area-bottom))
+    calc(1rem + var(--safe-area-left));
   animation: fadeIn 0.2s ease;
 }
 
@@ -10719,6 +10798,10 @@ button.danger:disabled {
   align-items: center;
   justify-content: center;
   z-index: 1000;
+  padding: calc(1rem + var(--safe-area-top))
+    calc(1rem + var(--safe-area-right))
+    calc(1rem + var(--safe-area-bottom))
+    calc(1rem + var(--safe-area-left));
   animation: fadeIn 0.2s ease-out;
 }
 
@@ -11043,6 +11126,10 @@ button.danger:disabled {
   align-items: center;
   justify-content: center;
   z-index: 1000;
+  padding: calc(1rem + var(--safe-area-top))
+    calc(1rem + var(--safe-area-right))
+    calc(1rem + var(--safe-area-bottom))
+    calc(1rem + var(--safe-area-left));
   animation: fadeIn 0.2s ease-out;
 }
 
@@ -11631,6 +11718,9 @@ button.danger:disabled {
     max-height: 85vh;
     border-radius: 1rem 1rem 0 0;
     box-shadow: 0 -4px 24px rgba(30, 42, 64, 0.15);
+    padding-right: calc(1.25rem + var(--safe-area-right));
+    padding-bottom: calc(1.25rem + var(--safe-area-bottom));
+    padding-left: calc(1.25rem + var(--safe-area-left));
   }
 
   /* Tail status for mobile */

--- a/apps/frontend/src/components/DhcpBulkSyncModal.css
+++ b/apps/frontend/src/components/DhcpBulkSyncModal.css
@@ -7,7 +7,10 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 1.25rem;
+  padding: calc(1.25rem + var(--safe-area-top))
+    calc(1.25rem + var(--safe-area-right))
+    calc(1.25rem + var(--safe-area-bottom))
+    calc(1.25rem + var(--safe-area-left));
   z-index: 1200;
 }
 

--- a/apps/frontend/src/components/DhcpBulkSyncResultsModal.css
+++ b/apps/frontend/src/components/DhcpBulkSyncResultsModal.css
@@ -7,7 +7,10 @@
   align-items: center;
   justify-content: center;
   z-index: 1200;
-  padding: 1.5rem;
+  padding: calc(1.5rem + var(--safe-area-top))
+    calc(1.5rem + var(--safe-area-right))
+    calc(1.5rem + var(--safe-area-bottom))
+    calc(1.5rem + var(--safe-area-left));
 }
 
 .dhcp-bulk-sync-results-modal {

--- a/apps/frontend/src/components/common/AboutModal.css
+++ b/apps/frontend/src/components/common/AboutModal.css
@@ -7,7 +7,10 @@
   align-items: center;
   justify-content: center;
   z-index: 1000;
-  padding: 1rem;
+  padding: calc(1rem + var(--safe-area-top))
+    calc(1rem + var(--safe-area-right))
+    calc(1rem + var(--safe-area-bottom))
+    calc(1rem + var(--safe-area-left));
   animation: fadeIn 0.2s ease-out;
 }
 

--- a/apps/frontend/src/components/common/ClusterInfoBanner.css
+++ b/apps/frontend/src/components/common/ClusterInfoBanner.css
@@ -225,8 +225,8 @@
     .cluster-info-banner--dropdown {
         position: fixed;
         top: auto;
-        right: 8px;
-        left: 8px;
+        right: calc(8px + var(--safe-area-right));
+        left: calc(8px + var(--safe-area-left));
         width: auto;
         min-width: unset;
         max-width: unset;

--- a/apps/frontend/src/components/common/ConfirmModal.css
+++ b/apps/frontend/src/components/common/ConfirmModal.css
@@ -10,7 +10,10 @@
   align-items: center;
   justify-content: center;
   z-index: 10000;
-  padding: 1rem;
+  padding: calc(1rem + var(--safe-area-top))
+    calc(1rem + var(--safe-area-right))
+    calc(1rem + var(--safe-area-bottom))
+    calc(1rem + var(--safe-area-left));
   animation: confirmModalFadeIn 0.15s ease-out;
 }
 

--- a/apps/frontend/src/components/common/PullToRefreshIndicator.css
+++ b/apps/frontend/src/components/common/PullToRefreshIndicator.css
@@ -1,6 +1,6 @@
 .pull-to-refresh-indicator {
     position: fixed;
-    top: 0;
+    top: var(--safe-area-top);
     left: 50%;
     display: flex;
     flex-direction: column;

--- a/apps/frontend/src/components/dhcp/DhcpSnapshotDrawer.css
+++ b/apps/frontend/src/components/dhcp/DhcpSnapshotDrawer.css
@@ -1,6 +1,3 @@
-:root {
-}
-
 .snapshot-drawer__overlay {
   position: fixed;
   inset: 0;
@@ -10,7 +7,10 @@
   justify-content: flex-end;
   align-items: stretch;
   z-index: 140;
-  padding: calc(var(--app-header-height, 72px) + 12px) 1.75rem 1.75rem;
+  padding: calc(var(--app-header-height, 72px) + 12px)
+    calc(1.75rem + var(--safe-area-right))
+    calc(1.75rem + var(--safe-area-bottom))
+    calc(1.75rem + var(--safe-area-left));
   opacity: 0;
   transition: opacity 200ms ease-out;
 }
@@ -34,7 +34,9 @@
   transition:
     transform 200ms ease-out,
     opacity 200ms ease-out;
-  max-height: calc(100vh - (var(--app-header-height, 72px) + 32px));
+  max-height: calc(
+    100dvh - var(--app-header-height, 72px) - 32px - var(--safe-area-bottom)
+  );
 }
 
 .snapshot-drawer.is-visible {
@@ -171,7 +173,10 @@
   align-items: center;
   justify-content: center;
   z-index: 50;
-  padding: 1.25rem;
+  padding: calc(1.25rem + var(--safe-area-top))
+    calc(1.25rem + var(--safe-area-right))
+    calc(1.25rem + var(--safe-area-bottom))
+    calc(1.25rem + var(--safe-area-left));
 }
 
 .snapshot-drawer__dialog {
@@ -299,7 +304,7 @@
 
 .drawer-pull {
   position: fixed;
-  right: 0;
+  right: var(--safe-area-right);
   top: 42%;
   transform: translateY(-50%);
   writing-mode: vertical-rl;

--- a/apps/frontend/src/components/layout/Header.tsx
+++ b/apps/frontend/src/components/layout/Header.tsx
@@ -44,7 +44,7 @@ export function Header() {
     }
 
     const setHeaderHeightVar = () => {
-      const height = headerEl.getBoundingClientRect().height;
+      const height = headerEl.offsetHeight;
       if (Number.isFinite(height) && height > 0) {
         document.documentElement.style.setProperty(
           "--app-header-height",
@@ -72,6 +72,54 @@ export function Header() {
     return () => {
       resizeObserver?.disconnect();
       window.removeEventListener("resize", setHeaderHeightVar);
+    };
+  }, []);
+
+  useEffect(() => {
+    const headerEl = headerRef.current;
+    const visualViewport = window.visualViewport;
+    if (!headerEl || !visualViewport) {
+      return;
+    }
+
+    let animationFrameId: number | null = null;
+
+    const syncHeaderToVisualViewport = () => {
+      animationFrameId = null;
+      headerEl.style.setProperty(
+        "--visual-viewport-offset-top",
+        `${Math.max(0, visualViewport.offsetTop)}px`,
+      );
+      headerEl.style.setProperty(
+        "--visual-viewport-offset-left",
+        `${Math.max(0, visualViewport.offsetLeft)}px`,
+      );
+      headerEl.style.setProperty(
+        "--visual-viewport-width",
+        `${visualViewport.width}px`,
+      );
+    };
+
+    const requestViewportSync = () => {
+      if (animationFrameId !== null) {
+        cancelAnimationFrame(animationFrameId);
+      }
+      animationFrameId = requestAnimationFrame(syncHeaderToVisualViewport);
+    };
+
+    syncHeaderToVisualViewport();
+    visualViewport.addEventListener("scroll", requestViewportSync);
+    visualViewport.addEventListener("resize", requestViewportSync);
+
+    return () => {
+      if (animationFrameId !== null) {
+        cancelAnimationFrame(animationFrameId);
+      }
+      visualViewport.removeEventListener("scroll", requestViewportSync);
+      visualViewport.removeEventListener("resize", requestViewportSync);
+      headerEl.style.removeProperty("--visual-viewport-offset-top");
+      headerEl.style.removeProperty("--visual-viewport-offset-left");
+      headerEl.style.removeProperty("--visual-viewport-width");
     };
   }, []);
 

--- a/apps/frontend/src/components/pwa/InstallPrompt.css
+++ b/apps/frontend/src/components/pwa/InstallPrompt.css
@@ -1,8 +1,8 @@
 /* Install Prompt Container */
 .install-prompt {
     position: fixed;
-    bottom: 20px;
-    right: 20px;
+    bottom: calc(20px + var(--safe-area-bottom));
+    right: calc(20px + var(--safe-area-right));
     display: flex;
     align-items: center;
     gap: 8px;
@@ -81,7 +81,10 @@
     align-items: center;
     justify-content: center;
     z-index: 2000;
-    padding: 20px;
+    padding: calc(20px + var(--safe-area-top))
+        calc(20px + var(--safe-area-right))
+        calc(20px + var(--safe-area-bottom))
+        calc(20px + var(--safe-area-left));
     animation: fadeIn 0.3s ease;
 }
 
@@ -179,9 +182,9 @@
 /* Mobile Adjustments */
 @media (max-width: 768px) {
     .install-prompt {
-        bottom: 80px;
+        bottom: calc(80px + var(--safe-area-bottom));
         /* Above mobile nav if present */
-        right: 16px;
+        right: calc(16px + var(--safe-area-right));
         padding: 10px 16px;
         font-size: 13px;
     }

--- a/apps/frontend/src/components/pwa/OfflineBanner.css
+++ b/apps/frontend/src/components/pwa/OfflineBanner.css
@@ -5,7 +5,9 @@
     left: 0;
     right: 0;
     z-index: 9999;
-    padding: 12px 20px;
+    padding: calc(12px + var(--safe-area-top))
+        calc(20px + var(--safe-area-right)) 12px
+        calc(20px + var(--safe-area-left));
     display: flex;
     align-items: center;
     justify-content: center;
@@ -52,7 +54,9 @@
 /* Mobile Adjustments */
 @media (max-width: 768px) {
     .offline-banner {
-        padding: 10px 16px;
+        padding: calc(10px + var(--safe-area-top))
+            calc(16px + var(--safe-area-right)) 10px
+            calc(16px + var(--safe-area-left));
         font-size: 13px;
     }
 
@@ -97,8 +101,16 @@
     /* Adjust based on banner height */
 }
 
+.offline-banner~.app-shell .app-header {
+    --app-header-base-top: 44px;
+}
+
 @media (max-width: 768px) {
     .offline-banner~* {
         margin-top: 40px;
+    }
+
+    .offline-banner~.app-shell .app-header {
+        --app-header-base-top: 40px;
     }
 }

--- a/apps/frontend/src/hooks/usePullToRefresh.ts
+++ b/apps/frontend/src/hooks/usePullToRefresh.ts
@@ -61,11 +61,17 @@ export function usePullToRefresh({
         };
 
         const handleTouchStart = (e: TouchEvent) => {
+            const target = e.target;
+            const startedInsideModal =
+                target instanceof Element &&
+                target.closest('[aria-modal="true"]') !== null;
+
             // Record starting position and whether we're at top
             // Don't set isPulling yet - wait to see the direction
             startY.current = e.touches[0].clientY;
             currentY.current = startY.current;
-            touchStartedAtTop.current = isAtTop() && !isRefreshing;
+            touchStartedAtTop.current =
+                !startedInsideModal && isAtTop() && !isRefreshing;
         };
 
         const handleTouchMove = (e: TouchEvent) => {

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -8,6 +8,25 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 
+  /* Browser-provided viewport cutout and home-indicator insets. */
+  --safe-area-top: max(
+    env(safe-area-inset-top, 0px),
+    env(safe-area-max-inset-top, 0px)
+  );
+  --safe-area-right: max(
+    env(safe-area-inset-right, 0px),
+    env(safe-area-max-inset-right, 0px)
+  );
+  --safe-area-bottom: max(
+    env(safe-area-inset-bottom, 0px),
+    env(safe-area-max-inset-bottom, 0px)
+  );
+  --safe-area-left: max(
+    env(safe-area-inset-left, 0px),
+    env(safe-area-max-inset-left, 0px)
+  );
+  --app-header-height: calc(4rem + var(--safe-area-top));
+
   /* Light Mode Colors */
   --color-text-primary: #1a1f2d;
   --color-text-secondary: #5a6e8b;

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -1,8 +1,31 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { registerSW } from 'virtual:pwa-register'
 import './index.css'
 import App from './App.tsx'
 import { ThemeProvider } from './context/ThemeContext'
+
+const serviceWorkerUpdateIntervalMs = 60 * 60 * 1000
+
+registerSW({
+  immediate: true,
+  onRegisteredSW(_serviceWorkerUrl, registration) {
+    if (!registration) return
+
+    const checkForUpdate = () => {
+      if (document.visibilityState === 'visible') {
+        void registration.update()
+      }
+    }
+
+    checkForUpdate()
+    window.setInterval(checkForUpdate, serviceWorkerUpdateIntervalMs)
+    document.addEventListener('visibilitychange', checkForUpdate)
+  },
+  onRegisterError(error) {
+    console.error('PWA service worker registration failed:', error)
+  },
+})
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/apps/frontend/src/pages/ConfigurationPage.css
+++ b/apps/frontend/src/pages/ConfigurationPage.css
@@ -642,6 +642,10 @@
   align-items: center;
   justify-content: center;
   z-index: 9999;
+  padding: calc(1rem + var(--safe-area-top))
+    calc(1rem + var(--safe-area-right))
+    calc(1rem + var(--safe-area-bottom))
+    calc(1rem + var(--safe-area-left));
 }
 
 .modal-container {

--- a/apps/frontend/src/pages/LogsPage.tsx
+++ b/apps/frontend/src/pages/LogsPage.tsx
@@ -7,6 +7,7 @@ import {
   faSquare,
   faSquareCheck,
   faTowerBroadcast,
+  faXmark,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import type { ReactNode } from "react";
@@ -3602,6 +3603,8 @@ export function LogsPage() {
   const [settingsPopupHorizontalAlign, setSettingsPopupHorizontalAlign] =
     useState<"left" | "right">("left");
   const settingsButtonRef = useRef<HTMLButtonElement>(null);
+  const settingsPanelRef = useRef<HTMLElement>(null);
+  const settingsCloseButtonRef = useRef<HTMLButtonElement>(null);
   const [filtersVisible, setFiltersVisible] = useState<boolean>(false);
   const [statisticsExpanded, setStatisticsExpanded] = useState<boolean>(false);
   const [mobileControlsExpanded, setMobileControlsExpanded] =
@@ -3836,7 +3839,7 @@ export function LogsPage() {
   const pullToRefresh = usePullToRefresh({
     onRefresh: handlePullToRefresh,
     threshold: 80,
-    disabled: false,
+    disabled: settingsOpen,
   });
 
   const handleClientClick = useCallback(
@@ -4363,6 +4366,54 @@ export function LogsPage() {
       setSettingsPopupHorizontalAlign("right");
     }
   }, [settingsOpen]);
+
+  const closeSettings = useCallback(() => {
+    setSettingsOpen(false);
+    window.requestAnimationFrame(() => settingsButtonRef.current?.focus());
+  }, []);
+
+  useEffect(() => {
+    if (!settingsOpen) {
+      return;
+    }
+
+    window.requestAnimationFrame(() => settingsCloseButtonRef.current?.focus());
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        closeSettings();
+        return;
+      }
+
+      if (event.key !== "Tab" || !settingsPanelRef.current) {
+        return;
+      }
+
+      const focusableElements = Array.from(
+        settingsPanelRef.current.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), input:not([disabled]), select:not([disabled]), [href], [tabindex]:not([tabindex="-1"])',
+        ),
+      );
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements.at(-1);
+
+      if (!firstElement || !lastElement) {
+        return;
+      }
+
+      if (event.shiftKey && document.activeElement === firstElement) {
+        event.preventDefault();
+        lastElement.focus();
+      } else if (!event.shiftKey && document.activeElement === lastElement) {
+        event.preventDefault();
+        firstElement.focus();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [closeSettings, settingsOpen]);
 
   const toggleColumnVisibility = (key: OptionalColumnKey) => {
     setColumnVisibility((prev) => {
@@ -8295,7 +8346,15 @@ export function LogsPage() {
                           ? "logs-page__settings-toggle active"
                           : "logs-page__settings-toggle"
                       }
-                      onClick={() => setSettingsOpen((prev) => !prev)}
+                      onClick={() => {
+                        if (settingsOpen) {
+                          closeSettings();
+                        } else {
+                          setSettingsOpen(true);
+                        }
+                      }}
+                      aria-expanded={settingsOpen}
+                      aria-controls="logs-table-settings"
                     >
                       Table settings
                     </button>
@@ -8304,17 +8363,35 @@ export function LogsPage() {
                       <>
                         <div
                           className="logs-page__settings-backdrop"
-                          onClick={() => setSettingsOpen(false)}
+                          onClick={closeSettings}
                         />
                         <section
+                          ref={settingsPanelRef}
+                          id="logs-table-settings"
                           className={`logs-page__settings logs-page__settings--${settingsPopupHorizontalAlign}`}
+                          role="dialog"
+                          aria-modal="true"
+                          aria-labelledby="logs-table-settings-title"
+                          aria-describedby="logs-table-settings-description"
                         >
-                          <header>
-                            <h2>Table settings</h2>
-                            <p>
-                              Adjust which optional columns appear in the logs
-                              table.
-                            </p>
+                          <header className="logs-page__settings-header">
+                            <div className="logs-page__settings-header-copy">
+                              <h2 id="logs-table-settings-title">Table settings</h2>
+                              <p id="logs-table-settings-description">
+                                Adjust which optional columns appear in the logs
+                                table.
+                              </p>
+                            </div>
+                            <button
+                              ref={settingsCloseButtonRef}
+                              type="button"
+                              className="logs-page__settings-close"
+                              onClick={closeSettings}
+                              aria-label="Close table settings"
+                              title="Close"
+                            >
+                              <FontAwesomeIcon icon={faXmark} />
+                            </button>
                           </header>
                           <div className="logs-page__settings-options">
                             {OPTIONAL_COLUMN_OPTIONS.map((option) => {

--- a/apps/frontend/src/vite-env.d.ts
+++ b/apps/frontend/src/vite-env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/client" />
 
 // Global constants injected by Vite
 declare const __APP_NAME__: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "technitium-dns-companion",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "technitium-dns-companion",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "MIT",
       "workspaces": [
         "apps/backend",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "technitium-dns-companion",
   "private": true,
-  "version": "1.9.0",
+  "version": "1.9.1",
   "license": "MIT",
   "workspaces": [
     "apps/backend",


### PR DESCRIPTION
## Summary

- make the mobile/PWA shell respect iPhone safe-area insets across headers, banners, dialogs, drawers, toasts, and floating controls
- keep the application header aligned with the iOS visual viewport during overscroll, pinch zoom, and panning
- improve the DNS Logs table-settings sheet with an explicit close control, focus management, Escape dismissal, and pull-to-refresh isolation
- register proactive PWA update checks when the app returns to the foreground and while it remains open
- bump the application version to 1.9.1 and add release notes

## Root cause

The layout relied on ordinary viewport positioning and body padding, which did not consistently account for iOS safe areas or the distinction between the layout and visual viewports during zoom. The DNS Logs pull-to-refresh hook also listened at document scope, allowing gestures inside the settings dialog to arm a page refresh.

## Impact

Mobile and installed-PWA users no longer see content overlap the iPhone status area, the header remains reachable while zoomed, and the DNS Logs settings sheet can be dismissed reliably without triggering refresh gestures.

## Validation

- `npm run lint`
- `npm run test` (380 backend and 752 frontend tests passed)
- `npm run build`
- pre-push backend and frontend test suites
