### PR TITLE
chore: release v1.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.9.2] - 2026-07-28
+
+### Fixed
+
+- **New Advanced Blocking regex entries can be added from DNS Filtering → Domains.** Allowed Regex and Blocked Regex input now produces the existing draggable entry preview without attempting an incompatible domain lookup, while exact duplicates remain search-only (closes #95).
+- **Clean dependency installs accept the committed Sharp version.** The frontend manifest now matches the lockfile so `npm ci` and the Technitium compatibility workflow no longer fail before tests begin.
+
+### Security
+
+- **Runtime and development dependencies received security updates.** Updated Axios and patched transitive releases of Body Parser, Fast URI, PostCSS, Brace Expansion, and Nano ID. The React Router RSC advisory was separately assessed as not applicable because Companion does not use React Server Components.
+
 ## [1.9.1] - 2026-07-22
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "technitium-dns-companion",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "technitium-dns-companion",
-      "version": "1.9.1",
+      "version": "1.9.2",
       "license": "MIT",
       "workspaces": [
         "apps/backend",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "technitium-dns-companion",
   "private": true,
-  "version": "1.9.1",
+  "version": "1.9.2",
   "license": "MIT",
   "workspaces": [
     "apps/backend",


### PR DESCRIPTION
## Summary

- bump the root package and lockfile version to 1.9.2
- add canonical v1.9.2 release notes for the Advanced Blocking regex-entry fix
- document the clean-install correction and dependency security maintenance included since v1.9.1

## Validation

- `npm ci --cache /private/tmp/technitium-dns-companion-npm-cache`
- `npm run lint`
- `npm run test` — 380 backend tests and 755 frontend tests passed
- `npm run build`
- version consistency check across `package.json` and `package-lock.json`
- repository pre-push test hook

## Audit note

`npm audit --omit=dev` reports only GHSA-qwww-vcr4-c8h2 through React Router. The advisory applies exclusively to unstable React Server Components APIs; Companion is a client-side Vite SPA without RSC usage, and Dependabot alert #105 was dismissed as not affected.