### PR TITLE
chore: release v1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.10.1] - 2026-08-13
+
+### Fixed
+
+- **Domain Groups can be bound to every Advanced Blocking group from the Domains tab.** Dropping a Domain Group onto **All Groups** now applies the selected allow/block binding across all groups, skips matching bindings, replaces opposite bindings, and reports success, no-op, or failure feedback instead of silently doing nothing.
+- **DNS Lookup typeahead avoids superseded request storms.** All Domains and exact-match searches now share a 750 ms debounce, cancel obsolete requests, retain the active search during pagination, and bypass service-worker interception for live search endpoints so browser cancellation reaches the network.
+
+### Testing
+
+- Added frontend regression coverage for bulk Domain Group binding plans and settled DNS Lookup searches.
+
 ## [1.10.0] - 2026-07-31
 
 ### Added

--- a/apps/frontend/src/pages/ConfigurationPage.tsx
+++ b/apps/frontend/src/pages/ConfigurationPage.tsx
@@ -92,6 +92,7 @@ import {
   isRegexDomainType,
   type AdvancedBlockingDomainType,
 } from "../utils/advanced-blocking-domain-entries";
+import { planDomainGroupBindings } from "../utils/domain-group-bindings";
 import "./ConfigurationPage.css";
 import { AppInput } from "../components/common/AppInput";
 
@@ -1198,60 +1199,104 @@ export function ConfigurationPage() {
     };
   }, [closeDgPopover, dgPopoverDgId]);
 
-  const handleBindDomainGroupToGroup = useCallback(
-    async (dgId: string, abGroupName: string, action: "allow" | "block") => {
-      // If the opposite binding exists, delete it first
-      const existingOpp = domainGroupPreview?.allBindings.find(
-        (b) =>
-          b.domainGroupId === dgId &&
-          b.advancedBlockingGroupName.toLowerCase() ===
-            abGroupName.toLowerCase() &&
-          b.action !== action,
+  const handleBindDomainGroupToGroups = useCallback(
+    async (
+      dgId: string,
+      targetGroupNames: string[],
+      action: "allow" | "block",
+    ) => {
+      const plan = planDomainGroupBindings(
+        domainGroupPreview?.allBindings ?? [],
+        dgId,
+        targetGroupNames,
+        action,
       );
-      if (existingOpp) {
-        await deleteDomainGroupBinding(dgId, existingOpp.bindingId);
-      }
+      const dgName =
+        domainGroupsList.find((group) => group.id === dgId)?.name ??
+        "Domain Group";
 
-      // If the same binding already exists, no-op
-      const existingSame = domainGroupPreview?.allBindings.find(
-        (b) =>
-          b.domainGroupId === dgId &&
-          b.advancedBlockingGroupName.toLowerCase() ===
-            abGroupName.toLowerCase() &&
-          b.action === action,
-      );
-      if (existingSame) {
-        await refreshDomainGroupsPreview();
+      if (plan.targetGroupNames.length === 0) {
+        pushToast({
+          message: `There are no Advanced Blocking groups available for "${dgName}".`,
+          tone: "info",
+        });
         return;
       }
 
-      await addDomainGroupBinding(dgId, {
-        advancedBlockingGroupName: abGroupName,
-        action,
-      });
-      setSessionAddedBindingKeys((prev) => {
-        const next = new Set(prev);
-        next.add(`${dgId}||${abGroupName.toLowerCase()}||${action}`);
-        return next;
-      });
-      await refreshDomainGroupsPreview();
-      if (selectedDomainGroup?.id === dgId) {
-        await loadSelectedDomainGroup(dgId);
+      if (
+        plan.bindingIdsToDelete.length === 0 &&
+        plan.groupNamesToAdd.length === 0
+      ) {
+        const targetDescription =
+          plan.targetGroupNames.length === 1 ?
+            `"${plan.targetGroupNames[0]}"`
+          : `all ${plan.targetGroupNames.length} groups`;
+        pushToast({
+          message: `"${dgName}" is already bound to ${targetDescription} for ${action} entries.`,
+          tone: "info",
+        });
+        return;
       }
 
-      const dgName =
-        domainGroupsList.find((g) => g.id === dgId)?.name ?? "Domain Group";
-      pushToast({
-        message: `"${dgName}" bound to ${abGroupName} — Apply in Domain Groups to sync DNS.`,
-        tone: "success",
-        timeout: 7000,
-      });
+      setDomainGroupsActionLoading(true);
+      setDomainGroupsError(null);
+      const addedGroupNames: string[] = [];
+
+      try {
+        for (const bindingId of plan.bindingIdsToDelete) {
+          await deleteDomainGroupBinding(dgId, bindingId);
+        }
+        for (const advancedBlockingGroupName of plan.groupNamesToAdd) {
+          await addDomainGroupBinding(dgId, {
+            advancedBlockingGroupName,
+            action,
+          });
+          addedGroupNames.push(advancedBlockingGroupName);
+        }
+
+        if (addedGroupNames.length > 0) {
+          setSessionAddedBindingKeys((previous) => {
+            const next = new Set(previous);
+            for (const groupName of addedGroupNames) {
+              next.add(`${dgId}||${groupName.toLowerCase()}||${action}`);
+            }
+            return next;
+          });
+        }
+
+        await refreshDomainGroupsPreview();
+        if (selectedDomainGroup?.id === dgId) {
+          await loadSelectedDomainGroup(dgId);
+        }
+
+        const targetDescription =
+          plan.targetGroupNames.length === 1 ?
+            plan.targetGroupNames[0]
+          : `all ${plan.targetGroupNames.length} groups`;
+        pushToast({
+          message: `"${dgName}" bound to ${targetDescription} — Apply in Domain Groups to sync DNS.`,
+          tone: "success",
+          timeout: 7000,
+        });
+      } catch (error) {
+        const message = getErrorMessage(error);
+        setDomainGroupsError(message);
+        pushToast({
+          message: `Could not bind "${dgName}": ${message}`,
+          tone: "error",
+          timeout: 7000,
+        });
+        await refreshDomainGroupsPreview();
+      } finally {
+        setDomainGroupsActionLoading(false);
+      }
     },
     [
       addDomainGroupBinding,
       deleteDomainGroupBinding,
       domainGroupPreview,
       domainGroupsList,
+      getErrorMessage,
       loadSelectedDomainGroup,
       pushToast,
       refreshDomainGroupsPreview,
@@ -1967,11 +2012,19 @@ export function ConfigurationPage() {
   ) => {
     e.preventDefault();
 
-    // Handle Domain Group pill drop (bind DG to AB group)
+    // Handle Domain Group pill drop (bind DG to one or all AB groups)
     const dgId = e.dataTransfer.getData("text/domain-group-id");
-    if (dgId && groupName !== "ALL_GROUPS") {
+    if (dgId) {
       setDragOverGroup(null);
-      void handleBindDomainGroupToGroup(dgId, groupName, activeDomainTypeAction);
+      setIsDraggingDomainGroup(false);
+      setDraggedDomainGroupId(null);
+      const targetGroupNames =
+        groupName === "ALL_GROUPS" ? groups : [groupName];
+      void handleBindDomainGroupToGroups(
+        dgId,
+        targetGroupNames,
+        activeDomainTypeAction,
+      );
       return;
     }
 

--- a/apps/frontend/src/pages/DnsLookupPage.tsx
+++ b/apps/frontend/src/pages/DnsLookupPage.tsx
@@ -26,6 +26,8 @@ import { AppInput } from "../components/common/AppInput";
 import { extractDomainFromInput } from "../utils/urlParsing";
 import "./DnsLookupPage.css";
 
+const DOMAIN_SEARCH_DEBOUNCE_MS = 750;
+
 export const DnsLookupPage: React.FC = () => {
   const { nodes } = useTechnitiumState();
   const { pushToast } = useToast();
@@ -178,8 +180,8 @@ export const DnsLookupPage: React.FC = () => {
 
   const loadAllDomains = useCallback(
     async (
-      page: number = 1,
-      searchTerm?: string,
+      page: number,
+      searchTerm: string,
       forceRefresh: boolean = false,
       abortSignal?: AbortSignal,
     ) => {
@@ -191,10 +193,6 @@ export const DnsLookupPage: React.FC = () => {
       setLoadingDomains(true);
       setIsSearchPending(false);
 
-      // Use provided search term or current searchFilter
-      const effectiveSearchTerm =
-        searchTerm !== undefined ? searchTerm : searchFilter;
-
       try {
         // If we have a full cache and not forcing refresh, try client-side filtering first
         if (
@@ -204,7 +202,7 @@ export const DnsLookupPage: React.FC = () => {
         ) {
           // Client-side filtering for datasets under 100k
           setUseClientSideFiltering(true);
-          setActiveSearchTerm(effectiveSearchTerm);
+          setActiveSearchTerm(searchTerm);
           setLoadingDomains(false);
           return;
         }
@@ -214,8 +212,8 @@ export const DnsLookupPage: React.FC = () => {
 
         // Build query parameters
         const params = new URLSearchParams();
-        if (effectiveSearchTerm.trim()) {
-          params.append("search", effectiveSearchTerm.trim());
+        if (searchTerm.trim()) {
+          params.append("search", searchTerm.trim());
           params.append("searchMode", searchMode);
         }
         if (typeFilter !== "all") {
@@ -239,11 +237,11 @@ export const DnsLookupPage: React.FC = () => {
         setCurrentPage(result.pagination.page);
         setTotalPages(result.pagination.totalPages);
         setTotalDomains(result.pagination.total);
-        setActiveSearchTerm(effectiveSearchTerm);
+        setActiveSearchTerm(searchTerm);
 
         // Cache full results if it's a reasonable size (no filters and under 100k)
         if (
-          !effectiveSearchTerm &&
+          !searchTerm &&
           typeFilter === "all" &&
           result.pagination.total <= 100000
         ) {
@@ -264,7 +262,6 @@ export const DnsLookupPage: React.FC = () => {
     [
       selectedNodeId,
       pushToast,
-      searchFilter,
       typeFilter,
       pageSize,
       searchMode,
@@ -314,13 +311,6 @@ export const DnsLookupPage: React.FC = () => {
     threshold: 80,
     disabled: !selectedNodeId,
   });
-
-  // Load domains when tab is activated
-  React.useEffect(() => {
-    if (activeTab === "domains" && selectedNodeId && allDomains.length === 0) {
-      loadAllDomains();
-    }
-  }, [activeTab, selectedNodeId, allDomains.length, loadAllDomains]);
 
   // Validate regex as user types (only in regex mode)
   React.useEffect(() => {
@@ -401,7 +391,7 @@ export const DnsLookupPage: React.FC = () => {
           setExactCheckLoading(false);
         }
       }
-    }, 300);
+    }, DOMAIN_SEARCH_DEBOUNCE_MS);
 
     return () => {
       window.clearTimeout(timeoutId);
@@ -470,7 +460,7 @@ export const DnsLookupPage: React.FC = () => {
     // Show pending indicator immediately for server-side
     setIsSearchPending(true);
 
-    // Shorter debounce for server-side (150ms instead of 250ms)
+    // Debounce server-side search so intermediate keystrokes do not reach the API.
     const timeoutId = setTimeout(() => {
       // Create new abort controller for this request
       const abortController = new AbortController();
@@ -478,7 +468,7 @@ export const DnsLookupPage: React.FC = () => {
 
       setCurrentPage(1); // Reset to page 1 on new search
       loadAllDomains(1, searchFilter, false, abortController.signal);
-    }, 150); // 150ms debounce - aggressive but still prevents too many requests
+    }, DOMAIN_SEARCH_DEBOUNCE_MS);
 
     return () => {
       clearTimeout(timeoutId);
@@ -1542,14 +1532,16 @@ export const DnsLookupPage: React.FC = () => {
                         <div className="dns-lookup__pagination-controls">
                           <button
                             className="dns-lookup__pagination-button"
-                            onClick={() => loadAllDomains(1)}
+                            onClick={() => loadAllDomains(1, searchFilter)}
                             disabled={currentPage === 1 || loadingDomains}
                           >
                             First
                           </button>
                           <button
                             className="dns-lookup__pagination-button"
-                            onClick={() => loadAllDomains(currentPage - 1)}
+                            onClick={() =>
+                              loadAllDomains(currentPage - 1, searchFilter)
+                            }
                             disabled={currentPage === 1 || loadingDomains}
                           >
                             Previous
@@ -1559,7 +1551,9 @@ export const DnsLookupPage: React.FC = () => {
                           </span>
                           <button
                             className="dns-lookup__pagination-button"
-                            onClick={() => loadAllDomains(currentPage + 1)}
+                            onClick={() =>
+                              loadAllDomains(currentPage + 1, searchFilter)
+                            }
                             disabled={
                               currentPage === totalPages || loadingDomains
                             }
@@ -1568,7 +1562,9 @@ export const DnsLookupPage: React.FC = () => {
                           </button>
                           <button
                             className="dns-lookup__pagination-button"
-                            onClick={() => loadAllDomains(totalPages)}
+                            onClick={() =>
+                              loadAllDomains(totalPages, searchFilter)
+                            }
                             disabled={
                               currentPage === totalPages || loadingDomains
                             }

--- a/apps/frontend/src/test/dns-lookup-search.test.tsx
+++ b/apps/frontend/src/test/dns-lookup-search.test.tsx
@@ -1,0 +1,118 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import DnsLookupPage from "../pages/DnsLookupPage";
+
+const { apiFetchMock, pushToastMock, technitiumStateMock } = vi.hoisted(() => ({
+  apiFetchMock: vi.fn(),
+  pushToastMock: vi.fn(),
+  technitiumStateMock: {
+    nodes: [
+      {
+        id: "node1",
+        name: "Node 1",
+        baseUrl: "https://node1.test",
+        isPrimary: false,
+      },
+    ],
+  },
+}));
+
+vi.mock("../config", () => ({
+  apiFetch: apiFetchMock,
+}));
+
+vi.mock("../context/useToast", () => ({
+  useToast: () => ({ pushToast: pushToastMock }),
+}));
+
+vi.mock("../context/useTechnitiumState", () => ({
+  useTechnitiumState: () => technitiumStateMock,
+}));
+
+describe("DnsLookupPage All Domains search", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+
+    apiFetchMock.mockImplementation((path: string) => {
+      if (path === "/advanced-blocking/node1") {
+        return Promise.resolve(
+          new Response(JSON.stringify({ config: { groups: [] } }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+
+      if (path.startsWith("/domain-lists/node1/all-domains?")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              domains: [],
+              lastRefreshed: null,
+              pagination: {
+                page: 1,
+                limit: 1000,
+                total: 100001,
+                totalPages: 101,
+              },
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
+        );
+      }
+
+      return Promise.resolve(
+        new Response(JSON.stringify({}), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("requests only the settled search value after the debounce", async () => {
+    render(<DnsLookupPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "All Domains" }));
+    await act(async () => {
+      vi.advanceTimersByTime(750);
+      await Promise.resolve();
+    });
+    apiFetchMock.mockClear();
+
+    const input = screen.getByPlaceholderText("Search domains...");
+    fireEvent.change(input, { target: { value: "npm" } });
+    fireEvent.change(input, { target: { value: "npm-cache" } });
+    fireEvent.change(input, { target: { value: "npm-cache.com" } });
+
+    const allDomainRequests = () =>
+      apiFetchMock.mock.calls
+        .map(([path]) => path as string)
+        .filter((path) => path.startsWith("/domain-lists/node1/all-domains?"));
+
+    expect(allDomainRequests()).toHaveLength(0);
+
+    await act(async () => {
+      vi.advanceTimersByTime(749);
+      await Promise.resolve();
+    });
+    expect(allDomainRequests()).toHaveLength(0);
+
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+      await Promise.resolve();
+    });
+
+    expect(allDomainRequests()).toEqual([
+      "/domain-lists/node1/all-domains?search=npm-cache.com&searchMode=text&page=1&limit=1000",
+    ]);
+  });
+});

--- a/apps/frontend/src/test/domain-group-bindings.test.ts
+++ b/apps/frontend/src/test/domain-group-bindings.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import type { DomainGroupBindingSummary } from "../types/domainGroups";
+import { planDomainGroupBindings } from "../utils/domain-group-bindings";
+
+const binding = (
+  overrides: Partial<DomainGroupBindingSummary>,
+): DomainGroupBindingSummary => ({
+  bindingId: "binding-1",
+  domainGroupId: "domain-group-1",
+  domainGroupName: "Streaming",
+  advancedBlockingGroupName: "Family",
+  action: "block",
+  ...overrides,
+});
+
+describe("Domain Group binding plans", () => {
+  it("adds a new Domain Group binding to every target group", () => {
+    expect(
+      planDomainGroupBindings(
+        [],
+        "domain-group-1",
+        ["Family", "Guests"],
+        "block",
+      ),
+    ).toEqual({
+      bindingIdsToDelete: [],
+      groupNamesToAdd: ["Family", "Guests"],
+      targetGroupNames: ["Family", "Guests"],
+    });
+  });
+
+  it("preserves matching bindings and only adds missing groups", () => {
+    expect(
+      planDomainGroupBindings(
+        [binding({})],
+        "domain-group-1",
+        ["Family", "Guests"],
+        "block",
+      ),
+    ).toEqual({
+      bindingIdsToDelete: [],
+      groupNamesToAdd: ["Guests"],
+      targetGroupNames: ["Family", "Guests"],
+    });
+  });
+
+  it("replaces opposite bindings before adding the requested action", () => {
+    expect(
+      planDomainGroupBindings(
+        [binding({ bindingId: "allow-binding", action: "allow" })],
+        "domain-group-1",
+        ["Family"],
+        "block",
+      ),
+    ).toEqual({
+      bindingIdsToDelete: ["allow-binding"],
+      groupNamesToAdd: ["Family"],
+      targetGroupNames: ["Family"],
+    });
+  });
+
+  it("matches group names case-insensitively and ignores other Domain Groups", () => {
+    expect(
+      planDomainGroupBindings(
+        [
+          binding({ advancedBlockingGroupName: "family" }),
+          binding({
+            bindingId: "other-domain-group-binding",
+            domainGroupId: "domain-group-2",
+            advancedBlockingGroupName: "Guests",
+          }),
+        ],
+        "domain-group-1",
+        ["Family", "Guests", "family"],
+        "block",
+      ),
+    ).toEqual({
+      bindingIdsToDelete: [],
+      groupNamesToAdd: ["Guests"],
+      targetGroupNames: ["Family", "Guests"],
+    });
+  });
+});

--- a/apps/frontend/src/utils/domain-group-bindings.ts
+++ b/apps/frontend/src/utils/domain-group-bindings.ts
@@ -1,0 +1,58 @@
+import type {
+  DomainGroupBindingAction,
+  DomainGroupBindingSummary,
+} from "../types/domainGroups";
+
+export interface DomainGroupBindingPlan {
+  bindingIdsToDelete: string[];
+  groupNamesToAdd: string[];
+  targetGroupNames: string[];
+}
+
+export function planDomainGroupBindings(
+  bindings: DomainGroupBindingSummary[],
+  domainGroupId: string,
+  targetGroupNames: string[],
+  action: DomainGroupBindingAction,
+): DomainGroupBindingPlan {
+  const uniqueTargets = new Map<string, string>();
+  for (const groupName of targetGroupNames) {
+    const normalizedName = groupName.trim();
+    if (
+      normalizedName &&
+      !uniqueTargets.has(normalizedName.toLowerCase())
+    ) {
+      uniqueTargets.set(normalizedName.toLowerCase(), normalizedName);
+    }
+  }
+
+  const bindingIdsToDelete: string[] = [];
+  const groupNamesToAdd: string[] = [];
+
+  for (const [targetNameLower, targetName] of uniqueTargets) {
+    const targetBindings = bindings.filter(
+      (binding) =>
+        binding.domainGroupId === domainGroupId &&
+        binding.advancedBlockingGroupName.toLowerCase() === targetNameLower,
+    );
+
+    const hasRequestedBinding = targetBindings.some(
+      (binding) => binding.action === action,
+    );
+    bindingIdsToDelete.push(
+      ...targetBindings
+        .filter((binding) => binding.action !== action)
+        .map((binding) => binding.bindingId),
+    );
+
+    if (!hasRequestedBinding) {
+      groupNamesToAdd.push(targetName);
+    }
+  }
+
+  return {
+    bindingIdsToDelete,
+    groupNamesToAdd,
+    targetGroupNames: [...uniqueTargets.values()],
+  };
+}

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -223,8 +223,14 @@ export default defineConfig({
             },
           },
           {
-            // API calls: Network-first (no timeout fallback).
-            urlPattern: /^https?:\/\/.*\/api\/.*/i,
+            // API calls: Network-first (no timeout fallback). Live typeahead
+            // endpoints bypass the service worker so AbortController can cancel
+            // superseded searches instead of leaving Workbox fetches running.
+            urlPattern: ({ url }) =>
+              url.pathname.startsWith("/api/") &&
+              !/^\/api\/domain-lists\/[^/]+\/(?:all-domains|check)$/i.test(
+                url.pathname,
+              ),
             handler: "NetworkFirst",
             options: {
               cacheName: "api-cache",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "technitium-dns-companion",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "technitium-dns-companion",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "license": "MIT",
       "workspaces": [
         "apps/backend",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "technitium-dns-companion",
   "private": true,
-  "version": "1.10.0",
+  "version": "1.10.1",
   "license": "MIT",
   "workspaces": [
     "apps/backend",


### PR DESCRIPTION
## Summary

- release v1.10.1 with two focused DNS Filtering reliability fixes
- make Domain Group drops on **All Groups** create the selected allow/block binding across every Advanced Blocking group
- debounce and cancel superseded DNS Lookup typeahead requests while preserving search terms during pagination
- bypass service-worker interception for live domain-search endpoints so browser cancellation reaches the network
- bump the root package and lockfile version and add canonical changelog notes

## Root cause

The **All Groups** drop path only handled ordinary domain payloads; Domain Group payloads were accepted visually but then fell through to an empty `text/plain` value and returned without feedback. DNS Lookup also used short independent debounces while Workbox continued handling the live endpoints, allowing obsolete requests to remain active.

## User impact

Domain Groups can now be bound to all Advanced Blocking groups in one drop, with duplicate/opposite-binding handling and visible success, no-op, or error feedback. DNS Lookup waits for settled input and avoids request storms during typing.

## Validation

- `npm run lint`
- `npm test` — 409 backend and 768 frontend tests passed
- `npm run build`
- version consistency check across `package.json` and `package-lock.json`
- `git diff --check`
- repository pre-push test hook
