### PR TITLE
feat(auth): optional trusted-header SSO auto-login for reverse-proxy forward-auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -296,3 +296,37 @@ TECHNITIUM_NODE2_BASE_URL=https://dns-secondary.example.com:53443
 # How many consecutive drift ticks before the first email fires
 # (default 3). At the default 60s evaluator interval this is ~2–3 min.
 # DNS_SCHEDULES_DRIFT_ALERT_THRESHOLD=3
+
+# --- Trusted-header SSO auto-login (reverse-proxy forward-auth) ---------------
+# When the Companion is fronted by a forward-auth reverse proxy (oauth2-proxy,
+# Authelia, Authentik, nginx auth_request, Traefik forwardAuth, etc.) that
+# injects an authenticated-identity header, enable this to skip the in-app
+# Technitium login: the proxy IS the access-control boundary, so a user who
+# passes the SSO gate is auto-signed-in under a shared service account. The
+# normal Technitium username/password form still serves whenever the header is
+# absent (e.g. reaching the container directly), i.e. it is the break-glass.
+#
+#   TRUSTED_SSO_HEADER_AUTH  — "true" to enable (default off; inert otherwise).
+#   TRUSTED_SSO_HEADER       — identity header name (default x-forwarded-user).
+#                              Set to whatever your proxy emits, e.g.
+#                              x-forwarded-email, x-auth-request-user, or an
+#                              IdP-specific header like x-authentik-email.
+#   TRUSTED_SSO_SERVICE_USER — shared Technitium username to log in as (default
+#                              admin). Used when no per-user entry matches.
+#   TRUSTED_SSO_SERVICE_PASS — that account's Technitium password. Store in a
+#                              secret manager, never commit.
+#
+# Optional per-user mode — map each SSO identity to that user's OWN Technitium
+# credentials, preserving per-user RBAC + audit. JSON keyed by the header value
+# (case-insensitive); identities not present fall back to the service account:
+#   TRUSTED_SSO_USER_CREDS={"alice@example.com":{"username":"alice","password":"..."}}
+#
+# Enable requires TRUSTED_SSO_HEADER_AUTH=true AND at least one of
+# TRUSTED_SSO_SERVICE_PASS or TRUSTED_SSO_USER_CREDS. Requires TRUST_PROXY=true
+# (auto-login only fires on requests the proxy marks secure via
+# X-Forwarded-Proto). When a per-user entry exists it takes precedence.
+# TRUSTED_SSO_HEADER_AUTH=true
+# TRUSTED_SSO_HEADER=x-forwarded-user
+# TRUSTED_SSO_SERVICE_USER=admin
+# TRUSTED_SSO_SERVICE_PASS=
+# TRUSTED_SSO_USER_CREDS=

--- a/apps/backend/src/auth/auth.middleware.ts
+++ b/apps/backend/src/auth/auth.middleware.ts
@@ -3,13 +3,18 @@ import { Injectable } from "@nestjs/common";
 import type { NextFunction, Request, Response } from "express";
 import { AuthRequestContext } from "./auth-request-context";
 import { AuthSessionService } from "./auth-session.service";
+import { AuthService } from "./auth.service";
 import { AUTH_SESSION_COOKIE_NAME } from "./auth.constants";
+import type { AuthSession } from "./auth.types";
 
 @Injectable()
 export class AuthRequestContextMiddleware implements NestMiddleware {
-  constructor(private readonly sessionService: AuthSessionService) {}
+  constructor(
+    private readonly sessionService: AuthSessionService,
+    private readonly authService: AuthService,
+  ) {}
 
-  use(req: Request, _res: Response, next: NextFunction): void {
+  async use(req: Request, res: Response, next: NextFunction): Promise<void> {
     const cookiesValue: unknown = (req as unknown as { cookies?: unknown })
       .cookies;
     const sessionId =
@@ -19,9 +24,33 @@ export class AuthRequestContextMiddleware implements NestMiddleware {
 
     const resolvedSessionId =
       typeof sessionId === "string" ? sessionId : undefined;
-    const session = resolvedSessionId
+    let session: AuthSession | undefined = resolvedSessionId
       ? this.sessionService.get(resolvedSessionId)
       : undefined;
+
+    // Trusted-header (reverse-proxy SSO) auto-login: when there's no valid
+    // session cookie but the forward-auth proxy injected an identity header,
+    // establish the session transparently and set the cookie so subsequent
+    // requests reuse it. Absent the header, we fall through with no session
+    // and the normal Technitium login form serves as the break-glass path.
+    if (
+      !session &&
+      req.secure &&
+      this.authService.trustedHeaderAuthEnabled()
+    ) {
+      const headerUser = this.authService.extractTrustedUser(req.headers);
+      if (headerUser) {
+        const minted = await this.authService.loginViaTrustedHeader(headerUser);
+        if (minted) {
+          session = minted.session;
+          res.cookie(
+            this.authService.cookieName(),
+            session.id,
+            this.authService.cookieOptions(true),
+          );
+        }
+      }
+    }
 
     AuthRequestContext.run({ session }, () => next());
   }

--- a/apps/backend/src/auth/auth.module.ts
+++ b/apps/backend/src/auth/auth.module.ts
@@ -9,6 +9,6 @@ import { AuthService } from "./auth.service";
   imports: [TechnitiumModule],
   controllers: [AuthController],
   providers: [AuthService, AuthSessionService, AuthRequestContextMiddleware],
-  exports: [AuthSessionService, AuthRequestContextMiddleware],
+  exports: [AuthService, AuthSessionService, AuthRequestContextMiddleware],
 })
 export class AuthModule {}

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -207,6 +207,117 @@ export class AuthService {
     return undefined;
   }
 
+  /**
+   * Resolve the Technitium credentials to log in with for a given
+   * proxy-provided identity.
+   *
+   * Per-user mode (optional): TRUSTED_SSO_USER_CREDS is a JSON object mapping
+   * the identity (as it appears in the header, e.g. an email) to that user's
+   * own Technitium { username, password }. When the identity has an entry,
+   * the Companion signs in as that user — preserving per-user Technitium RBAC
+   * and audit. Lookup is case-insensitive on the identity key.
+   *
+   * Shared-admin fallback: when no per-user entry matches, fall back to the
+   * shared service account (TRUSTED_SSO_SERVICE_USER / _SERVICE_PASS). This
+   * is the intended mode when the SSO gate is itself the access boundary.
+   *
+   * Returns undefined when neither is configured (feature effectively off).
+   */
+  private resolveTrustedCreds(
+    displayUser: string,
+  ): { username: string; password: string } | undefined {
+    const raw = process.env.TRUSTED_SSO_USER_CREDS;
+    if (raw && raw.trim()) {
+      try {
+        const map = JSON.parse(raw) as Record<
+          string,
+          { username?: string; password?: string } | undefined
+        >;
+        const lowered = displayUser.toLowerCase();
+        const entry =
+          map[displayUser] ??
+          Object.entries(map).find(([k]) => k.toLowerCase() === lowered)?.[1];
+        if (entry?.username && entry?.password) {
+          return { username: entry.username, password: entry.password };
+        }
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Unknown error";
+        this.logger.warn(`TRUSTED_SSO_USER_CREDS parse failed: ${message}`);
+      }
+    }
+
+    const serviceUser =
+      (process.env.TRUSTED_SSO_SERVICE_USER ?? "").trim() || "admin";
+    const servicePass = process.env.TRUSTED_SSO_SERVICE_PASS ?? "";
+    if (!servicePass) {
+      return undefined;
+    }
+    return { username: serviceUser, password: servicePass };
+  }
+
+  /**
+   * Trusted-header (reverse-proxy SSO) auto-login.
+   *
+   * When the app sits behind a forward-auth reverse proxy (e.g. Authentik),
+   * the proxy has already authenticated the user and injects an identity
+   * header. Rather than prompt for a second, in-app Technitium login, we
+   * establish the Companion session on the user's behalf using resolved
+   * credentials (per-user if configured, else a shared service account),
+   * then relabel the session to the proxy-provided identity for
+   * display/audit.
+   *
+   * Opt-in and inert unless enabled + configured — see
+   * trustedHeaderAuthEnabled().
+   */
+  async loginViaTrustedHeader(
+    displayUser: string,
+  ): Promise<{ session: AuthSession } | undefined> {
+    const creds = this.resolveTrustedCreds(displayUser);
+    if (!creds) {
+      return undefined;
+    }
+
+    try {
+      const { session } = await this.login(creds);
+      // Relabel to the SSO identity (session is the stored reference).
+      session.user = displayUser;
+      return { session };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      this.logger.warn(`Trusted-header auto-login failed: ${message}`);
+      return undefined;
+    }
+  }
+
+  /** Whether trusted-header SSO auto-login is enabled and fully configured. */
+  trustedHeaderAuthEnabled(): boolean {
+    if (process.env.TRUSTED_SSO_HEADER_AUTH !== "true") {
+      return false;
+    }
+    const hasService = !!(process.env.TRUSTED_SSO_SERVICE_PASS ?? "");
+    const hasUserMap = !!(process.env.TRUSTED_SSO_USER_CREDS ?? "").trim();
+    return hasService || hasUserMap;
+  }
+
+  /**
+   * Extract the proxy-injected identity from the configured header
+   * (default x-forwarded-user). Returns undefined when absent/empty so
+   * the caller falls through to the normal (break-glass) login form.
+   */
+  extractTrustedUser(
+    headers: Record<string, string | string[] | undefined>,
+  ): string | undefined {
+    const headerName =
+      ((process.env.TRUSTED_SSO_HEADER ?? "").trim() || "x-forwarded-user")
+        .toLowerCase();
+    const raw = headers[headerName];
+    const value =
+      typeof raw === "string" ? raw : Array.isArray(raw) ? raw[0] : undefined;
+    const trimmed = typeof value === "string" ? value.trim() : "";
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+
   async login(
     dto: AuthLoginRequestDto,
   ): Promise<{ session: AuthSession; response: AuthLoginResponseDto }> {


### PR DESCRIPTION
## Problem

Session-auth (v1.4+) always requires an interactive Technitium login in the Companion UI. When the Companion is deployed behind a forward-auth reverse proxy (oauth2-proxy, Authelia, Authentik, nginx `auth_request`, Traefik `forwardAuth`, …), the user has already authenticated at the proxy — so they hit a second, redundant login. There's no way to treat the SSO gate as the access-control boundary.

## What this adds

An **opt-in** trusted-header auto-login (off by default, zero behaviour change when unset):

- When enabled and a request arrives with no valid session, over a proxy-trusted secure connection (`TRUST_PROXY`), carrying the configured identity header, the backend establishes the Companion session on the user's behalf and sets the session cookie — no login form.
- Credentials are resolved per identity: an optional per-user map (`TRUSTED_SSO_USER_CREDS`) preserves per-user Technitium RBAC/audit; otherwise a shared service account (`TRUSTED_SSO_SERVICE_*`) is used. The session is labelled with the proxy-provided identity.
- **Break-glass preserved:** when the header is absent (e.g. reaching the container directly), the normal Technitium login form still serves.

## Config (all optional; feature inert unless `TRUSTED_SSO_HEADER_AUTH=true`)

- `TRUSTED_SSO_HEADER_AUTH` — enable
- `TRUSTED_SSO_HEADER` — identity header (default `x-forwarded-user`)
- `TRUSTED_SSO_SERVICE_USER` / `TRUSTED_SSO_SERVICE_PASS` — shared account
- `TRUSTED_SSO_USER_CREDS` — optional JSON per-user credential map

## Security notes

- Only honoured on `req.secure` (requires `TRUST_PROXY`); the proxy must set the identity header authoritatively and strip any client-supplied copy.
- Shared-account mode intentionally collapses UI users onto one Technitium identity — suited to deployments where the SSO gate is the access boundary.

## Compatibility / testing

- Default off → byte-identical to current behaviour (verified: header ignored when disabled).
- Verified with a live forward-auth proxy: header present → auto-login yields a working multi-node session; header absent → break-glass login form; break-glass credential login still succeeds.
