### PR TITLE
fix: align sharp manifest with lockfile

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -52,7 +52,7 @@
     "globals": "^16.4.0",
     "jsdom": "^27.0.1",
     "rollup-plugin-visualizer": "^5.14.0",
-    "sharp": "^0.35.3",
+    "sharp": "^0.35.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.45.0",
     "vite": "^7.3.6",


### PR DESCRIPTION
## Summary

Align the frontend `sharp` version range with the version already resolved in the root lockfile.

## Root cause

A grouped dependency update left `apps/frontend/package.json` requiring `sharp ^0.35.3` while `package-lock.json` recorded the frontend workspace and dependency tree at `sharp ^0.35.0`. GitHub Actions therefore rejected the repository during `npm ci`, before the Technitium compatibility suite could run.

## Impact

`npm ci` can install the committed dependency graph again, allowing the scheduled Technitium v15 compatibility workflow and other clean-install jobs to proceed.

## Validation

- `npm ci`
- `npm test` — 380 backend tests and 752 frontend tests passed
- `npm run build`
- `git diff --check`
