### PR TITLE
fix: allow adding Advanced Blocking regex entries

### DIFF
--- a/apps/frontend/src/pages/ConfigurationPage.tsx
+++ b/apps/frontend/src/pages/ConfigurationPage.tsx
@@ -76,6 +76,11 @@ import {
     compareStringArrays,
     compareUrlArrays,
 } from "../utils/arrayComparison";
+import {
+  getNewRegexEntryCandidate,
+  isRegexDomainType,
+  type AdvancedBlockingDomainType,
+} from "../utils/advanced-blocking-domain-entries";
 import "./ConfigurationPage.css";
 import { AppInput } from "../components/common/AppInput";
 
@@ -574,9 +579,8 @@ export function ConfigurationPage() {
   const [dragOverGroup, setDragOverGroup] = useState<string | null>(null);
   const [checking, setChecking] = useState(false);
   const [groups, setGroups] = useState<string[]>([]);
-  const [activeDomainType, setActiveDomainType] = useState<
-    "blocked" | "allowed" | "blockedRegex" | "allowedRegex"
-  >("blocked");
+  const [activeDomainType, setActiveDomainType] =
+    useState<AdvancedBlockingDomainType>("blocked");
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
 
   // The binding action that corresponds to the current activeDomainType tab
@@ -1672,15 +1676,24 @@ export function ConfigurationPage() {
 
   const handleCheckDomain = useCallback(
     async (domainOverride?: string) => {
-      // Regex patterns cannot be checked via the domain lookup API
-      if (
-        activeDomainType === "blockedRegex" ||
-        activeDomainType === "allowedRegex"
-      ) {
+      const rawInput = (domainOverride ?? searchInput).trim();
+      if (!rawInput || !selectedNodeId) return;
+
+      // Regex patterns cannot be checked via the domain lookup API. Prepare
+      // new patterns locally so they can still be dragged into a group.
+      if (isRegexDomainType(activeDomainType)) {
+        const candidate = getNewRegexEntryCandidate(
+          rawInput,
+          activeDomainType,
+          testStagedConfig ?? selectedNodeConfig,
+        );
+        setSearchedDomain(candidate);
+        setDomainExists(false);
+        setDomainInGroups([]);
+        setDomainMatchDetails([]);
         return;
       }
-      const rawInput = domainOverride ?? searchInput.trim();
-      if (!rawInput || !selectedNodeId) return;
+
       const domain = extractDomainFromInput(rawInput);
       setChecking(true);
       try {
@@ -1720,7 +1733,14 @@ export function ConfigurationPage() {
         setChecking(false);
       }
     },
-    [activeDomainType, searchInput, selectedNodeId, extractDomainFromInput],
+    [
+      activeDomainType,
+      searchInput,
+      selectedNodeId,
+      extractDomainFromInput,
+      testStagedConfig,
+      selectedNodeConfig,
+    ],
   );
 
   const handleDomainClick = useCallback(

--- a/apps/frontend/src/test/advanced-blocking-domain-entries.test.ts
+++ b/apps/frontend/src/test/advanced-blocking-domain-entries.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import type { AdvancedBlockingConfig } from "../types/advancedBlocking";
+import {
+  getNewRegexEntryCandidate,
+  isRegexDomainType,
+} from "../utils/advanced-blocking-domain-entries";
+
+const config = {
+  groups: [
+    {
+      allowedRegex: ["^allowed\\.example$"],
+      blockedRegex: ["^blocked\\.example$"],
+    },
+  ],
+} as AdvancedBlockingConfig;
+
+describe("Advanced Blocking domain entries", () => {
+  it("identifies both regex domain types", () => {
+    expect(isRegexDomainType("allowedRegex")).toBe(true);
+    expect(isRegexDomainType("blockedRegex")).toBe(true);
+    expect(isRegexDomainType("allowed")).toBe(false);
+    expect(isRegexDomainType("blocked")).toBe(false);
+  });
+
+  it("prepares a trimmed new regex entry for the draggable preview", () => {
+    expect(
+      getNewRegexEntryCandidate(
+        "  ^new\\.example$  ",
+        "allowedRegex",
+        config,
+      ),
+    ).toBe("^new\\.example$");
+  });
+
+  it("does not prepare an entry that already exists for the selected type", () => {
+    expect(
+      getNewRegexEntryCandidate(
+        "^allowed\\.example$",
+        "allowedRegex",
+        config,
+      ),
+    ).toBeNull();
+    expect(
+      getNewRegexEntryCandidate(
+        "^blocked\\.example$",
+        "blockedRegex",
+        config,
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/frontend/src/utils/advanced-blocking-domain-entries.ts
+++ b/apps/frontend/src/utils/advanced-blocking-domain-entries.ts
@@ -1,0 +1,28 @@
+import type { AdvancedBlockingConfig } from "../types/advancedBlocking";
+
+export type AdvancedBlockingDomainType =
+  | "blocked"
+  | "allowed"
+  | "blockedRegex"
+  | "allowedRegex";
+
+export function isRegexDomainType(
+  domainType: AdvancedBlockingDomainType,
+): domainType is "blockedRegex" | "allowedRegex" {
+  return domainType === "blockedRegex" || domainType === "allowedRegex";
+}
+
+export function getNewRegexEntryCandidate(
+  input: string,
+  domainType: "blockedRegex" | "allowedRegex",
+  config: AdvancedBlockingConfig | null | undefined,
+): string | null {
+  const candidate = input.trim();
+  if (!candidate) return null;
+
+  const exists = config?.groups.some((group) =>
+    (group[domainType] ?? []).includes(candidate),
+  );
+
+  return exists ? null : candidate;
+}


### PR DESCRIPTION
## Summary

- prepare new Allowed Regex and Blocked Regex entries locally instead of sending them to the domain lookup API
- expose new regex input through the existing draggable-entry workflow
- suppress the new-entry preview when the exact regex already exists for the selected action type
- add regression coverage for both regex modes, trimming, and duplicate detection

## Validation

- `npm run lint` (frontend)
- `npm run typecheck` (frontend)
- `npm run test` (380 backend tests and 755 frontend tests passed; expected skips/todos remain)
- `npm run build`
- repository pre-push test hook

Fixes #95