### PR TITLE
feat: add hardened trusted-header SSO beta

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@
 ### Minimal working configuration - only 2 variables per node for clusters! ###
 
 ## Docker Compose runtime options - OPTIONAL
+# Use :beta to opt into the rolling soak-test channel. Pin a sha-* tag to
+# reproduce or roll back an exact beta build. The Compose default is :latest.
+# COMPANION_IMAGE=ghcr.io/fail-safe/technitium-dns-companion:latest
 # COMPANION_HTTP_BIND=0.0.0.0
 # COMPANION_HTTP_PORT=3000
 # COMPANION_HTTPS_BIND=0.0.0.0
@@ -67,6 +70,8 @@ TECHNITIUM_NODE2_NAME="DNS Secondary"
 #
 #  Supported variables:
 #    TECHNITIUM_BACKGROUND_TOKEN_FILE  -> reads TECHNITIUM_BACKGROUND_TOKEN from file
+#    TECHNITIUM_SCHEDULE_TOKEN_FILE    -> reads TECHNITIUM_SCHEDULE_TOKEN from file
+#    TRUSTED_SSO_PROXY_SECRET_FILE     -> reads TRUSTED_SSO_PROXY_SECRET from file
 #    TECHNITIUM_<NODE>_TOKEN_FILE      -> reads per-node token from file
 #
 #  Example (Docker Swarm):
@@ -126,6 +131,25 @@ TECHNITIUM_NODE2_BASE_URL=https://dns-secondary.example.com:53443
 # - Set to 1 for: reverse proxy (nginx/Traefik/Caddy) -> Companion
 # - Set to 2 for: CDN/LB (e.g., Cloudflare) -> reverse proxy -> Companion
 # - Do NOT enable TRUST_PROXY unless you control/trust the proxy chain; otherwise clients can spoof forwarded headers.
+
+## Trusted-header SSO - OPTIONAL
+#
+# Trusted SSO accepts identity only from an authenticating reverse proxy. It
+# preserves Technitium RBAC by mapping every SSO identity to a distinct
+# Technitium username and one cluster-wide API token created on the Primary.
+# See docs/features/TRUSTED_HEADER_SSO.md before enabling this feature.
+#
+# TRUSTED_SSO_ENABLED=false
+# TRUSTED_SSO_IDENTITY_HEADER=X-Forwarded-User
+# TRUSTED_SSO_PROXY_SECRET_HEADER=X-Trusted-Proxy-Secret
+# TRUSTED_SSO_PROXY_SECRET_FILE=/run/secrets/companion_sso_proxy_secret
+# TRUSTED_SSO_TOKEN_MAP_FILE=/data/trusted-sso-token-map.json
+# TRUSTED_SSO_PROXY_CIDRS=172.20.0.0/16,2001:db8:1234::/64
+# TRUSTED_SSO_LOGOUT_URL=https://idp.example.com/application/o/companion/end-session/
+#
+# The proxy secret must contain at least 32 characters. When proxy CIDRs are
+# configured, direct requests from outside those CIDRs retain password login as
+# a break-glass path. Without CIDRs, password login is disabled while SSO is on.
 
 ## Background Token (read-only, for background jobs) - OPTIONAL
 #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: Validate Pull Request
+
+on:
+  pull_request:
+    branches:
+      - main
+      - next
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint frontend
+        run: npm run lint --workspace apps/frontend
+
+      - name: Lint backend without modifying source
+        working-directory: apps/backend
+        run: npx eslint "{src,apps,libs,test}/**/*.ts"
+
+      - name: Run unit tests
+        run: npm test
+
+      - name: Run backend end-to-end tests
+        run: npm run test:e2e --workspace apps/backend
+
+      - name: Build all workspaces
+        run: npm run build

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,7 +25,43 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  quality:
+    name: Test release candidate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint frontend
+        run: npm run lint --workspace apps/frontend
+
+      - name: Lint backend without modifying source
+        working-directory: apps/backend
+        run: npx eslint "{src,apps,libs,test}/**/*.ts"
+
+      - name: Run unit tests
+        run: npm test
+
+      - name: Run backend end-to-end tests
+        run: npm run test:e2e --workspace apps/backend
+
+      - name: Build all workspaces
+        run: npm run build
+
   build-and-push:
+    needs: quality
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -75,9 +111,10 @@ jobs:
             type=raw,value=next,enable=${{ github.ref == 'refs/heads/next' }}
             type=raw,value=beta,enable=${{ github.ref == 'refs/heads/next' }}
             type=raw,value=${{ steps.package-version.outputs.version }}-beta,enable=${{ github.ref == 'refs/heads/next' }}
-            # Manual runs: stable name + sha tag (safe for optional pushing)
-            type=raw,value=manual,enable=${{ github.event_name == 'workflow_dispatch' }}
-            type=sha,enable=${{ github.event_name == 'workflow_dispatch' }}
+            # Every published branch/tag image also gets an immutable source-revision tag.
+            type=sha,enable=${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
+            # Manual runs from non-channel refs retain a discoverable rolling alias.
+            type=raw,value=manual,enable=${{ github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/next' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v7

--- a/.github/workflows/sync-next-from-main.yml
+++ b/.github/workflows/sync-next-from-main.yml
@@ -25,6 +25,7 @@ jobs:
     name: Merge main into next
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
 
     steps:
@@ -64,3 +65,11 @@ jobs:
       - name: Push updated next
         if: steps.check.outputs.needs_merge == 'true'
         run: git push origin next
+
+      # Pushes made with GITHUB_TOKEN do not trigger other workflows. Dispatch
+      # the beta publisher explicitly so next and :beta cannot silently drift.
+      - name: Publish the reconciled next beta
+        if: steps.check.outputs.needs_merge == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run docker-publish.yml --ref next -f push_image=true

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ ehthumbs.db
 
 # Local development files
 .dev-data/
+.sso-test/
 scripts/remote-dev.sh
 scripts/reset-dev-node-modules.sh
 NEXT_STEPS.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Hardened trusted-header SSO.** An authenticating reverse proxy can establish identity-bound Companion sessions using a constant-time-verified proxy secret, optional immediate-peer IPv4/IPv6 CIDRs, and exact per-user Technitium cluster API-token mappings. The feature preserves Technitium RBAC and audit attribution, validates the replicated token owner on every reachable node, fails closed on malformed proxy assertions, supports direct-network break-glass login, and provides deliberate local or IdP logout behavior.
+
+### Security
+
+- Trusted-SSO sessions are re-bound to the same proxy assertion on every API request; missing or changed identities invalidate the local session before protected work. Identity headers and `X-Forwarded-Proto` alone cannot authenticate, mapped credentials are never returned to the browser, and operator-managed SSO tokens are not revoked by local logout.
+- Trusted-SSO session creation is bounded to eight active sessions per mapped identity, preventing a valid user from growing the in-memory session store without limit while preserving multi-device access.
+
+### Changed
+
+- Docker Compose accepts `COMPANION_IMAGE` so operators can opt into `:beta` or pin an immutable `sha-<commit>` build without editing the maintained Compose file. Published images expose their source revision in OCI metadata and the About dialog.
+- The Docker publisher now runs lint, unit tests, backend E2E tests, and the full build before pushing an image. Every published branch or release image receives an immutable source-revision tag.
+
+### Fixed
+
+- Release reconciliation now explicitly republishes the updated `next` branch, preventing GitHub's workflow-token fan-out suppression from leaving the rolling `:beta` image behind the branch.
+
+### Testing
+
+- Added regression coverage for trusted-SSO per-identity session bounds and isolation from password or other-user sessions.
+
+### Documentation
+
+- Added token-map creation and rotation guidance plus nginx, Caddy, and Traefik examples that remove client assertions and inject authenticated identity and the proxy secret only after forward authentication. Shared-account SSO is explicitly unsupported because it would collapse Technitium's per-user authorization boundary.
+
 ## [1.10.1] - 2026-08-13
 
 ### Fixed

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -162,6 +162,35 @@ Compose also limits the service's local `json-file` logs to three 10 MB files
 by default. Use `COMPANION_LOG_MAX_SIZE` and `COMPANION_LOG_MAX_FILES` in
 `.env` to tune those limits.
 
+### Opt into the beta channel
+
+Set the image override in `.env`:
+
+```bash
+COMPANION_IMAGE=ghcr.io/fail-safe/technitium-dns-companion:beta
+```
+
+Then pull and recreate the service:
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+The `beta` and `next` tags move with the `next` branch. Each published build
+also has an immutable `sha-<commit>` tag. Record the revision shown in the
+About dialog or inspect the image labels before reporting a problem:
+
+```bash
+docker image inspect "$COMPANION_IMAGE" \
+  --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}'
+```
+
+To return to stable, change `COMPANION_IMAGE` back to
+`ghcr.io/fail-safe/technitium-dns-companion:latest`, then run the same pull and
+up commands. See the [Beta Testing Guide](docs/BETA_TESTING.md) for exact-build
+pinning and rollback guidance.
+
 ## Troubleshooting
 
 - Container will not start: `docker compose logs` then `docker compose config` to validate env vars.

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ COPY apps/frontend/package.json ./apps/frontend/
 # Stage 1: Build frontend
 FROM --platform=$BUILDPLATFORM node:24-alpine3.22 AS frontend-builder
 ARG BUILDPLATFORM
+ARG BUILD_REVISION=unknown
 ARG NPM_VERSION
 
 WORKDIR /app
@@ -38,7 +39,7 @@ RUN --mount=type=cache,target=/root/.npm \
 COPY apps/frontend/ ./apps/frontend/
 
 # Build frontend
-RUN npm run build --workspace=apps/frontend
+RUN BUILD_REVISION="$BUILD_REVISION" npm run build --workspace=apps/frontend
 
 # Stage 2: Build backend
 FROM --platform=$BUILDPLATFORM node:24-alpine3.22 AS backend-builder

--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ Docs: [docs/features/SESSION_AUTH_AND_TOKEN_MIGRATION.md](docs/features/SESSION_
 | `1.6`, `1.6.9` | Pinned version tags |
 | `beta` | Pre-release from the `next` branch — may include features not yet in stable |
 | `next` | Rolling `next` branch head (same image as `beta`, dev-facing alias) |
+| `sha-<commit>` | Immutable build for reproducing a beta result or rollback |
+
+Want to help soak-test upcoming changes? See the opt-in [Beta Testing
+Guide](docs/BETA_TESTING.md) for install, verification, reporting, and rollback
+steps. Beta is never selected unless you explicitly choose it.
 
 The fastest path is the download-and-run script (no repo clone required). For full options and HTTPS details, see [DOCKER.md](DOCKER.md).
 

--- a/apps/backend/src/auth/auth-request-context.ts
+++ b/apps/backend/src/auth/auth-request-context.ts
@@ -1,8 +1,12 @@
 import { AsyncLocalStorage } from "node:async_hooks";
-import type { AuthSession } from "./auth.types";
+import type {
+  AuthSession,
+  TrustedSsoRequestClassification,
+} from "./auth.types";
 
 interface AuthRequestContextState {
   session?: AuthSession;
+  trustedSsoRequest?: TrustedSsoRequestClassification;
 }
 
 const storage = new AsyncLocalStorage<AuthRequestContextState>();
@@ -23,5 +27,9 @@ export const AuthRequestContext = {
     }
 
     store.session = session;
+  },
+
+  getTrustedSsoRequest(): TrustedSsoRequestClassification | undefined {
+    return storage.getStore()?.trustedSsoRequest;
   },
 };

--- a/apps/backend/src/auth/auth-session.service.spec.ts
+++ b/apps/backend/src/auth/auth-session.service.spec.ts
@@ -28,6 +28,8 @@ describe("AuthSessionService — create + get + delete (baseline)", () => {
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
     );
     expect(session.user).toBe("alice");
+    expect(session.authSource).toBe("password");
+    expect(session.technitiumUser).toBe("alice");
     expect(session.tokensByNodeId).toEqual({ node1: "tok-1" });
     expect(session.nodeAuthStatesByNodeId).toEqual({
       node1: { status: "authenticated" },
@@ -63,6 +65,62 @@ describe("AuthSessionService — create + get + delete (baseline)", () => {
     const fetched = service.get(session.id);
     expect(fetched).toBeDefined();
     expect(fetched!.lastSeenAt).toBeGreaterThan(created);
+    service.onModuleDestroy();
+  });
+
+  it("bounds one auth source for one user without evicting other sessions", () => {
+    const service = new AuthSessionService();
+    const oldestSsoSession = service.create(
+      "alice@example.test",
+      {},
+      undefined,
+      {
+        authSource: "trusted-sso",
+        technitiumUser: "alice",
+        maxSessionsForUser: 2,
+      },
+    );
+    const passwordSession = service.create("alice@example.test", {});
+    const otherSsoSession = service.create("bob@example.test", {}, undefined, {
+      authSource: "trusted-sso",
+      technitiumUser: "bob",
+      maxSessionsForUser: 2,
+    });
+    const retainedSsoSession = service.create(
+      "alice@example.test",
+      {},
+      undefined,
+      {
+        authSource: "trusted-sso",
+        technitiumUser: "alice",
+        maxSessionsForUser: 2,
+      },
+    );
+    const newestSsoSession = service.create(
+      "alice@example.test",
+      {},
+      undefined,
+      {
+        authSource: "trusted-sso",
+        technitiumUser: "alice",
+        maxSessionsForUser: 2,
+      },
+    );
+
+    expect(service.get(oldestSsoSession.id)).toBeUndefined();
+    expect(service.get(retainedSsoSession.id)).toBe(retainedSsoSession);
+    expect(service.get(newestSsoSession.id)).toBe(newestSsoSession);
+    expect(service.get(passwordSession.id)).toBe(passwordSession);
+    expect(service.get(otherSsoSession.id)).toBe(otherSsoSession);
+    expect(service.count()).toBe(4);
+    service.onModuleDestroy();
+  });
+
+  it("rejects invalid per-user session limits", () => {
+    const service = new AuthSessionService();
+    expect(() =>
+      service.create("alice", {}, undefined, { maxSessionsForUser: 0 }),
+    ).toThrow("maxSessionsForUser must be a positive integer");
     service.onModuleDestroy();
   });
 });

--- a/apps/backend/src/auth/auth-session.service.ts
+++ b/apps/backend/src/auth/auth-session.service.ts
@@ -49,12 +49,27 @@ export class AuthSessionService implements OnModuleDestroy {
     user: string,
     tokensByNodeId: Record<string, string>,
     nodeAuthStatesByNodeId?: Record<string, AuthNodeSessionState>,
+    options?: {
+      authSource?: AuthSession["authSource"];
+      technitiumUser?: string;
+      maxSessionsForUser?: number;
+    },
   ): AuthSession {
+    if (options?.maxSessionsForUser !== undefined) {
+      this.evictOldestMatchingSessions(
+        user,
+        options.authSource ?? "password",
+        options.maxSessionsForUser,
+      );
+    }
+
     const id = randomUUID();
     const now = Date.now();
     const session: AuthSession = {
       id,
       user,
+      authSource: options?.authSource ?? "password",
+      technitiumUser: options?.technitiumUser ?? user,
       createdAt: new Date(now).toISOString(),
       lastSeenAt: now,
       tokensByNodeId,
@@ -63,6 +78,27 @@ export class AuthSessionService implements OnModuleDestroy {
 
     this.sessions.set(id, session);
     return session;
+  }
+
+  private evictOldestMatchingSessions(
+    user: string,
+    authSource: AuthSession["authSource"],
+    maxSessions: number,
+  ): void {
+    if (!Number.isInteger(maxSessions) || maxSessions < 1) {
+      throw new Error("maxSessionsForUser must be a positive integer");
+    }
+
+    this.sweepExpired();
+    const matchingSessionIds: string[] = [];
+    for (const [id, session] of this.sessions) {
+      if (session.user === user && session.authSource === authSource) {
+        matchingSessionIds.push(id);
+      }
+    }
+    while (matchingSessionIds.length >= maxSessions) {
+      this.sessions.delete(matchingSessionIds.shift()!);
+    }
   }
 
   get(sessionId: string): AuthSession | undefined {

--- a/apps/backend/src/auth/auth.controller.me.spec.ts
+++ b/apps/backend/src/auth/auth.controller.me.spec.ts
@@ -4,6 +4,7 @@ import { AuthRequestContext } from "./auth-request-context";
 import { AuthController } from "./auth.controller";
 import { AuthService } from "./auth.service";
 import type { AuthSession } from "./auth.types";
+import { TrustedSsoService } from "./trusted-sso.service";
 
 describe("AuthController /auth/me", () => {
   beforeEach(() => {
@@ -12,6 +13,13 @@ describe("AuthController /auth/me", () => {
 
   async function createController(getBackgroundSummaryImpl?: jest.Mock) {
     const authServiceMock: Partial<AuthService> = {};
+    const trustedSsoServiceMock: Partial<TrustedSsoService> = {
+      getStatus: jest.fn().mockReturnValue({
+        enabled: false,
+        available: false,
+        manualLoginAllowed: true,
+      }),
+    };
 
     const getBackgroundPtrTokenValidationSummaryMock =
       getBackgroundSummaryImpl ??
@@ -32,6 +40,7 @@ describe("AuthController /auth/me", () => {
       providers: [
         { provide: AuthService, useValue: authServiceMock },
         { provide: TechnitiumService, useValue: technitiumServiceMock },
+        { provide: TrustedSsoService, useValue: trustedSsoServiceMock },
       ],
     }).compile();
 
@@ -68,6 +77,11 @@ describe("AuthController /auth/me", () => {
       sessionAuthEnabled: true,
       authenticated: false,
       configuredNodeIds: ["nodeA", "nodeB"],
+      trustedSso: {
+        enabled: false,
+        available: false,
+        manualLoginAllowed: true,
+      },
       backgroundPtrToken,
     });
 
@@ -82,6 +96,8 @@ describe("AuthController /auth/me", () => {
       createdAt: new Date().toISOString(),
       lastSeenAt: Date.now(),
       user: "alice",
+      authSource: "password",
+      technitiumUser: "alice",
       tokensByNodeId: { nodeA: "t1", nodeB: "t2" },
     };
 
@@ -90,6 +106,8 @@ describe("AuthController /auth/me", () => {
     expect(res.authenticated).toBe(true);
     expect(res.sessionAuthEnabled).toBe(true);
     expect(res.user).toBe("alice");
+    expect(res.authSource).toBe("password");
+    expect(res.technitiumUser).toBe("alice");
     expect(res.nodeIds?.sort()).toEqual(["nodeA", "nodeB"]);
     expect(res.unreachableNodeIds).toEqual([]);
     expect(res.failedNodeIds).toEqual([]);
@@ -105,6 +123,8 @@ describe("AuthController /auth/me", () => {
       createdAt: new Date().toISOString(),
       lastSeenAt: Date.now(),
       user: "alice",
+      authSource: "password",
+      technitiumUser: "alice",
       tokensByNodeId: { nodeB: "t2" },
       nodeAuthStatesByNodeId: {
         nodeA: { status: "unreachable", error: "timeout" },

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -13,12 +13,14 @@ import { AuthRequestContext } from "./auth-request-context";
 import { AuthService } from "./auth.service";
 import type { AuthLoginRequestDto, AuthMeResponseDto } from "./auth.types";
 import { Public } from "./public.decorator";
+import { TrustedSsoService } from "./trusted-sso.service";
 
 @Controller("auth")
 export class AuthController {
   constructor(
     private readonly authService: AuthService,
     private readonly technitiumService: TechnitiumService,
+    private readonly trustedSsoService: TrustedSsoService,
   ) {}
 
   @Public()
@@ -51,12 +53,14 @@ export class AuthController {
       this.technitiumService.getBackgroundPtrTokenValidationSummary();
 
     const configuredNodeIds = this.technitiumService.getConfiguredNodeIds();
+    const trustedSso = this.trustedSsoService.getStatus(req);
 
     if (!session) {
       return {
         sessionAuthEnabled,
         authenticated: false,
         configuredNodeIds,
+        trustedSso,
         ...(transport ? { transport } : {}),
         backgroundPtrToken,
       };
@@ -74,10 +78,13 @@ export class AuthController {
       sessionAuthEnabled,
       authenticated: true,
       user: session.user,
+      authSource: session.authSource,
+      technitiumUser: session.technitiumUser,
       nodeIds: Object.keys(session.tokensByNodeId),
       unreachableNodeIds,
       failedNodeIds,
       configuredNodeIds,
+      trustedSso,
       ...(transport ? { transport } : {}),
       backgroundPtrToken,
     };
@@ -95,6 +102,7 @@ export class AuthController {
         "Session authentication requires HTTPS (direct HTTPS or a TLS-terminating reverse proxy with TRUST_PROXY=true).",
       );
     }
+    this.trustedSsoService.assertPasswordLoginAllowed(req);
 
     const { session, response } = await this.authService.login(body);
 
@@ -104,6 +112,23 @@ export class AuthController {
       this.authService.cookieOptions(req.secure),
     );
 
+    return response;
+  }
+
+  @Public()
+  @Post("sso/login")
+  async ssoLogin(
+    @Req() req: Request,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const { session, response } =
+      await this.trustedSsoService.loginForRequest(req);
+
+    res.cookie(
+      this.authService.cookieName(),
+      session.id,
+      this.authService.cookieOptions(req.secure),
+    );
     return response;
   }
 

--- a/apps/backend/src/auth/auth.middleware.spec.ts
+++ b/apps/backend/src/auth/auth.middleware.spec.ts
@@ -1,0 +1,90 @@
+import type { Request, Response } from "express";
+import { AuthRequestContext } from "./auth-request-context";
+import { AuthSessionService } from "./auth-session.service";
+import { AUTH_SESSION_COOKIE_NAME } from "./auth.constants";
+import { AuthRequestContextMiddleware } from "./auth.middleware";
+import { TrustedSsoService } from "./trusted-sso.service";
+
+describe("AuthRequestContextMiddleware trusted SSO binding", () => {
+  let sessions: AuthSessionService;
+
+  beforeEach(() => {
+    sessions = new AuthSessionService();
+  });
+
+  afterEach(() => sessions.onModuleDestroy());
+
+  function runWithClassification(
+    classification: ReturnType<TrustedSsoService["classify"]>,
+    sessionId: string,
+  ) {
+    const trustedSso = {
+      classify: jest.fn().mockReturnValue(classification),
+    } as unknown as TrustedSsoService;
+    const middleware = new AuthRequestContextMiddleware(sessions, trustedSso);
+    const req = {
+      cookies: { [AUTH_SESSION_COOKIE_NAME]: sessionId },
+    } as unknown as Request;
+    const clearCookie = jest.fn();
+    const res = { clearCookie } as unknown as Response;
+    let contextSession = "not-run" as unknown;
+
+    middleware.use(req, res, () => {
+      contextSession = AuthRequestContext.getSession();
+    });
+    return { clearCookie, contextSession };
+  }
+
+  it("keeps a trusted SSO session only for the same valid assertion", () => {
+    const session = sessions.create(
+      "alice@example.test",
+      { nodeA: "token" },
+      undefined,
+      { authSource: "trusted-sso", technitiumUser: "alice" },
+    );
+    const result = runWithClassification(
+      { kind: "valid", identity: "alice@example.test" },
+      session.id,
+    );
+    expect(result.contextSession).toBe(session);
+    expect(result.clearCookie).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      "missing assertion",
+      { kind: "invalid", error: "invalid-proxy-assertion" },
+    ],
+    ["direct request", { kind: "direct" }],
+    ["identity switch", { kind: "valid", identity: "bob@example.test" }],
+  ] as const)(
+    "clears the cookie and local session on %s",
+    (_label, classification) => {
+      const session = sessions.create(
+        "alice@example.test",
+        { nodeA: "token" },
+        undefined,
+        { authSource: "trusted-sso", technitiumUser: "alice" },
+      );
+      const result = runWithClassification(classification, session.id);
+      expect(result.contextSession).toBeUndefined();
+      expect(sessions.get(session.id)).toBeUndefined();
+      expect(result.clearCookie).toHaveBeenCalledWith(
+        AUTH_SESSION_COOKIE_NAME,
+        {
+          path: "/",
+        },
+      );
+    },
+  );
+
+  it("does not bind password sessions to an SSO assertion", () => {
+    const session = sessions.create("alice", { nodeA: "token" });
+    const result = runWithClassification(
+      { kind: "invalid", error: "invalid-proxy-assertion" },
+      session.id,
+    );
+    expect(result.contextSession).toBe(session);
+    expect(result.clearCookie).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/auth/auth.middleware.ts
+++ b/apps/backend/src/auth/auth.middleware.ts
@@ -4,12 +4,16 @@ import type { NextFunction, Request, Response } from "express";
 import { AuthRequestContext } from "./auth-request-context";
 import { AuthSessionService } from "./auth-session.service";
 import { AUTH_SESSION_COOKIE_NAME } from "./auth.constants";
+import { TrustedSsoService } from "./trusted-sso.service";
 
 @Injectable()
 export class AuthRequestContextMiddleware implements NestMiddleware {
-  constructor(private readonly sessionService: AuthSessionService) {}
+  constructor(
+    private readonly sessionService: AuthSessionService,
+    private readonly trustedSsoService: TrustedSsoService,
+  ) {}
 
-  use(req: Request, _res: Response, next: NextFunction): void {
+  use(req: Request, res: Response, next: NextFunction): void {
     const cookiesValue: unknown = (req as unknown as { cookies?: unknown })
       .cookies;
     const sessionId =
@@ -19,10 +23,21 @@ export class AuthRequestContextMiddleware implements NestMiddleware {
 
     const resolvedSessionId =
       typeof sessionId === "string" ? sessionId : undefined;
-    const session = resolvedSessionId
+    let session = resolvedSessionId
       ? this.sessionService.get(resolvedSessionId)
       : undefined;
+    const trustedSsoRequest = this.trustedSsoService.classify(req);
 
-    AuthRequestContext.run({ session }, () => next());
+    if (
+      session?.authSource === "trusted-sso" &&
+      (trustedSsoRequest.kind !== "valid" ||
+        trustedSsoRequest.identity !== session.user)
+    ) {
+      this.sessionService.delete(session.id);
+      session = undefined;
+      res.clearCookie(AUTH_SESSION_COOKIE_NAME, { path: "/" });
+    }
+
+    AuthRequestContext.run({ session, trustedSsoRequest }, () => next());
   }
 }

--- a/apps/backend/src/auth/auth.module.ts
+++ b/apps/backend/src/auth/auth.module.ts
@@ -4,11 +4,21 @@ import { AuthSessionService } from "./auth-session.service";
 import { AuthController } from "./auth.controller";
 import { AuthRequestContextMiddleware } from "./auth.middleware";
 import { AuthService } from "./auth.service";
+import { TrustedSsoService } from "./trusted-sso.service";
 
 @Module({
   imports: [TechnitiumModule],
   controllers: [AuthController],
-  providers: [AuthService, AuthSessionService, AuthRequestContextMiddleware],
-  exports: [AuthSessionService, AuthRequestContextMiddleware],
+  providers: [
+    AuthService,
+    AuthSessionService,
+    TrustedSsoService,
+    AuthRequestContextMiddleware,
+  ],
+  exports: [
+    AuthSessionService,
+    TrustedSsoService,
+    AuthRequestContextMiddleware,
+  ],
 })
 export class AuthModule {}

--- a/apps/backend/src/auth/auth.service.spec.ts
+++ b/apps/backend/src/auth/auth.service.spec.ts
@@ -214,4 +214,32 @@ describe("AuthService.login", () => {
       service.login({ username: "alice", password: "pw" }),
     ).rejects.toBeInstanceOf(UnauthorizedException);
   });
+
+  it("revokes password tokens but only deletes local trusted-SSO sessions", async () => {
+    const { service, sessionService, axiosMock } = createService([
+      { id: "nodeA", baseUrl: "https://n1" },
+    ]);
+    axiosMock.get.mockResolvedValue({ data: { status: "ok" } });
+
+    const passwordSession = sessionService.create("alice", {
+      nodeA: "password-token",
+    });
+    await service.logout(passwordSession);
+    expect(axiosMock.get).toHaveBeenCalledWith(
+      "https://n1/api/user/logout",
+      expect.objectContaining({ params: { token: "password-token" } }),
+    );
+
+    axiosMock.get.mockClear();
+    const ssoSession = sessionService.create(
+      "alice@example.test",
+      { nodeA: "operator-token" },
+      undefined,
+      { authSource: "trusted-sso", technitiumUser: "alice" },
+    );
+    await service.logout(ssoSession);
+    expect(axiosMock.get).not.toHaveBeenCalled();
+    expect(sessionService.get(ssoSession.id)).toBeUndefined();
+    sessionService.onModuleDestroy();
+  });
 });

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -331,6 +331,7 @@ export class AuthService {
       username,
       tokensByNodeId,
       nodeAuthStatesByNodeId,
+      { authSource: "password", technitiumUser: username },
     );
 
     return { session, response: { authenticated: true, nodes: results } };
@@ -341,26 +342,30 @@ export class AuthService {
       return;
     }
 
-    // Best-effort logout at Technitium nodes (invalidates the tokens)
-    for (const node of this.nodeConfigs) {
-      const token = session.tokensByNodeId[node.id];
-      if (!token) {
-        continue;
-      }
+    if (session.authSource === "password") {
+      // Password-login tokens are ephemeral Technitium sessions and should be
+      // revoked upstream. Trusted-SSO tokens are operator-managed mappings and
+      // must survive a local Companion logout.
+      for (const node of this.nodeConfigs) {
+        const token = session.tokensByNodeId[node.id];
+        if (!token) {
+          continue;
+        }
 
-      try {
-        await axios.get(`${node.baseUrl}/api/user/logout`, {
-          params: { token },
-          headers: { Authorization: `Bearer ${token}` },
-          timeout: 15_000,
-          httpsAgent: this.httpsAgent,
-        });
-      } catch (error) {
-        const message =
-          error instanceof Error ? error.message : "Unknown error";
-        this.logger.debug(
-          `Logout failed for node ${node.id} (ignored): ${message}`,
-        );
+        try {
+          await axios.get(`${node.baseUrl}/api/user/logout`, {
+            params: { token },
+            headers: { Authorization: `Bearer ${token}` },
+            timeout: 15_000,
+            httpsAgent: this.httpsAgent,
+          });
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : "Unknown error";
+          this.logger.debug(
+            `Logout failed for node ${node.id} (ignored): ${message}`,
+          );
+        }
       }
     }
 

--- a/apps/backend/src/auth/auth.types.ts
+++ b/apps/backend/src/auth/auth.types.ts
@@ -3,9 +3,28 @@ export interface AuthSession {
   createdAt: string;
   lastSeenAt: number;
   user: string;
+  authSource: "password" | "trusted-sso";
+  technitiumUser: string;
   tokensByNodeId: Record<string, string>;
   nodeAuthStatesByNodeId?: Record<string, AuthNodeSessionState>;
 }
+
+export type TrustedSsoError =
+  | "identity-not-authorized"
+  | "invalid-proxy-assertion";
+
+export interface TrustedSsoStatus {
+  enabled: boolean;
+  available: boolean;
+  manualLoginAllowed: boolean;
+  error?: TrustedSsoError;
+  logoutUrl?: string;
+}
+
+export type TrustedSsoRequestClassification =
+  | { kind: "disabled" | "direct" }
+  | { kind: "invalid"; error: "invalid-proxy-assertion" }
+  | { kind: "valid"; identity: string };
 
 export interface AuthLoginRequestDto {
   username: string;
@@ -50,10 +69,13 @@ export interface AuthMeResponseDto {
   sessionAuthEnabled: boolean;
   authenticated: boolean;
   user?: string;
+  authSource?: AuthSession["authSource"];
+  technitiumUser?: string;
   nodeIds?: string[];
   unreachableNodeIds?: string[];
   failedNodeIds?: string[];
   configuredNodeIds?: string[];
+  trustedSso: TrustedSsoStatus;
   transport?: {
     requestSecure: boolean;
     httpsEnabled: boolean;

--- a/apps/backend/src/auth/trusted-sso.service.spec.ts
+++ b/apps/backend/src/auth/trusted-sso.service.spec.ts
@@ -1,0 +1,378 @@
+import {
+  HttpStatus,
+  ServiceUnavailableException,
+  UnauthorizedException,
+} from "@nestjs/common";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { Request } from "express";
+import { TechnitiumService } from "../technitium/technitium.service";
+import type { TechnitiumNodeConfig } from "../technitium/technitium.types";
+import { AuthSessionService } from "./auth-session.service";
+import { TrustedSsoService } from "./trusted-sso.service";
+
+const ORIGINAL_ENV = { ...process.env };
+const TEST_DIR = join(tmpdir(), `trusted-sso-${process.pid}`);
+const SECRET = "a-secure-test-secret-with-at-least-32-characters";
+
+describe("TrustedSsoService", () => {
+  const sessionServices: AuthSessionService[] = [];
+  let fileIndex = 0;
+
+  beforeAll(() => mkdirSync(TEST_DIR, { recursive: true }));
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.TRUSTED_SSO_ENABLED;
+    delete process.env.TRUSTED_SSO_IDENTITY_HEADER;
+    delete process.env.TRUSTED_SSO_PROXY_SECRET_HEADER;
+    delete process.env.TRUSTED_SSO_PROXY_SECRET;
+    delete process.env.TRUSTED_SSO_PROXY_SECRET_FILE;
+    delete process.env.TRUSTED_SSO_PROXY_CIDRS;
+    delete process.env.TRUSTED_SSO_TOKEN_MAP_FILE;
+    delete process.env.TRUSTED_SSO_LOGOUT_URL;
+  });
+
+  afterEach(() => {
+    for (const service of sessionServices.splice(0)) {
+      service.onModuleDestroy();
+    }
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  const nodes: TechnitiumNodeConfig[] = [
+    {
+      id: "nodeA",
+      name: "nodeA",
+      baseUrl: "https://node-a.example.test",
+      token: "",
+      queryLoggerAppName: undefined,
+      queryLoggerClassPath: undefined,
+    },
+    {
+      id: "nodeB",
+      name: "nodeB",
+      baseUrl: "https://node-b.example.test",
+      token: "",
+      queryLoggerAppName: undefined,
+      queryLoggerClassPath: undefined,
+    },
+  ];
+
+  function writeMap(value?: unknown): string {
+    const path = join(TEST_DIR, `map-${fileIndex++}.json`);
+    writeFileSync(
+      path,
+      JSON.stringify(
+        value ?? {
+          version: 1,
+          identities: {
+            "alice@example.test": {
+              username: "alice",
+              token: "cluster-token",
+            },
+          },
+        },
+      ),
+    );
+    return path;
+  }
+
+  function enable(overrides?: Record<string, string>): void {
+    Object.assign(process.env, {
+      TRUSTED_SSO_ENABLED: "true",
+      TRUSTED_SSO_PROXY_SECRET: SECRET,
+      TRUSTED_SSO_TOKEN_MAP_FILE: writeMap(),
+      ...overrides,
+    });
+  }
+
+  function createService(
+    validate = jest
+      .fn()
+      .mockResolvedValueOnce({ username: "alice" })
+      .mockResolvedValueOnce({ username: "alice" }),
+  ) {
+    const sessions = new AuthSessionService();
+    sessionServices.push(sessions);
+    const technitium = {
+      validateExplicitSessionToken: validate,
+    } as unknown as TechnitiumService;
+    return {
+      service: new TrustedSsoService(nodes, technitium, sessions),
+      sessions,
+      validate,
+    };
+  }
+
+  function makeRequest(args?: {
+    identity?: string;
+    secret?: string;
+    peer?: string;
+    secure?: boolean;
+    duplicateIdentity?: boolean;
+  }): Request {
+    const rawHeaders: string[] = [];
+    if (args?.identity !== undefined) {
+      rawHeaders.push("X-Forwarded-User", args.identity);
+      if (args.duplicateIdentity) {
+        rawHeaders.push("X-Forwarded-User", args.identity);
+      }
+    }
+    if (args?.secret !== undefined) {
+      rawHeaders.push("X-Trusted-Proxy-Secret", args.secret);
+    }
+    return {
+      secure: args?.secure ?? true,
+      rawHeaders,
+      headers: {},
+      socket: { remoteAddress: args?.peer ?? "127.0.0.1" },
+    } as unknown as Request;
+  }
+
+  it("leaves disabled deployments unchanged without requiring SSO files", () => {
+    process.env.TRUSTED_SSO_IDENTITY_HEADER = "not a header";
+    process.env.TRUSTED_SSO_PROXY_SECRET = "too-short";
+    const { service } = createService();
+    expect(service.classify(makeRequest())).toEqual({ kind: "disabled" });
+    expect(service.getStatus(makeRequest())).toEqual({
+      enabled: false,
+      available: false,
+      manualLoginAllowed: true,
+    });
+  });
+
+  it.each([
+    ["short secret", { TRUSTED_SSO_PROXY_SECRET: "too-short" }],
+    ["missing token map", { TRUSTED_SSO_TOKEN_MAP_FILE: "" }],
+    ["invalid boolean", { TRUSTED_SSO_ENABLED: "yes" }],
+    ["invalid CIDR", { TRUSTED_SSO_PROXY_CIDRS: "10.0.0.0/99" }],
+    [
+      "insecure logout URL",
+      { TRUSTED_SSO_LOGOUT_URL: "http://idp.test/logout" },
+    ],
+  ])("rejects %s at startup", (_label, overrides) => {
+    enable(overrides);
+    expect(() => createService()).toThrow();
+  });
+
+  it("requires one cluster token and rejects legacy per-node mappings", () => {
+    enable({
+      TRUSTED_SSO_TOKEN_MAP_FILE: writeMap({
+        version: 1,
+        identities: {
+          "alice@example.test": {
+            username: "alice",
+            tokensByNodeId: { nodeA: "token-a", unknown: "token-x" },
+          },
+        },
+      }),
+    });
+    expect(() => createService()).toThrow(/invalid schema/);
+
+    enable({
+      TRUSTED_SSO_TOKEN_MAP_FILE: writeMap({
+        version: 1,
+        identities: {
+          "alice@example.test": { username: "alice", token: "" },
+        },
+      }),
+    });
+    expect(() => createService()).toThrow(/invalid cluster API token/);
+  });
+
+  it("rejects duplicate JSON keys in the strict token map", () => {
+    const path = join(TEST_DIR, `map-${fileIndex++}.json`);
+    writeFileSync(
+      path,
+      '{"version":1,"version":1,"identities":{"alice@example.test":{"username":"alice","token":"cluster-token"}}}',
+    );
+    enable({ TRUSTED_SSO_TOKEN_MAP_FILE: path });
+    expect(() => createService()).toThrow(/valid JSON/);
+  });
+
+  it("accepts the proxy secret from _FILE without exposing it in errors", () => {
+    const secretFile = join(TEST_DIR, "proxy-secret");
+    writeFileSync(secretFile, SECRET);
+    enable({
+      TRUSTED_SSO_PROXY_SECRET: "",
+      TRUSTED_SSO_PROXY_SECRET_FILE: secretFile,
+    });
+    const { service } = createService();
+    expect(
+      service.classify(
+        makeRequest({ identity: "alice@example.test", secret: SECRET }),
+      ),
+    ).toEqual({ kind: "valid", identity: "alice@example.test" });
+
+    process.env.TRUSTED_SSO_LOGOUT_URL = SECRET;
+    let message = "";
+    try {
+      createService();
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+    expect(message).not.toContain(SECRET);
+  });
+
+  it("validates TLS, CIDRs, one identity header, and the proxy secret", () => {
+    enable({ TRUSTED_SSO_PROXY_CIDRS: "10.20.0.0/16,2001:db8::/32" });
+    const { service } = createService();
+    const valid = {
+      identity: "alice@example.test",
+      secret: SECRET,
+      peer: "10.20.4.8",
+    };
+
+    expect(service.classify(makeRequest(valid))).toEqual({
+      kind: "valid",
+      identity: "alice@example.test",
+    });
+    expect(
+      service.classify(makeRequest({ ...valid, peer: "::ffff:10.20.4.8" })),
+    ).toEqual({ kind: "valid", identity: "alice@example.test" });
+    expect(
+      service.classify(makeRequest({ ...valid, peer: "2001:db8::42" })),
+    ).toEqual({ kind: "valid", identity: "alice@example.test" });
+    expect(
+      service.classify(makeRequest({ ...valid, peer: "192.0.2.10" })),
+    ).toEqual({ kind: "direct" });
+    expect(
+      service.classify(makeRequest({ ...valid, secret: `${SECRET}-wrong` })),
+    ).toMatchObject({ kind: "invalid" });
+    expect(
+      service.classify(makeRequest({ ...valid, secure: false })),
+    ).toMatchObject({ kind: "invalid" });
+    expect(
+      service.classify(makeRequest({ ...valid, duplicateIdentity: true })),
+    ).toMatchObject({ kind: "invalid" });
+    expect(
+      service.classify(makeRequest({ ...valid, identity: " alice " })),
+    ).toMatchObject({ kind: "invalid" });
+  });
+
+  it("matches identities exactly and reports unmapped identities without fallback", () => {
+    enable();
+    const { service } = createService();
+    const req = makeRequest({ identity: "Alice@example.test", secret: SECRET });
+    expect(service.getStatus(req)).toMatchObject({
+      enabled: true,
+      available: false,
+      manualLoginAllowed: false,
+      error: "identity-not-authorized",
+    });
+  });
+
+  it("returns a validated HTTPS or relative logout URL in SSO status", () => {
+    enable({ TRUSTED_SSO_LOGOUT_URL: "/auth/sign-out" });
+    const { service } = createService();
+    expect(
+      service.getStatus(
+        makeRequest({ identity: "alice@example.test", secret: SECRET }),
+      ),
+    ).toMatchObject({
+      available: true,
+      logoutUrl: "/auth/sign-out",
+    });
+  });
+
+  it("allows break-glass password login only outside configured proxy CIDRs", () => {
+    enable({ TRUSTED_SSO_PROXY_CIDRS: "10.20.0.0/16" });
+    const { service } = createService();
+    expect(() =>
+      service.assertPasswordLoginAllowed(makeRequest({ peer: "10.20.1.2" })),
+    ).toThrow();
+    expect(() =>
+      service.assertPasswordLoginAllowed(makeRequest({ peer: "192.0.2.4" })),
+    ).not.toThrow();
+  });
+
+  it("creates an attributed SSO session only after every reachable token owner matches", async () => {
+    enable();
+    const { service, validate } = createService();
+    const result = await service.loginForRequest(
+      makeRequest({ identity: "alice@example.test", secret: SECRET }),
+    );
+    expect(result.session).toMatchObject({
+      user: "alice@example.test",
+      authSource: "trusted-sso",
+      technitiumUser: "alice",
+      tokensByNodeId: { nodeA: "cluster-token", nodeB: "cluster-token" },
+    });
+    expect(result.response.nodes).toEqual([
+      { nodeId: "nodeA", success: true, authState: "authenticated" },
+      { nodeId: "nodeB", success: true, authState: "authenticated" },
+    ]);
+    expect(validate).toHaveBeenNthCalledWith(1, "nodeA", "cluster-token");
+    expect(validate).toHaveBeenNthCalledWith(2, "nodeB", "cluster-token");
+    expect(JSON.stringify(result.response)).not.toContain("cluster-token");
+  });
+
+  it("permits a partial session only when the other node is unreachable", async () => {
+    enable();
+    const validate = jest
+      .fn()
+      .mockResolvedValueOnce({ username: "alice" })
+      .mockRejectedValueOnce(new ServiceUnavailableException("offline"));
+    const { service } = createService(validate);
+    const result = await service.loginForRequest(
+      makeRequest({ identity: "alice@example.test", secret: SECRET }),
+    );
+    expect(result.session.tokensByNodeId).toEqual({
+      nodeA: "cluster-token",
+    });
+    expect(result.session.nodeAuthStatesByNodeId?.nodeB.status).toBe(
+      "unreachable",
+    );
+  });
+
+  it("fails the whole login on invalid tokens or owner mismatch", async () => {
+    enable();
+    const validate = jest
+      .fn()
+      .mockResolvedValueOnce({ username: "alice" })
+      .mockResolvedValueOnce({ username: "mallory" });
+    const { service, sessions } = createService(validate);
+    await expect(
+      service.loginForRequest(
+        makeRequest({ identity: "alice@example.test", secret: SECRET }),
+      ),
+    ).rejects.toBeInstanceOf(UnauthorizedException);
+    expect(sessions.count()).toBe(0);
+  });
+
+  it("single-flights validation per identity and bounds distinct local sessions", async () => {
+    enable();
+    const validate = jest.fn().mockResolvedValue({ username: "alice" });
+    const { service, sessions } = createService(validate);
+    const req = makeRequest({ identity: "alice@example.test", secret: SECRET });
+    const results = await Promise.all(
+      Array.from({ length: 10 }, () => service.loginForRequest(req)),
+    );
+    expect(validate).toHaveBeenCalledTimes(2);
+    expect(new Set(results.map((result) => result.session.id)).size).toBe(10);
+    expect(sessions.count()).toBe(8);
+    expect(sessions.get(results[0].session.id)).toBeUndefined();
+    expect(sessions.get(results[1].session.id)).toBeUndefined();
+    expect(sessions.get(results[9].session.id)).toBe(results[9].session);
+  });
+
+  it("applies a five-second cooldown after validation failure", async () => {
+    enable();
+    const validate = jest.fn().mockRejectedValue(new Error("invalid"));
+    const { service } = createService(validate);
+    const req = makeRequest({ identity: "alice@example.test", secret: SECRET });
+    await expect(service.loginForRequest(req)).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+    await expect(service.loginForRequest(req)).rejects.toMatchObject({
+      status: HttpStatus.TOO_MANY_REQUESTS,
+    });
+    expect(validate).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/backend/src/auth/trusted-sso.service.ts
+++ b/apps/backend/src/auth/trusted-sso.service.ts
@@ -1,0 +1,675 @@
+import {
+  ForbiddenException,
+  HttpException,
+  HttpStatus,
+  Inject,
+  Injectable,
+  Logger,
+  ServiceUnavailableException,
+  UnauthorizedException,
+} from "@nestjs/common";
+import { createHash, timingSafeEqual } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { isIP } from "node:net";
+import type { Request } from "express";
+import { parseTree } from "jsonc-parser";
+import type { Node as JsonNode, ParseError } from "jsonc-parser";
+import { TECHNITIUM_NODES_TOKEN } from "../technitium/technitium.constants";
+import { TechnitiumService } from "../technitium/technitium.service";
+import type { TechnitiumNodeConfig } from "../technitium/technitium.types";
+import { getEnvOrFile } from "../utils/env-file";
+import { AuthRequestContext } from "./auth-request-context";
+import { AuthSessionService } from "./auth-session.service";
+import type {
+  AuthNodeSessionState,
+  AuthSession,
+  TrustedSsoRequestClassification,
+  TrustedSsoStatus,
+} from "./auth.types";
+
+const DEFAULT_IDENTITY_HEADER = "x-forwarded-user";
+const DEFAULT_SECRET_HEADER = "x-trusted-proxy-secret";
+const FAILURE_COOLDOWN_MS = 5_000;
+const MAX_SESSIONS_PER_IDENTITY = 8;
+const HEADER_NAME_PATTERN = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
+const IDENTITY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._@+-]{0,254}$/;
+
+interface TrustedSsoIdentityMapping {
+  username: string;
+  token: string;
+}
+
+interface TrustedSsoConfig {
+  enabled: boolean;
+  identityHeader: string;
+  secretHeader: string;
+  secretDigest?: Buffer;
+  proxyCidrs: ParsedCidr[];
+  identities: Map<string, TrustedSsoIdentityMapping>;
+  logoutUrl?: string;
+}
+
+interface ParsedCidr {
+  family: 4 | 6;
+  network: bigint;
+  prefix: number;
+}
+
+interface TrustedSsoValidation {
+  mapping: TrustedSsoIdentityMapping;
+  nodeAuthStatesByNodeId: Record<string, AuthNodeSessionState>;
+  authenticatedNodeIds: string[];
+}
+
+export interface TrustedSsoLoginResult {
+  session: AuthSession;
+  response: {
+    authenticated: true;
+    nodes: Array<{
+      nodeId: string;
+      success: boolean;
+      authState: AuthNodeSessionState["status"];
+      error?: string;
+    }>;
+  };
+}
+
+@Injectable()
+export class TrustedSsoService {
+  private readonly logger = new Logger(TrustedSsoService.name);
+  private readonly config: TrustedSsoConfig;
+  private readonly validationFlights = new Map<
+    string,
+    Promise<TrustedSsoValidation>
+  >();
+  private readonly failureCooldowns = new Map<string, number>();
+
+  constructor(
+    @Inject(TECHNITIUM_NODES_TOKEN)
+    private readonly nodeConfigs: TechnitiumNodeConfig[],
+    private readonly technitiumService: TechnitiumService,
+    private readonly sessionService: AuthSessionService,
+  ) {
+    this.config = this.loadConfig();
+    if (this.config.enabled) {
+      this.logger.log(
+        `Trusted SSO enabled with ${this.config.identities.size} exact identity mapping(s).`,
+      );
+    }
+  }
+
+  isEnabled(): boolean {
+    return this.config.enabled;
+  }
+
+  classify(req: Request): TrustedSsoRequestClassification {
+    if (!this.config.enabled) {
+      return { kind: "disabled" };
+    }
+
+    if (!this.isImmediatePeerTrusted(req)) {
+      return { kind: "direct" };
+    }
+
+    if (!req.secure) {
+      return { kind: "invalid", error: "invalid-proxy-assertion" };
+    }
+
+    const identity = this.readSingleHeader(req, this.config.identityHeader);
+    const suppliedSecret = this.readSingleHeader(req, this.config.secretHeader);
+    if (
+      !identity ||
+      !IDENTITY_PATTERN.test(identity) ||
+      !suppliedSecret ||
+      !this.secretMatches(suppliedSecret)
+    ) {
+      return { kind: "invalid", error: "invalid-proxy-assertion" };
+    }
+
+    return { kind: "valid", identity };
+  }
+
+  getStatus(req?: Request): TrustedSsoStatus {
+    if (!this.config.enabled) {
+      return {
+        enabled: false,
+        available: false,
+        manualLoginAllowed: true,
+      };
+    }
+
+    const classification =
+      AuthRequestContext.getTrustedSsoRequest() ??
+      (req ? this.classify(req) : { kind: "invalid" as const });
+    const manualLoginAllowed = req ? this.isManualLoginAllowed(req) : false;
+    const base = {
+      enabled: true,
+      manualLoginAllowed,
+      ...(this.config.logoutUrl ? { logoutUrl: this.config.logoutUrl } : {}),
+    };
+
+    if (classification.kind === "valid") {
+      if (!this.config.identities.has(classification.identity)) {
+        return {
+          ...base,
+          available: false,
+          error: "identity-not-authorized",
+        };
+      }
+      return { ...base, available: true };
+    }
+
+    if (classification.kind === "invalid") {
+      return {
+        ...base,
+        available: false,
+        error: "invalid-proxy-assertion",
+      };
+    }
+
+    return { ...base, available: false };
+  }
+
+  assertPasswordLoginAllowed(req: Request): void {
+    if (!this.isManualLoginAllowed(req)) {
+      throw new ForbiddenException(
+        "Password login is disabled for requests through the trusted SSO proxy.",
+      );
+    }
+  }
+
+  async loginForRequest(req: Request): Promise<TrustedSsoLoginResult> {
+    const classification =
+      AuthRequestContext.getTrustedSsoRequest() ?? this.classify(req);
+    if (classification.kind !== "valid") {
+      throw new UnauthorizedException("Invalid trusted proxy assertion");
+    }
+
+    const mapping = this.config.identities.get(classification.identity);
+    if (!mapping) {
+      throw new ForbiddenException("SSO identity is not authorized");
+    }
+
+    const cooldownUntil = this.failureCooldowns.get(classification.identity);
+    if (cooldownUntil && cooldownUntil > Date.now()) {
+      throw new HttpException(
+        "SSO token validation is temporarily rate limited after a failure",
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+
+    let validationPromise = this.validationFlights.get(classification.identity);
+    if (!validationPromise) {
+      validationPromise = this.validateMapping(mapping);
+      this.validationFlights.set(classification.identity, validationPromise);
+      void validationPromise
+        .then(() => this.failureCooldowns.delete(classification.identity))
+        .catch(() =>
+          this.failureCooldowns.set(
+            classification.identity,
+            Date.now() + FAILURE_COOLDOWN_MS,
+          ),
+        )
+        .finally(() => {
+          if (
+            this.validationFlights.get(classification.identity) ===
+            validationPromise
+          ) {
+            this.validationFlights.delete(classification.identity);
+          }
+        });
+    }
+
+    const validation = await validationPromise;
+    const tokensByNodeId = Object.fromEntries(
+      validation.authenticatedNodeIds.map((nodeId) => [
+        nodeId,
+        validation.mapping.token,
+      ]),
+    );
+    const session = this.sessionService.create(
+      classification.identity,
+      tokensByNodeId,
+      validation.nodeAuthStatesByNodeId,
+      {
+        authSource: "trusted-sso",
+        technitiumUser: validation.mapping.username,
+        maxSessionsForUser: MAX_SESSIONS_PER_IDENTITY,
+      },
+    );
+
+    return {
+      session,
+      response: {
+        authenticated: true,
+        nodes: this.nodeConfigs.map((node) => {
+          const state = validation.nodeAuthStatesByNodeId[node.id];
+          return {
+            nodeId: node.id,
+            success: state.status === "authenticated",
+            authState: state.status,
+            ...(state.error ? { error: state.error } : {}),
+          };
+        }),
+      },
+    };
+  }
+
+  private async validateMapping(
+    mapping: TrustedSsoIdentityMapping,
+  ): Promise<TrustedSsoValidation> {
+    const results = await Promise.all(
+      this.nodeConfigs.map(async (node) => {
+        try {
+          const tokenOwner =
+            await this.technitiumService.validateExplicitSessionToken(
+              node.id,
+              mapping.token,
+            );
+          if (tokenOwner.username !== mapping.username) {
+            return {
+              nodeId: node.id,
+              state: {
+                status: "failed" as const,
+                error: "Mapped token owner does not match configured username",
+              },
+            };
+          }
+          return {
+            nodeId: node.id,
+            state: { status: "authenticated" as const },
+          };
+        } catch (error) {
+          const unreachable =
+            error instanceof HttpException &&
+            [
+              HttpStatus.SERVICE_UNAVAILABLE,
+              HttpStatus.GATEWAY_TIMEOUT,
+            ].includes(error.getStatus());
+          return {
+            nodeId: node.id,
+            state: {
+              status: unreachable
+                ? ("unreachable" as const)
+                : ("failed" as const),
+              error: unreachable
+                ? "Technitium node is unreachable"
+                : "Mapped token validation failed",
+            },
+          };
+        }
+      }),
+    );
+
+    const nodeAuthStatesByNodeId = Object.fromEntries(
+      results.map(({ nodeId, state }) => [nodeId, state]),
+    );
+    const failed = results.filter(({ state }) => state.status === "failed");
+    if (failed.length > 0) {
+      throw new UnauthorizedException({
+        message: "Trusted SSO token validation failed",
+        nodes: failed.map(({ nodeId, state }) => ({
+          nodeId,
+          success: false,
+          authState: state.status,
+          error: state.error,
+        })),
+      });
+    }
+
+    const authenticatedNodeIds = results
+      .filter(({ state }) => state.status === "authenticated")
+      .map(({ nodeId }) => nodeId);
+    if (authenticatedNodeIds.length === 0) {
+      throw new ServiceUnavailableException(
+        "No configured Technitium node is currently reachable",
+      );
+    }
+
+    return { mapping, nodeAuthStatesByNodeId, authenticatedNodeIds };
+  }
+
+  private isManualLoginAllowed(req: Request): boolean {
+    if (!this.config.enabled) {
+      return true;
+    }
+    return (
+      this.config.proxyCidrs.length > 0 && !this.isImmediatePeerTrusted(req)
+    );
+  }
+
+  private isImmediatePeerTrusted(req: Request): boolean {
+    if (this.config.proxyCidrs.length === 0) {
+      return true;
+    }
+    const remoteAddress = req.socket?.remoteAddress;
+    if (!remoteAddress) {
+      return false;
+    }
+    return this.config.proxyCidrs.some((cidr) =>
+      addressInCidr(remoteAddress, cidr),
+    );
+  }
+
+  private readSingleHeader(req: Request, name: string): string | undefined {
+    const rawHeaders = req.rawHeaders;
+    if (Array.isArray(rawHeaders) && rawHeaders.length > 0) {
+      const values: string[] = [];
+      for (let index = 0; index < rawHeaders.length; index += 2) {
+        if (rawHeaders[index]?.toLowerCase() === name) {
+          values.push(rawHeaders[index + 1] ?? "");
+        }
+      }
+      return values.length === 1 ? values[0] : undefined;
+    }
+
+    const value = req.headers[name];
+    return typeof value === "string" ? value : undefined;
+  }
+
+  private secretMatches(suppliedSecret: string): boolean {
+    if (!this.config.secretDigest) {
+      return false;
+    }
+    const suppliedDigest = createHash("sha256")
+      .update(suppliedSecret, "utf8")
+      .digest();
+    return timingSafeEqual(this.config.secretDigest, suppliedDigest);
+  }
+
+  private loadConfig(): TrustedSsoConfig {
+    const enabled = readBoolean("TRUSTED_SSO_ENABLED", false);
+    if (!enabled) {
+      return {
+        enabled,
+        identityHeader: DEFAULT_IDENTITY_HEADER,
+        secretHeader: DEFAULT_SECRET_HEADER,
+        proxyCidrs: [],
+        identities: new Map(),
+      };
+    }
+
+    const identityHeader = readHeaderName(
+      "TRUSTED_SSO_IDENTITY_HEADER",
+      DEFAULT_IDENTITY_HEADER,
+    );
+    const secretHeader = readHeaderName(
+      "TRUSTED_SSO_PROXY_SECRET_HEADER",
+      DEFAULT_SECRET_HEADER,
+    );
+    if (identityHeader === secretHeader) {
+      throw new Error(
+        "TRUSTED_SSO_IDENTITY_HEADER and TRUSTED_SSO_PROXY_SECRET_HEADER must differ.",
+      );
+    }
+
+    const secret = getEnvOrFile("TRUSTED_SSO_PROXY_SECRET");
+    if (!secret || secret.length < 32) {
+      throw new Error(
+        "TRUSTED_SSO_PROXY_SECRET must contain at least 32 characters (directly or via TRUSTED_SSO_PROXY_SECRET_FILE).",
+      );
+    }
+
+    const mapPath = process.env.TRUSTED_SSO_TOKEN_MAP_FILE?.trim();
+    if (!mapPath) {
+      throw new Error(
+        "TRUSTED_SSO_TOKEN_MAP_FILE is required when trusted SSO is enabled.",
+      );
+    }
+
+    const proxyCidrs = (process.env.TRUSTED_SSO_PROXY_CIDRS ?? "")
+      .split(",")
+      .map((value) => value.trim())
+      .filter(Boolean)
+      .map(parseCidr);
+    const logoutUrl = parseLogoutUrl(process.env.TRUSTED_SSO_LOGOUT_URL);
+
+    return {
+      enabled,
+      identityHeader,
+      secretHeader,
+      secretDigest: createHash("sha256").update(secret, "utf8").digest(),
+      proxyCidrs,
+      identities: this.loadTokenMap(mapPath),
+      ...(logoutUrl ? { logoutUrl } : {}),
+    };
+  }
+
+  private loadTokenMap(path: string): Map<string, TrustedSsoIdentityMapping> {
+    let parsed: unknown;
+    try {
+      const source = readFileSync(path, "utf8");
+      assertStrictJson(source);
+      parsed = JSON.parse(source) as unknown;
+    } catch {
+      throw new Error(
+        "TRUSTED_SSO_TOKEN_MAP_FILE must reference a readable, valid JSON file.",
+      );
+    }
+
+    const root = requireObject(parsed, "token map");
+    assertExactKeys(root, ["version", "identities"], "token map");
+    if (root.version !== 1) {
+      throw new Error("Trusted SSO token map version must be 1.");
+    }
+    const identities = requireObject(root.identities, "token map identities");
+    if (Object.keys(identities).length === 0) {
+      throw new Error(
+        "Trusted SSO token map must contain at least one identity.",
+      );
+    }
+
+    if (this.nodeConfigs.length === 0) {
+      throw new Error(
+        "Trusted SSO requires at least one configured Technitium node.",
+      );
+    }
+
+    const mappings = new Map<string, TrustedSsoIdentityMapping>();
+    for (const [identity, value] of Object.entries(identities)) {
+      if (!IDENTITY_PATTERN.test(identity)) {
+        throw new Error(
+          `Trusted SSO token map contains a malformed identity key.`,
+        );
+      }
+      const entry = requireObject(value, `identity mapping for ${identity}`);
+      assertExactKeys(
+        entry,
+        ["username", "token"],
+        `identity mapping for ${identity}`,
+      );
+      if (
+        typeof entry.username !== "string" ||
+        !IDENTITY_PATTERN.test(entry.username)
+      ) {
+        throw new Error(`Trusted SSO mapping has an invalid username.`);
+      }
+      if (typeof entry.token !== "string" || entry.token.length === 0) {
+        throw new Error(
+          "Trusted SSO mapping contains an empty or invalid cluster API token.",
+        );
+      }
+      mappings.set(identity, {
+        username: entry.username,
+        token: entry.token,
+      });
+    }
+    return mappings;
+  }
+}
+
+function assertStrictJson(source: string): void {
+  const errors: ParseError[] = [];
+  const root = parseTree(source, errors, {
+    allowTrailingComma: false,
+    disallowComments: true,
+  });
+  if (!root || errors.length > 0) {
+    throw new Error("Invalid JSON");
+  }
+
+  const walk = (node: JsonNode): void => {
+    if (node.type === "object") {
+      const keys = new Set<string>();
+      for (const property of node.children ?? []) {
+        const key = property.children?.[0]?.value as unknown;
+        if (typeof key !== "string" || keys.has(key)) {
+          throw new Error("Duplicate JSON object key");
+        }
+        keys.add(key);
+      }
+    }
+    for (const child of node.children ?? []) {
+      walk(child);
+    }
+  };
+  walk(root);
+}
+
+function readBoolean(name: string, defaultValue: boolean): boolean {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") {
+    return defaultValue;
+  }
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  throw new Error(`${name} must be either "true" or "false".`);
+}
+
+function readHeaderName(name: string, defaultValue: string): string {
+  const value = (process.env[name] ?? defaultValue).trim().toLowerCase();
+  if (!value || !HEADER_NAME_PATTERN.test(value)) {
+    throw new Error(`${name} must be a valid HTTP header name.`);
+  }
+  return value;
+}
+
+function parseLogoutUrl(raw: string | undefined): string | undefined {
+  const value = raw?.trim();
+  if (!value) return undefined;
+  if (
+    value.startsWith("/") &&
+    !value.startsWith("//") &&
+    !value.includes("\\")
+  ) {
+    return value;
+  }
+  try {
+    const url = new URL(value);
+    if (
+      url.protocol === "https:" &&
+      url.username === "" &&
+      url.password === ""
+    ) {
+      return url.toString();
+    }
+  } catch {
+    // The shared error below deliberately excludes the configured value.
+  }
+  throw new Error(
+    "TRUSTED_SSO_LOGOUT_URL must be an HTTPS URL or a relative path beginning with one slash.",
+  );
+}
+
+function requireObject(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Trusted SSO ${label} must be a JSON object.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function assertExactKeys(
+  object: Record<string, unknown>,
+  allowed: string[],
+  label: string,
+): void {
+  const unexpected = Object.keys(object).filter(
+    (key) => !allowed.includes(key),
+  );
+  const missing = allowed.filter((key) => !(key in object));
+  if (unexpected.length > 0 || missing.length > 0) {
+    throw new Error(
+      `Trusted SSO ${label} has an invalid schema (missing: ${missing.join(", ") || "none"}; unexpected: ${unexpected.join(", ") || "none"}).`,
+    );
+  }
+}
+
+function parseCidr(value: string): ParsedCidr {
+  const slash = value.indexOf("/");
+  const address = slash === -1 ? value : value.slice(0, slash);
+  const family = isIP(stripZone(address));
+  if (family !== 4 && family !== 6) {
+    throw new Error("TRUSTED_SSO_PROXY_CIDRS contains an invalid IP address.");
+  }
+  const maxPrefix = family === 4 ? 32 : 128;
+  const prefixText = slash === -1 ? String(maxPrefix) : value.slice(slash + 1);
+  if (!/^\d+$/.test(prefixText)) {
+    throw new Error(
+      "TRUSTED_SSO_PROXY_CIDRS contains an invalid prefix length.",
+    );
+  }
+  const prefix = Number.parseInt(prefixText, 10);
+  if (prefix < 0 || prefix > maxPrefix) {
+    throw new Error(
+      "TRUSTED_SSO_PROXY_CIDRS contains an invalid prefix length.",
+    );
+  }
+  const numeric = parseIp(address, family);
+  const hostBits = BigInt(maxPrefix - prefix);
+  return {
+    family,
+    prefix,
+    network: hostBits === 0n ? numeric : (numeric >> hostBits) << hostBits,
+  };
+}
+
+function addressInCidr(address: string, cidr: ParsedCidr): boolean {
+  const normalized = stripZone(address);
+  let family = isIP(normalized);
+  let candidate = normalized;
+  if (family === 6 && /^::ffff:\d+\.\d+\.\d+\.\d+$/i.test(normalized)) {
+    candidate = normalized.slice("::ffff:".length);
+    family = 4;
+  }
+  if (family !== cidr.family) return false;
+  const maxPrefix = family === 4 ? 32 : 128;
+  const hostBits = BigInt(maxPrefix - cidr.prefix);
+  const numeric = parseIp(candidate, family);
+  const network = hostBits === 0n ? numeric : (numeric >> hostBits) << hostBits;
+  return network === cidr.network;
+}
+
+function stripZone(address: string): string {
+  const zoneIndex = address.indexOf("%");
+  return zoneIndex === -1 ? address : address.slice(0, zoneIndex);
+}
+
+function parseIp(address: string, family: 4 | 6): bigint {
+  if (family === 4) {
+    return address
+      .split(".")
+      .map(Number)
+      .reduce((result, part) => (result << 8n) | BigInt(part), 0n);
+  }
+
+  let normalized = stripZone(address).toLowerCase();
+  if (normalized.includes(".")) {
+    const lastColon = normalized.lastIndexOf(":");
+    const ipv4 = normalized
+      .slice(lastColon + 1)
+      .split(".")
+      .map(Number);
+    normalized = `${normalized.slice(0, lastColon)}:${((ipv4[0] << 8) | ipv4[1]).toString(16)}:${((ipv4[2] << 8) | ipv4[3]).toString(16)}`;
+  }
+  const [leftText, rightText] = normalized.split("::");
+  const left = leftText ? leftText.split(":") : [];
+  const right = rightText ? rightText.split(":") : [];
+  const omitted = 8 - left.length - right.length;
+  const parts = normalized.includes("::")
+    ? [...left, ...Array.from({ length: omitted }, () => "0"), ...right]
+    : left;
+  return parts.reduce(
+    (result, part) => (result << 16n) | BigInt(Number.parseInt(part, 16)),
+    0n,
+  );
+}

--- a/apps/backend/src/technitium/technitium.service.ts
+++ b/apps/backend/src/technitium/technitium.service.ts
@@ -504,6 +504,40 @@ export class TechnitiumService {
     return this.nodeConfigs.map((node) => node.id);
   }
 
+  async validateExplicitSessionToken(
+    nodeId: string,
+    token: string,
+  ): Promise<{ username: string }> {
+    const node = this.findNode(nodeId);
+    type SessionInfo = { username?: string };
+    const envelope = await this.requestWithExplicitToken<
+      TechnitiumApiResponse<SessionInfo>
+    >(node, { method: "GET", url: "/api/user/session/get" }, token, {
+      suppressNetworkErrorLog: true,
+    });
+    const envelopeObject = envelope as TechnitiumApiResponse<SessionInfo> &
+      SessionInfo;
+    if (envelopeObject.status !== "ok") {
+      if (envelopeObject.status === "invalid-token") {
+        throw new UnauthorizedException(
+          `Technitium DNS node "${node.id}" rejected the mapped session token.`,
+        );
+      }
+      throw new UnauthorizedException(
+        `Technitium DNS node "${node.id}" could not validate the mapped session token.`,
+      );
+    }
+
+    const username =
+      envelopeObject.response?.username ?? envelopeObject.username;
+    if (!username) {
+      throw new UnauthorizedException(
+        `Technitium DNS node "${node.id}" did not identify the mapped token owner.`,
+      );
+    }
+    return { username };
+  }
+
   /**
    * Resolve a hostname to IP address with timeout.
    * Used to match cluster nodes when hostnames don't resolve to the configured baseUrl IPs.

--- a/apps/backend/src/utils/env-file.spec.ts
+++ b/apps/backend/src/utils/env-file.spec.ts
@@ -22,6 +22,8 @@ describe("env-file utilities", () => {
     delete process.env.TEST_VAR_FILE;
     delete process.env.TECHNITIUM_BACKGROUND_TOKEN;
     delete process.env.TECHNITIUM_BACKGROUND_TOKEN_FILE;
+    delete process.env.TRUSTED_SSO_PROXY_SECRET;
+    delete process.env.TRUSTED_SSO_PROXY_SECRET_FILE;
     delete process.env.TECHNITIUM_NODES;
     delete process.env.TECHNITIUM_NODE1_TOKEN;
     delete process.env.TECHNITIUM_NODE1_TOKEN_FILE;
@@ -104,6 +106,18 @@ describe("env-file utilities", () => {
       resolveEnvFileVariables();
 
       expect(process.env.TECHNITIUM_NODE1_TOKEN).toBe("node1-secret-token");
+    });
+
+    it("should resolve the trusted SSO proxy secret from file", () => {
+      const filePath = join(testDir, "trusted-sso-secret.txt");
+      writeFileSync(filePath, "trusted-sso-secret-value");
+      process.env.TRUSTED_SSO_PROXY_SECRET_FILE = filePath;
+
+      resolveEnvFileVariables();
+
+      expect(process.env.TRUSTED_SSO_PROXY_SECRET).toBe(
+        "trusted-sso-secret-value",
+      );
     });
 
     it("should not overwrite existing env values", () => {

--- a/apps/backend/src/utils/env-file.ts
+++ b/apps/backend/src/utils/env-file.ts
@@ -88,6 +88,7 @@ export function resolveEnvFileVariables(): void {
   const sensitiveVars = [
     "TECHNITIUM_BACKGROUND_TOKEN",
     "TECHNITIUM_SCHEDULE_TOKEN",
+    "TRUSTED_SSO_PROXY_SECRET",
   ];
 
   // Resolve statically-known sensitive variables

--- a/apps/backend/test/app.e2e-spec.ts
+++ b/apps/backend/test/app.e2e-spec.ts
@@ -42,4 +42,18 @@ describe("AppController (e2e)", () => {
         );
       });
   });
+
+  it("does not establish a session from forwarded proto and identity headers alone", async () => {
+    const agent = request.agent(app.getHttpServer());
+    await agent
+      .get("/api/auth/me")
+      .set("X-Forwarded-Proto", "https")
+      .set("X-Forwarded-User", "alice@example.test")
+      .expect(200)
+      .expect((res) => {
+        expect(res.body).toMatchObject({ authenticated: false });
+        expect(res.headers["set-cookie"]).toBeUndefined();
+      });
+
+  });
 });

--- a/apps/frontend/src/App.css
+++ b/apps/frontend/src/App.css
@@ -15,6 +15,28 @@
   backdrop-filter: blur(2px) !important;
 }
 
+.login__sso-state {
+  margin: 0 0 1rem;
+  padding: 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: 0.75rem;
+  background: var(--color-bg-secondary);
+}
+
+.login__sso-state h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.125rem;
+}
+
+.login__sso-state p {
+  margin: 0 0 1rem;
+  color: var(--color-text-secondary);
+}
+
+.login__sso-state p:last-child {
+  margin-bottom: 0;
+}
+
 /* Ensure font applies to all content inside tooltip */
 .domain-tooltip *,
 .domain-tooltip div,

--- a/apps/frontend/src/components/common/AboutModal.css
+++ b/apps/frontend/src/components/common/AboutModal.css
@@ -109,6 +109,13 @@
   justify-content: center;
 }
 
+.about-modal__revision {
+  color: var(--color-text-tertiary);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", monospace;
+  font-size: 0.8rem;
+}
+
 .about-modal__update-pill {
   display: inline-flex;
   align-items: center;

--- a/apps/frontend/src/components/common/AboutModal.tsx
+++ b/apps/frontend/src/components/common/AboutModal.tsx
@@ -15,6 +15,10 @@ interface AboutModalProps {
 }
 
 export function AboutModal({ isOpen, onClose }: AboutModalProps) {
+  const buildRevision =
+    __BUILD_REVISION__ === "development" || __BUILD_REVISION__ === "unknown" ?
+      null
+    : __BUILD_REVISION__.slice(0, 7);
   const {
     latestVersion,
     latestReleaseUrl,
@@ -67,6 +71,14 @@ export function AboutModal({ isOpen, onClose }: AboutModalProps) {
           </h2>
           <div className="about-modal__version-row">
             <span className="about-modal__version">v{__APP_VERSION__}</span>
+            {buildRevision && (
+              <span
+                className="about-modal__revision"
+                title={`Build revision ${__BUILD_REVISION__}`}
+              >
+                {buildRevision}
+              </span>
+            )}
           </div>
           <div className="about-modal__version-check">
             {isUpdateAvailable && latestVersion ?

--- a/apps/frontend/src/context/AuthContext.tsx
+++ b/apps/frontend/src/context/AuthContext.tsx
@@ -8,15 +8,25 @@ import {
     triggerAuthRedirect,
 } from "../config";
 import { AuthContext } from "./authContextInstance";
+import { redirectToTrustedSsoLogout } from "../utils/trustedSso";
 
 export type AuthStatus = {
   sessionAuthEnabled?: boolean;
   authenticated: boolean;
   user?: string;
+  authSource?: "password" | "trusted-sso";
+  technitiumUser?: string;
   nodeIds?: string[];
   unreachableNodeIds?: string[];
   failedNodeIds?: string[];
   configuredNodeIds?: string[];
+  trustedSso?: {
+    enabled: boolean;
+    available: boolean;
+    manualLoginAllowed: boolean;
+    error?: "identity-not-authorized" | "invalid-proxy-assertion";
+    logoutUrl?: string;
+  };
   transport?: AuthTransportInfo;
   backgroundPtrToken?: BackgroundPtrTokenValidationSummary;
 };
@@ -32,7 +42,34 @@ export type AuthContextValue = {
     totp?: string;
   }) => Promise<void>;
   logout: () => Promise<void>;
+  continueWithSso: () => Promise<void>;
+  ssoSuppressed: boolean;
 };
+
+const TRUSTED_SSO_SUPPRESSED_KEY = "trusted-sso-login-suppressed";
+
+function readSsoSuppressed(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return (
+      window.sessionStorage?.getItem(TRUSTED_SSO_SUPPRESSED_KEY) === "true"
+    );
+  } catch {
+    return false;
+  }
+}
+
+function writeSsoSuppressed(suppressed: boolean): void {
+  try {
+    if (suppressed) {
+      window.sessionStorage?.setItem(TRUSTED_SSO_SUPPRESSED_KEY, "true");
+    } else {
+      window.sessionStorage?.removeItem(TRUSTED_SSO_SUPPRESSED_KEY);
+    }
+  } catch {
+    // Storage can be unavailable in privacy-restricted browser contexts.
+  }
+}
 
 async function safeReadError(response: Response): Promise<string> {
   try {
@@ -101,6 +138,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [status, setStatus] = useState<AuthStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [ssoSuppressed, setSsoSuppressed] = useState(readSsoSuppressed);
 
   const statusRef = useRef<AuthStatus | null>(null);
 
@@ -110,6 +148,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const refreshInFlightRef = useRef<Promise<void> | null>(null);
   const lastPresenceRefreshAtRef = useRef<number>(0);
+  const ssoBootstrapAttemptedRef = useRef(false);
+  const ssoBootstrapErrorRef = useRef<string | null>(null);
 
   useEffect(() => {
     statusRef.current = status;
@@ -126,18 +166,64 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       if (!silent) {
         setLoading(true);
       }
-      setError(null);
+      if (!ssoBootstrapErrorRef.current) {
+        setError(null);
+      }
       try {
         const wasAuthenticated = statusRef.current?.authenticated === true;
         const res = await apiFetch("/auth/me");
         if (!res.ok) {
           setStatus((prev) => ({
+            ...prev,
             sessionAuthEnabled: prev?.sessionAuthEnabled,
             authenticated: false,
           }));
           return;
         }
-        const data = (await res.json()) as AuthStatus;
+        let data = (await res.json()) as AuthStatus;
+        setStatus(data);
+
+        if (
+          !data.authenticated &&
+          data.trustedSso?.available === true &&
+          !readSsoSuppressed() &&
+          !ssoBootstrapAttemptedRef.current
+        ) {
+          ssoBootstrapAttemptedRef.current = true;
+          const ssoResponse = await apiFetch("/auth/sso/login", {
+            method: "POST",
+          });
+          if (ssoResponse.ok) {
+            const refreshedResponse = await apiFetch("/auth/me");
+            if (refreshedResponse.ok) {
+              data = (await refreshedResponse.json()) as AuthStatus;
+              if (!data.authenticated) {
+                const message =
+                  "SSO sign-in completed, but the session could not be confirmed.";
+                ssoBootstrapErrorRef.current = message;
+                setError(message);
+              }
+            } else {
+              const message = await safeReadError(refreshedResponse);
+              ssoBootstrapErrorRef.current = message;
+              setError(message);
+            }
+          } else {
+            const message = await safeReadError(ssoResponse);
+            ssoBootstrapErrorRef.current = message;
+            setError(message);
+          }
+        }
+
+        if (data.authenticated) {
+          ssoBootstrapAttemptedRef.current = false;
+          ssoBootstrapErrorRef.current = null;
+          setError(null);
+        } else if (data.trustedSso?.available !== true) {
+          ssoBootstrapAttemptedRef.current = false;
+          ssoBootstrapErrorRef.current = null;
+          setError(null);
+        }
 
         // If the user previously had an authenticated Companion session and it
         // is now gone, treat it as an expiry and use the existing redirect/toast
@@ -153,10 +239,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setStatus(data);
       } catch (e) {
         setStatus((prev) => ({
+          ...prev,
           sessionAuthEnabled: prev?.sessionAuthEnabled,
           authenticated: false,
         }));
-        setError(e instanceof Error ? e.message : "Failed to check session");
+        const message =
+          e instanceof Error ? e.message : "Failed to check session";
+        if (ssoBootstrapAttemptedRef.current) {
+          ssoBootstrapErrorRef.current = message;
+        }
+        setError(message);
       } finally {
         if (!silent) {
           setLoading(false);
@@ -248,19 +340,57 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const logout = useCallback(async () => {
     setError(null);
+    const trustedSsoSession = statusRef.current?.authSource === "trusted-sso";
+    const logoutUrl = statusRef.current?.trustedSso?.logoutUrl;
     try {
       await apiFetch("/auth/logout", { method: "POST" });
     } finally {
-      await refresh();
+      if (trustedSsoSession && !logoutUrl) {
+        writeSsoSuppressed(true);
+        setSsoSuppressed(true);
+      }
+      if (trustedSsoSession && logoutUrl) {
+        redirectToTrustedSsoLogout(logoutUrl);
+      } else {
+        await refresh();
+      }
     }
+  }, [refresh]);
+
+  const continueWithSso = useCallback(async () => {
+    writeSsoSuppressed(false);
+    setSsoSuppressed(false);
+    ssoBootstrapAttemptedRef.current = false;
+    ssoBootstrapErrorRef.current = null;
+    setError(null);
+    await refresh();
   }, [refresh]);
 
   const value = useMemo<AuthContextValue>(() => {
     // Ensure the context value identity changes for auth-related events even
     // when `status` is still null and other exposed fields haven't changed.
     void authEventNonce;
-    return { status, loading, error, refresh, login, logout };
-  }, [status, loading, error, refresh, login, logout, authEventNonce]);
+    return {
+      status,
+      loading,
+      error,
+      refresh,
+      login,
+      logout,
+      continueWithSso,
+      ssoSuppressed,
+    };
+  }, [
+    status,
+    loading,
+    error,
+    refresh,
+    login,
+    logout,
+    continueWithSso,
+    ssoSuppressed,
+    authEventNonce,
+  ]);
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }

--- a/apps/frontend/src/pages/LoginPage.tsx
+++ b/apps/frontend/src/pages/LoginPage.tsx
@@ -14,7 +14,14 @@ function isTotpRequiredError(message: string): boolean {
 }
 
 export default function LoginPage() {
-  const { status, loading, login } = useAuth();
+  const {
+    status,
+    loading,
+    error: authError,
+    login,
+    continueWithSso,
+    ssoSuppressed,
+  } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -41,6 +48,8 @@ export default function LoginPage() {
   const [error, setError] = useState<string | null>(null);
   const [totpRequired, setTotpRequired] = useState(false);
   const totpInputRef = useRef<HTMLInputElement>(null);
+  const trustedSso = status?.trustedSso;
+  const manualLoginAllowed = trustedSso?.manualLoginAllowed ?? true;
 
   if (
     !loading &&
@@ -94,8 +103,67 @@ export default function LoginPage() {
           color: "var(--color-text-secondary)",
         }}
       >
-        Use your Technitium DNS username and password.
+        {manualLoginAllowed ?
+          "Use your Technitium DNS username and password."
+        : "Authentication is managed by your trusted identity provider."}
       </p>
+
+      {!manualLoginAllowed &&
+        trustedSso?.error === "identity-not-authorized" && (
+          <div role="alert" className="login__sso-state">
+            <h2>Access denied</h2>
+            <p>
+              Your SSO identity is valid but is not authorized for Technitium
+              DNS Companion. Ask an administrator to add an exact identity and
+              Technitium user mapping.
+            </p>
+          </div>
+        )}
+
+      {!manualLoginAllowed &&
+        trustedSso?.error === "invalid-proxy-assertion" && (
+          <div role="alert" className="login__sso-state">
+            <h2>SSO is unavailable</h2>
+            <p>
+              The trusted proxy assertion is missing or invalid. Contact the
+              administrator responsible for the reverse proxy configuration.
+            </p>
+          </div>
+        )}
+
+      {!manualLoginAllowed && trustedSso?.available && ssoSuppressed && (
+        <div role="status" className="login__sso-state">
+          <h2>Signed out locally</h2>
+          <p>
+            Automatic SSO sign-in is paused for this browser tab until you
+            choose to continue.
+          </p>
+          <button
+            className="button primary"
+            type="button"
+            onClick={() => void continueWithSso()}
+          >
+            Continue with SSO
+          </button>
+        </div>
+      )}
+
+      {!manualLoginAllowed &&
+        trustedSso?.available &&
+        !ssoSuppressed &&
+        authError && (
+          <div role="alert" className="login__sso-state">
+            <h2>SSO sign-in failed</h2>
+            <p style={{ whiteSpace: "pre-line" }}>{authError}</p>
+            <button
+              className="button primary"
+              type="button"
+              onClick={() => void continueWithSso()}
+            >
+              Continue with SSO
+            </button>
+          </div>
+        )}
 
       {redirectedReason === "node-session-expired" && (
         <div
@@ -130,7 +198,7 @@ export default function LoginPage() {
         </div>
       )}
 
-      <form
+      {manualLoginAllowed && <form
         onSubmit={onSubmit}
         className="login__form"
         style={{
@@ -235,7 +303,7 @@ export default function LoginPage() {
         >
           Sign in
         </button>
-      </form>
+      </form>}
     </div>
   );
 }

--- a/apps/frontend/src/test/auth-session-expiry-routing.test.tsx
+++ b/apps/frontend/src/test/auth-session-expiry-routing.test.tsx
@@ -8,7 +8,11 @@ import { isNodeSessionRequiredButMissing } from "../utils/authSession";
 
 const authMock = vi.hoisted(() => ({
   login: vi.fn(),
+  continueWithSso: vi.fn(),
 }));
+
+let mockedAuthError: string | null = null;
+let mockedSsoSuppressed = false;
 
 let mockedAuthStatus: {
   sessionAuthEnabled: boolean;
@@ -16,6 +20,12 @@ let mockedAuthStatus: {
   configuredNodeIds: string[];
   nodeIds: string[];
   unreachableNodeIds?: string[];
+  trustedSso?: {
+    enabled: boolean;
+    available: boolean;
+    manualLoginAllowed: boolean;
+    error?: "identity-not-authorized" | "invalid-proxy-assertion";
+  };
 } | null = null;
 
 vi.mock("../context/useAuth", async () => {
@@ -33,12 +43,15 @@ vi.mock("../context/useAuth", async () => {
         configuredNodeIds: mockedAuthStatus?.configuredNodeIds ?? ["node1"],
         nodeIds: mockedAuthStatus?.nodeIds ?? [],
         unreachableNodeIds: mockedAuthStatus?.unreachableNodeIds ?? [],
+        trustedSso: mockedAuthStatus?.trustedSso,
       },
       loading: false,
-      error: null,
+      error: mockedAuthError,
       refresh: vi.fn(async () => {}),
       login: authMock.login,
       logout: vi.fn(async () => {}),
+      continueWithSso: authMock.continueWithSso,
+      ssoSuppressed: mockedSsoSuppressed,
     }),
   };
 });
@@ -47,6 +60,10 @@ describe("Auth routing when node session expires", () => {
   beforeEach(() => {
     authMock.login.mockReset();
     authMock.login.mockResolvedValue(undefined);
+    authMock.continueWithSso.mockReset();
+    authMock.continueWithSso.mockResolvedValue(undefined);
+    mockedAuthError = null;
+    mockedSsoSuppressed = false;
   });
 
   it("shows login page (does not redirect) when cookie is valid but nodeIds is empty", () => {
@@ -177,5 +194,81 @@ describe("Auth routing when node session expires", () => {
         unreachableNodeIds: [],
       }),
     ).toBe(true);
+  });
+
+  it.each([
+    ["identity-not-authorized" as const, "Access denied"],
+    ["invalid-proxy-assertion" as const, "SSO is unavailable"],
+  ])("shows the %s SSO state without a password form", (error, heading) => {
+    mockedAuthStatus = {
+      sessionAuthEnabled: true,
+      authenticated: false,
+      configuredNodeIds: ["node1"],
+      nodeIds: [],
+      trustedSso: {
+        enabled: true,
+        available: false,
+        manualLoginAllowed: false,
+        error,
+      },
+    };
+
+    render(
+      <MemoryRouter initialEntries={["/login"]}>
+        <Routes>
+          <Route path="/login" element={<LoginPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole("heading", { name: heading })).toBeInTheDocument();
+    expect(screen.queryByLabelText("Password")).not.toBeInTheDocument();
+  });
+
+  it("keeps the password form visible for direct break-glass access", () => {
+    mockedAuthStatus = {
+      sessionAuthEnabled: true,
+      authenticated: false,
+      configuredNodeIds: ["node1"],
+      nodeIds: [],
+      trustedSso: {
+        enabled: true,
+        available: false,
+        manualLoginAllowed: true,
+      },
+    };
+    render(
+      <MemoryRouter initialEntries={["/login"]}>
+        <Routes>
+          <Route path="/login" element={<LoginPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(screen.getByLabelText("Password")).toBeInTheDocument();
+  });
+
+  it("offers Continue with SSO after a deliberate local logout", async () => {
+    const user = userEvent.setup();
+    mockedSsoSuppressed = true;
+    mockedAuthStatus = {
+      sessionAuthEnabled: true,
+      authenticated: false,
+      configuredNodeIds: ["node1"],
+      nodeIds: [],
+      trustedSso: {
+        enabled: true,
+        available: true,
+        manualLoginAllowed: false,
+      },
+    };
+    render(
+      <MemoryRouter initialEntries={["/login"]}>
+        <Routes>
+          <Route path="/login" element={<LoginPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await user.click(screen.getByRole("button", { name: "Continue with SSO" }));
+    expect(authMock.continueWithSso).toHaveBeenCalledTimes(1);
+    expect(screen.queryByLabelText("Password")).not.toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/test/trusted-sso-auth-context.test.tsx
+++ b/apps/frontend/src/test/trusted-sso-auth-context.test.tsx
@@ -1,0 +1,173 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthProvider } from "../context/AuthContext";
+import { useAuth } from "../context/useAuth";
+
+const redirectMock = vi.hoisted(() => vi.fn());
+vi.mock("../utils/trustedSso", () => ({
+  redirectToTrustedSsoLogout: redirectMock,
+}));
+
+function response(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: vi.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+describe("trusted SSO authentication context", () => {
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <AuthProvider>{children}</AuthProvider>
+  );
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    redirectMock.mockReset();
+    fetchSpy = vi.spyOn(global, "fetch");
+  });
+
+  afterEach(() => fetchSpy.mockRestore());
+
+  it("bootstraps SSO once and refreshes authenticated status", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(
+        response({
+          authenticated: false,
+          trustedSso: {
+            enabled: true,
+            available: true,
+            manualLoginAllowed: false,
+          },
+        }),
+      )
+      .mockResolvedValueOnce(response({ authenticated: true }))
+      .mockResolvedValueOnce(
+        response({
+          authenticated: true,
+          authSource: "trusted-sso",
+          user: "alice@example.test",
+          technitiumUser: "alice",
+          trustedSso: {
+            enabled: true,
+            available: true,
+            manualLoginAllowed: false,
+          },
+        }),
+      );
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.status).toMatchObject({
+      authenticated: true,
+      authSource: "trusted-sso",
+      technitiumUser: "alice",
+    });
+    expect(fetchSpy.mock.calls.map(([url]) => url)).toEqual([
+      "/api/auth/me",
+      "/api/auth/sso/login",
+      "/api/auth/me",
+    ]);
+    expect(fetchSpy.mock.calls[1]?.[1]).toMatchObject({ method: "POST" });
+  });
+
+  it("does not loop or retry automatically after SSO validation is denied", async () => {
+    const available = {
+      authenticated: false,
+      trustedSso: {
+        enabled: true,
+        available: true,
+        manualLoginAllowed: false,
+      },
+    };
+    fetchSpy
+      .mockResolvedValueOnce(response(available))
+      .mockResolvedValueOnce(
+        response({ message: "Trusted SSO token validation failed" }, 401),
+      )
+      .mockResolvedValueOnce(response(available));
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() =>
+      expect(result.current.error).toBe(
+        "Trusted SSO token validation failed",
+      ),
+    );
+
+    await act(async () => result.current.refresh());
+    expect(
+      fetchSpy.mock.calls.filter(([url]) => url === "/api/auth/sso/login"),
+    ).toHaveLength(1);
+  });
+
+  it("suppresses automatic re-login after local SSO logout until continued", async () => {
+    const authenticated = {
+      authenticated: true,
+      authSource: "trusted-sso",
+      trustedSso: {
+        enabled: true,
+        available: true,
+        manualLoginAllowed: false,
+      },
+    };
+    const available = {
+      authenticated: false,
+      trustedSso: authenticated.trustedSso,
+    };
+    fetchSpy
+      .mockResolvedValueOnce(response(authenticated))
+      .mockResolvedValueOnce(response({ ok: true }))
+      .mockResolvedValueOnce(response(available))
+      .mockResolvedValueOnce(response(available))
+      .mockResolvedValueOnce(response({ authenticated: true }))
+      .mockResolvedValueOnce(response(authenticated));
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.status?.authenticated).toBe(true));
+
+    await act(async () => result.current.logout());
+    expect(result.current.ssoSuppressed).toBe(true);
+    expect(result.current.status?.authenticated).toBe(false);
+    expect(
+      fetchSpy.mock.calls.filter(([url]) => url === "/api/auth/sso/login"),
+    ).toHaveLength(0);
+
+    await act(async () => result.current.continueWithSso());
+    expect(result.current.ssoSuppressed).toBe(false);
+    expect(result.current.status?.authenticated).toBe(true);
+    expect(
+      fetchSpy.mock.calls.filter(([url]) => url === "/api/auth/sso/login"),
+    ).toHaveLength(1);
+  });
+
+  it("redirects to the IdP logout URL after clearing the local session", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(
+        response({
+          authenticated: true,
+          authSource: "trusted-sso",
+          trustedSso: {
+            enabled: true,
+            available: true,
+            manualLoginAllowed: false,
+            logoutUrl: "https://idp.example.test/end-session/",
+          },
+        }),
+      )
+      .mockResolvedValueOnce(response({ ok: true }));
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.status?.authenticated).toBe(true));
+    await act(async () => result.current.logout());
+
+    expect(redirectMock).toHaveBeenCalledWith(
+      "https://idp.example.test/end-session/",
+    );
+    expect(fetchSpy).toHaveBeenLastCalledWith(
+      "/api/auth/logout",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+});

--- a/apps/frontend/src/test/trusted-sso-logout.test.ts
+++ b/apps/frontend/src/test/trusted-sso-logout.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it, vi } from "vitest";
+import { redirectToTrustedSsoLogout } from "../utils/trustedSso";
+
+describe("trusted SSO IdP logout", () => {
+  it("redirects to the validated logout URL supplied by the backend", () => {
+    const navigate = vi.fn();
+    redirectToTrustedSsoLogout(
+      "https://idp.example.test/application/o/companion/end-session/",
+      navigate,
+    );
+    expect(navigate).toHaveBeenCalledWith(
+      "https://idp.example.test/application/o/companion/end-session/",
+    );
+  });
+});

--- a/apps/frontend/src/utils/trustedSso.ts
+++ b/apps/frontend/src/utils/trustedSso.ts
@@ -1,0 +1,6 @@
+export function redirectToTrustedSsoLogout(
+  logoutUrl: string,
+  navigate: (url: string) => void = (url) => window.location.assign(url),
+): void {
+  navigate(logoutUrl);
+}

--- a/apps/frontend/src/vite-env.d.ts
+++ b/apps/frontend/src/vite-env.d.ts
@@ -5,6 +5,7 @@
 declare const __APP_NAME__: string;
 declare const __APP_SHORT_NAME__: string;
 declare const __APP_VERSION__: string;
+declare const __BUILD_REVISION__: string;
 
 interface ImportMetaEnv {
     readonly VITE_API_URL?: string;

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -53,6 +53,9 @@ export default defineConfig({
     __APP_NAME__: JSON.stringify(APP_NAME),
     __APP_SHORT_NAME__: JSON.stringify(APP_SHORT_NAME),
     __APP_VERSION__: JSON.stringify(rootPackageJson.version),
+    __BUILD_REVISION__: JSON.stringify(
+      process.env.BUILD_REVISION || "development",
+    ),
   },
   resolve: {
     // Ensure a single React instance to avoid invalid hook calls during dev HMR

--- a/deploy/sso-test/nginx.conf.template
+++ b/deploy/sso-test/nginx.conf.template
@@ -1,0 +1,34 @@
+pid /tmp/nginx.pid;
+
+events {}
+
+http {
+    access_log /dev/stdout;
+    error_log /dev/stderr warn;
+    client_body_temp_path /tmp/client_body;
+    proxy_temp_path /tmp/proxy;
+
+    server {
+        listen 8443 ssl;
+        server_name _;
+
+        ssl_certificate /etc/nginx/tls/cert.pem;
+        ssl_certificate_key /etc/nginx/tls/key.pem;
+        ssl_protocols TLSv1.2 TLSv1.3;
+
+        location / {
+            auth_basic "Trusted SSO test";
+            auth_basic_user_file /etc/nginx/auth/htpasswd;
+
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header Connection "";
+            proxy_set_header Authorization "";
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header X-Forwarded-User $remote_user;
+            proxy_set_header X-Trusted-Proxy-Secret "${TRUSTED_SSO_PROXY_SECRET}";
+            proxy_pass http://technitium-dns-companion-test:3000;
+        }
+    }
+}

--- a/docker-compose.sso-test.yml
+++ b/docker-compose.sso-test.yml
@@ -1,0 +1,75 @@
+# Test-only trusted-header SSO overlay for docker-compose.prod.test.yml.
+# Generate local credentials first with scripts/setup-trusted-sso-test.sh.
+
+services:
+  technitium-dns-companion-test:
+    environment:
+      HTTPS_ENABLED: "false"
+      TRUST_PROXY: "true"
+      TRUST_PROXY_HOPS: "1"
+      TRUSTED_SSO_ENABLED: "true"
+      TRUSTED_SSO_IDENTITY_HEADER: X-Forwarded-User
+      TRUSTED_SSO_PROXY_SECRET_HEADER: X-Trusted-Proxy-Secret
+      TRUSTED_SSO_PROXY_SECRET_FILE: /run/secrets/trusted-sso-proxy-secret
+      TRUSTED_SSO_TOKEN_MAP_FILE: /run/secrets/trusted-sso-token-map.json
+      TRUSTED_SSO_PROXY_CIDRS: ${SSO_TEST_PROXY_CIDR:-172.31.253.0/24}
+    ports:
+      - "127.0.0.1:${SSO_TEST_DIRECT_PORT:-5300}:3000"
+    volumes:
+      - type: bind
+        source: ./.sso-test/proxy-secret
+        target: /run/secrets/trusted-sso-proxy-secret
+        read_only: true
+      - type: bind
+        source: ./.sso-test/token-map.json
+        target: /run/secrets/trusted-sso-token-map.json
+        read_only: true
+
+  trusted-sso-test-proxy:
+    image: nginx:1.29-alpine
+    container_name: technitium-dns-companion-sso-test-proxy
+    restart: unless-stopped
+    depends_on:
+      - technitium-dns-companion-test
+    entrypoint:
+      - /bin/sh
+      - -ec
+      - |
+        export TRUSTED_SSO_PROXY_SECRET="$$(cat /run/secrets/trusted-sso-proxy-secret)"
+        envsubst '$$TRUSTED_SSO_PROXY_SECRET' < /etc/nginx/templates/trusted-sso.conf.template > /tmp/nginx.conf
+        exec nginx -c /tmp/nginx.conf -g 'daemon off;'
+    ports:
+      - "${PRODTEST_HOST_HTTPS_PORT:-5443}:8443"
+    volumes:
+      - type: bind
+        source: ./deploy/sso-test/nginx.conf.template
+        target: /etc/nginx/templates/trusted-sso.conf.template
+        read_only: true
+      - type: bind
+        source: ./.sso-test/proxy-secret
+        target: /run/secrets/trusted-sso-proxy-secret
+        read_only: true
+      - type: bind
+        source: ./.sso-test/htpasswd
+        target: /etc/nginx/auth/htpasswd
+        read_only: true
+      - type: bind
+        source: ./.sso-test/tls
+        target: /etc/nginx/tls
+        read_only: true
+    read_only: true
+    tmpfs:
+      - /var/cache/nginx
+      - /var/run
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      technitium-dns-companion-network:
+        ipv4_address: ${SSO_TEST_PROXY_IP:-172.31.253.10}
+
+networks:
+  technitium-dns-companion-network:
+    ipam:
+      config:
+        - subnet: ${SSO_TEST_PROXY_CIDR:-172.31.253.0/24}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   technitium-dns-companion:
     # Production default: pull the published image. For local builds, use:
     # docker compose -f docker-compose.yml -f docker-compose.local-build.yml up -d --build
-    image: ghcr.io/fail-safe/technitium-dns-companion:latest
+    image: ${COMPANION_IMAGE:-ghcr.io/fail-safe/technitium-dns-companion:latest}
     # Stable name retained for compatibility with existing scripts and tooling.
     container_name: technitium-dns-companion
     restart: unless-stopped

--- a/docs/BETA_TESTING.md
+++ b/docs/BETA_TESTING.md
@@ -1,0 +1,75 @@
+# Beta Testing
+
+The beta channel is an opt-in preview of the current `next` branch. It is for
+operators who can tolerate regressions, retain a rollback path, and report the
+exact build they tested. Stable installations continue to use `:latest` unless
+their image is explicitly changed.
+
+## Before you start
+
+- Back up persistent Companion data and any configuration files you manage.
+- Keep the previous stable image available until the soak test is complete.
+- Do not test first on the only path you have to administer DNS.
+- Review the current [Unreleased changelog](../CHANGELOG.md#unreleased), with
+  particular attention to upgrade notes and security-sensitive features.
+
+## Install with Docker Compose
+
+Set this in the `.env` file next to `docker-compose.yml`:
+
+```bash
+COMPANION_IMAGE=ghcr.io/fail-safe/technitium-dns-companion:beta
+```
+
+Then pull, recreate, and confirm health:
+
+```bash
+docker compose pull
+docker compose up -d
+docker compose ps
+```
+
+The `beta` and `next` tags are rolling aliases. For a longer test or a reliable
+reproduction, replace `:beta` with the immutable `sha-<commit>` tag associated
+with the build.
+
+## Record the exact build
+
+The About dialog shows the application version and short source revision. The
+complete revision is also stored in the image metadata:
+
+```bash
+docker image inspect \
+  ghcr.io/fail-safe/technitium-dns-companion:beta \
+  --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}'
+```
+
+Include that revision, the image digest, your Technitium DNS version, browser,
+deployment shape, and concise reproduction steps in beta reports. Redact API
+tokens, proxy secrets, cookies, private hostnames, and private DNS data.
+
+## Suggested soak checks
+
+- Sign in and out, then confirm the expected Technitium identity and RBAC.
+- Check node overview, query logs, zones, filtering, DHCP, and any scheduled
+  automation you normally use.
+- Exercise the deployment behind its real TLS reverse proxy and from a mobile
+  viewport if those are part of your environment.
+- Watch container health, restarts, memory, and logs over at least 24 hours.
+- If testing trusted-header SSO, keep a separately verified break-glass path
+  and follow the dedicated [SSO guide](features/TRUSTED_HEADER_SSO.md).
+
+## Roll back
+
+Change the Compose override back to stable:
+
+```bash
+COMPANION_IMAGE=ghcr.io/fail-safe/technitium-dns-companion:latest
+docker compose pull
+docker compose up -d
+```
+
+If stable moved during the test, pin the previous known-good `sha-<commit>` tag
+instead. Restore persistent data only when the beta changed durable state and
+the relevant feature documentation calls for it; a normal image-only rollback
+should not replace data unnecessarily.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ Welcome to the documentation for Technitium DNS Companion. This guide will help 
 
 - **[../README.md](../README.md)** - Project overview and quick start
 - **[../DOCKER.md](../DOCKER.md)** - Docker deployment guide (production & development)
+- **[BETA_TESTING.md](./BETA_TESTING.md)** - Opt-in beta soak testing, reporting, and rollback
 - **[../DEVELOPMENT.md](../DEVELOPMENT.md)** - Development setup and contributing guide
 
 ### Architecture & Design
@@ -62,6 +63,7 @@ Detailed documentation for specific features:
 
 - **[features/HEALTH_CHECK_API.md](./features/HEALTH_CHECK_API.md)** - Health check API for monitoring and Docker health checks
 - **[features/SESSION_AUTH_AND_TOKEN_MIGRATION.md](./features/SESSION_AUTH_AND_TOKEN_MIGRATION.md)** - Session auth (v1.2+) overview, recommended deployment model, Technitium permissions map, and cluster-token → background-token migration
+- **[features/TRUSTED_HEADER_SSO.md](./features/TRUSTED_HEADER_SSO.md)** - Hardened trusted-proxy SSO, per-user token maps, rotation, break-glass access, and reverse-proxy requirements
 - **[features/TECHNITIUM_VERSION_COMPATIBILITY.md](./features/TECHNITIUM_VERSION_COMPATIBILITY.md)** - Technitium DNS v14/v15 API compatibility baseline and upgrade notes
 - **[features/AUTHENTICATION_DECISION.md](./features/AUTHENTICATION_DECISION.md)** - Authentication approach and token strategy rationale
 - **[features/CONFIG_CHANGE_DETECTION.md](./features/CONFIG_CHANGE_DETECTION.md)** - Unsaved changes detection

--- a/docs/features/TRUSTED_HEADER_SSO.md
+++ b/docs/features/TRUSTED_HEADER_SSO.md
@@ -1,0 +1,308 @@
+# Trusted-header SSO
+
+Trusted-header SSO lets an authenticating reverse proxy sign users into
+Technitium DNS Companion without sending passwords to Companion. It is disabled
+by default and is an additive authentication option intended for a minor
+release.
+
+The security boundary has three parts:
+
+1. the request is HTTPS as observed by Companion;
+2. the immediate socket peer is in an optional configured proxy CIDR; and
+3. the proxy supplies exactly one valid identity header and a matching secret.
+
+An identity header or `X-Forwarded-Proto` alone is never sufficient. The proxy
+must remove client-supplied assertion headers and inject replacements only after
+successful authentication.
+
+## Authorization model
+
+Every SSO identity maps exactly to one Technitium username and one cluster-wide
+API token. Technitium replicates users, permissions, and API tokens created on
+the Primary to every node in its cluster. Companion validates the same token
+against every configured node with
+`/api/user/session/get` and requires the returned owner to equal the configured
+username before creating a session. Unreachable nodes may produce the existing
+degraded partial session; an invalid token or owner mismatch fails the complete
+login.
+
+Companion retains at most eight active trusted-SSO sessions for one mapped
+identity. Creating a ninth evicts that identity's oldest SSO session without
+affecting password sessions or another identity. This supports normal
+multi-device use while bounding server-side session state.
+
+Trusted SSO therefore expects all configured Companion nodes to belong to the
+same Technitium cluster. Independent clusters or standalone nodes require
+separate Companion deployments for this authentication mode.
+
+Shared-account mode and fallback for unmapped identities are intentionally not
+supported. Both would make multiple people operate as one Technitium principal,
+collapsing per-user RBAC and audit attribution.
+
+## Configuration
+
+```dotenv
+TRUSTED_SSO_ENABLED=true
+TRUSTED_SSO_IDENTITY_HEADER=X-Forwarded-User
+TRUSTED_SSO_PROXY_SECRET_HEADER=X-Trusted-Proxy-Secret
+TRUSTED_SSO_PROXY_SECRET_FILE=/run/secrets/companion_sso_proxy_secret
+TRUSTED_SSO_PROXY_CIDRS=172.20.0.0/16,2001:db8:1234::/64
+TRUSTED_SSO_TOKEN_MAP_FILE=/data/trusted-sso-token-map.json
+TRUSTED_SSO_LOGOUT_URL=https://idp.example.com/application/o/companion/end-session/
+TRUST_PROXY=true
+TRUST_PROXY_HOPS=1
+```
+
+`TRUSTED_SSO_PROXY_SECRET` may be set directly, but the `_FILE` form is
+recommended. The value must be at least 32 characters. Generate it with a
+cryptographically secure secret manager or random-byte generator and never put
+it in source control.
+
+`TRUSTED_SSO_PROXY_CIDRS` accepts comma-separated IPv4 and IPv6 CIDRs and checks
+the immediate socket peer, not `X-Forwarded-For`. When CIDRs are present,
+password login is available only to direct clients outside them. When CIDRs are
+omitted, every request is expected to arrive through the authenticating proxy
+and password login is disabled while SSO is enabled.
+
+`TRUSTED_SSO_LOGOUT_URL` is optional and must be an HTTPS URL or a relative path
+beginning with a single slash. With a URL, logout clears the local session and
+redirects to the identity provider. Without one, logout clears the local
+session, pauses automatic SSO login in the browser tab, and displays **Continue
+with SSO**.
+
+The application validates all enabled SSO configuration once during startup.
+Invalid headers, CIDRs, secrets, URLs, or token-map schemas stop the backend
+instead of silently weakening authentication.
+
+## Token map
+
+Create a separate Technitium user for each person on the cluster Primary, grant
+only the permissions that person needs, and create one API token owned by that
+user on the Primary through **Administration → Sessions → Create Token** or
+`/api/admin/sessions/createToken`. Save the returned token immediately.
+Technitium synchronizes the user, permissions, and API token to its Secondary
+nodes. Store the mapping in a root-readable file mounted read-only into the
+container:
+
+```json
+{
+  "version": 1,
+  "identities": {
+    "alice@example.com": {
+      "username": "alice",
+      "token": "cluster-token-created-for-alice"
+    },
+    "bob@example.com": {
+      "username": "bob",
+      "token": "cluster-token-created-for-bob"
+    }
+  }
+}
+```
+
+Identity matching is exact and case-sensitive. Companion expands the replicated
+cluster token into its server-side per-node session state only for nodes that
+successfully validate it. Tokens never enter the browser or API response.
+
+Technitium documents that API tokens created on the cluster Primary are
+synchronized to every node, while ordinary interactive login sessions remain
+node-local. See [Understanding Clustering And How To Configure It](https://blog.technitium.com/2025/11/understanding-clustering-and-how-to.html).
+
+### Rotation
+
+1. Create a replacement token under the same Technitium principal on the
+   cluster Primary and allow it to synchronize to the Secondary nodes.
+2. Write a complete version-1 map to a new file, set restrictive file
+   permissions, and atomically replace the mounted map.
+3. Restart Companion so it loads and validates the new configuration.
+4. Sign in through SSO and verify the expected username and node access.
+5. Revoke the old tokens in Technitium.
+
+Restarting clears all in-memory Companion sessions, so no session continues to
+hold an old mapped token after the cutover. Rotate the proxy secret separately
+as a coordinated proxy-and-Companion change; the current configuration accepts
+one secret at a time.
+
+## Test without an OIDC provider
+
+Companion consumes authenticated proxy assertions and does not implement the
+OIDC exchange itself. The repository includes a test-only Compose overlay that
+uses nginx Basic Auth to exercise the same identity-header contract without an
+IdP.
+
+Prepare local test credentials and a short-lived self-signed certificate:
+
+```bash
+./scripts/setup-trusted-sso-test.sh
+```
+
+The script prompts for the asserted identity, its Technitium username, the
+cluster-wide API token, and a temporary Basic Auth password. Secret material is
+written with restrictive permissions beneath the ignored `.sso-test/`
+directory and is never printed.
+
+Build, validate, and start the isolated production-test stack:
+
+```bash
+docker build -t technitium-dns-companion:prodtest -f Dockerfile .
+docker compose \
+  -f docker-compose.prod.test.yml \
+  -f docker-compose.sso-test.yml \
+  config --quiet
+docker compose \
+  -f docker-compose.prod.test.yml \
+  -f docker-compose.sso-test.yml \
+  up -d
+```
+
+The authenticated proxy listens on port `5443` by default. The browser will
+require explicit trust for the generated certificate and then prompt for the
+temporary Basic Auth credentials. The direct Companion HTTP port is bound only
+to `127.0.0.1:5300` for negative assertion-spoofing checks from the Docker host.
+
+Verify that an identity header without the proxy secret cannot establish a
+session:
+
+```bash
+curl -i \
+  -H 'X-Forwarded-Proto: https' \
+  -H 'X-Forwarded-User: your-test-identity' \
+  http://127.0.0.1:5300/api/auth/me
+```
+
+The response must remain unauthenticated and must not create a session cookie.
+To stop the harness without deleting `.dev-data` or `.sso-test`:
+
+```bash
+docker compose \
+  -f docker-compose.prod.test.yml \
+  -f docker-compose.sso-test.yml \
+  down --remove-orphans
+```
+
+Basic Auth is only a stand-in for local validation. Do not deploy this overlay
+as the production identity provider.
+
+## Reverse-proxy requirements
+
+All examples use placeholders. Keep the proxy secret in the proxy's secret
+store or deployment templating, not in a committed configuration file. Restrict
+network access to Companion so untrusted clients cannot bypass the proxy. Set
+`TRUSTED_SSO_PROXY_CIDRS` to the actual proxy network whenever a separate direct
+break-glass route is required.
+
+### nginx
+
+This example uses `auth_request`. The authentication endpoint must return the
+verified identity in `X-Auth-Request-User` only on success.
+
+```nginx
+location = /_auth {
+    internal;
+    proxy_pass http://forward-auth/verify;
+    proxy_pass_request_body off;
+    proxy_set_header Content-Length "";
+    proxy_set_header X-Original-URI $request_uri;
+    proxy_set_header X-Forwarded-User "";
+    proxy_set_header X-Trusted-Proxy-Secret "";
+}
+
+location / {
+    auth_request /_auth;
+    auth_request_set $sso_user $upstream_http_x_auth_request_user;
+
+    proxy_set_header X-Forwarded-User $sso_user;
+    proxy_set_header X-Trusted-Proxy-Secret "__READ_FROM_PROXY_SECRET_STORE__";
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Host $host;
+    proxy_pass http://technitium-dns-companion:3000;
+}
+```
+
+An empty `proxy_set_header` value prevents the original field from being
+forwarded, while setting a value replaces it. Do not derive `$sso_user` from a
+client request header.
+
+### Caddy
+
+`request_header` removes incoming assertion fields before `forward_auth`.
+`copy_headers` then copies the identity from the successful authentication
+response. `header_up` overwrites the secret sent to Companion.
+
+```caddyfile
+companion.example.com {
+    request_header -X-Forwarded-User
+    request_header -X-Trusted-Proxy-Secret
+
+    forward_auth forward-auth:4181 {
+        uri /verify
+        copy_headers X-Forwarded-User
+    }
+
+    reverse_proxy technitium-dns-companion:3000 {
+        header_up X-Trusted-Proxy-Secret {$TRUSTED_SSO_PROXY_SECRET}
+    }
+}
+```
+
+The authentication service must emit `X-Forwarded-User` only after it has
+authenticated the request.
+
+### Traefik
+
+Apply middleware in the shown order: remove client assertions, authenticate and
+copy the verified identity, then inject the Companion secret.
+
+```yaml
+http:
+  middlewares:
+    strip-client-assertions:
+      headers:
+        customRequestHeaders:
+          X-Forwarded-User: ""
+          X-Trusted-Proxy-Secret: ""
+
+    companion-forward-auth:
+      forwardAuth:
+        address: http://forward-auth:4181/verify
+        authResponseHeaders:
+          - X-Forwarded-User
+
+    inject-companion-secret:
+      headers:
+        customRequestHeaders:
+          X-Trusted-Proxy-Secret: "__READ_FROM_PROXY_SECRET_STORE__"
+
+  routers:
+    companion:
+      rule: Host(`companion.example.com`)
+      service: companion
+      middlewares:
+        - strip-client-assertions
+        - companion-forward-auth
+        - inject-companion-secret
+
+  services:
+    companion:
+      loadBalancer:
+        servers:
+          - url: http://technitium-dns-companion:3000
+```
+
+Traefik's `authResponseHeaders` replaces a conflicting forwarded request header.
+The explicit stripping middleware also prevents the untrusted values from being
+sent to the authentication service.
+
+## Runtime behavior
+
+- `/api/auth/me` reports whether SSO is enabled, available for the current
+  request, and whether direct password login is allowed.
+- `/api/auth/sso/login` is the only endpoint that creates an SSO session. It
+  validates mapped tokens through `TechnitiumService`, single-flights concurrent
+  validation for one identity, and applies a five-second cooldown after failure.
+- Every later API request must carry the same valid assertion. Missing,
+  malformed, or changed assertions delete the local SSO session and clear its
+  cookie before protected work runs.
+- Password sessions keep their existing upstream Technitium token revocation on
+  logout. SSO logout removes only the local session because the mapped tokens
+  are managed and rotated by the operator.

--- a/scripts/setup-trusted-sso-test.sh
+++ b/scripts/setup-trusted-sso-test.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+SSO_TEST_DIR="$PROJECT_ROOT/.sso-test"
+TOKEN_MAP_PATH="$SSO_TEST_DIR/token-map.json"
+PROXY_SECRET_PATH="$SSO_TEST_DIR/proxy-secret"
+HTPASSWD_PATH="$SSO_TEST_DIR/htpasswd"
+TLS_DIR="$SSO_TEST_DIR/tls"
+
+for command_name in node openssl htpasswd; do
+	if ! command -v "$command_name" >/dev/null 2>&1; then
+		echo "Required command not found: $command_name" >&2
+		exit 1
+	fi
+done
+
+read_value() {
+	local prompt="$1"
+	local default_value="${2:-}"
+	local result
+	if [ -n "$default_value" ]; then
+		printf "%s [%s]: " "$prompt" "$default_value" >&2
+	else
+		printf "%s: " "$prompt" >&2
+	fi
+	IFS= read -r result
+	printf "%s" "${result:-$default_value}"
+}
+
+identity="$(read_value "Asserted SSO identity")"
+technitium_user="$(read_value "Technitium username" "$identity")"
+test_hostname="$(read_value "Test proxy hostname" "localhost")"
+
+identity_pattern='^[A-Za-z0-9][A-Za-z0-9._@+-]{0,254}$'
+if [[ ! "$identity" =~ $identity_pattern ]]; then
+	echo "The asserted identity does not match Companion's accepted identity format." >&2
+	exit 1
+fi
+if [[ ! "$technitium_user" =~ $identity_pattern ]]; then
+	echo "The Technitium username does not match Companion's accepted username format." >&2
+	exit 1
+fi
+if [ -z "$test_hostname" ] || [[ "$test_hostname" == *[[:space:]]* ]]; then
+	echo "The test proxy hostname must be a non-empty hostname or IP address." >&2
+	exit 1
+fi
+
+printf "Technitium cluster API token (input hidden): " >&2
+IFS= read -r -s cluster_token
+printf "\n" >&2
+if [ -z "$cluster_token" ]; then
+	echo "The Technitium cluster API token cannot be empty." >&2
+	exit 1
+fi
+
+umask 077
+mkdir -p "$TLS_DIR"
+
+openssl rand -hex 32 >"$PROXY_SECRET_PATH"
+
+# The single-quoted JavaScript program must reach Node without shell expansion.
+# shellcheck disable=SC2016
+printf '%s\0%s\0%s\0' "$identity" "$technitium_user" "$cluster_token" |
+	node -e '
+const fs = require("node:fs");
+const [identity, username, token] = fs.readFileSync(0, "utf8").split("\0");
+const outputPath = process.argv[1];
+const document = {
+  version: 1,
+  identities: { [identity]: { username, token } },
+};
+fs.writeFileSync(outputPath, `${JSON.stringify(document, null, 2)}\n`, {
+  mode: 0o600,
+});
+' "$TOKEN_MAP_PATH"
+unset cluster_token
+
+echo "Choose a temporary Basic Auth password for $identity."
+htpasswd -cB "$HTPASSWD_PATH" "$identity"
+
+if [[ "$test_hostname" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+	subject_alt_name="IP:$test_hostname,IP:127.0.0.1,DNS:localhost"
+else
+	subject_alt_name="DNS:$test_hostname,DNS:localhost,IP:127.0.0.1"
+fi
+
+openssl req \
+	-x509 \
+	-newkey rsa:2048 \
+	-sha256 \
+	-nodes \
+	-days 14 \
+	-subj "/CN=$test_hostname" \
+	-addext "subjectAltName=$subject_alt_name" \
+	-keyout "$TLS_DIR/key.pem" \
+	-out "$TLS_DIR/cert.pem" \
+	>/dev/null 2>&1
+
+chmod 600 "$PROXY_SECRET_PATH" "$TOKEN_MAP_PATH" "$HTPASSWD_PATH" "$TLS_DIR/key.pem"
+chmod 644 "$TLS_DIR/cert.pem"
+
+echo
+echo "Trusted SSO test assets created in .sso-test/."
+echo "No secret or token value was printed."
+echo
+echo "Validate the Compose model:"
+echo "  docker compose -f docker-compose.prod.test.yml -f docker-compose.sso-test.yml config --quiet"
+echo
+echo "Build and start the test stack:"
+echo "  docker build -t technitium-dns-companion:prodtest -f Dockerfile ."
+echo "  docker compose -f docker-compose.prod.test.yml -f docker-compose.sso-test.yml up -d"


### PR DESCRIPTION
## Summary

- add opt-in trusted-header SSO with exact identity-to-Technitium-user mapping, fail-closed proxy assertions, per-node token-owner validation, assertion-bound sessions, and deliberate IdP/local logout
- bound trusted-SSO sessions to eight per mapped identity after a pre-publication security scan found an unbounded session-growth path
- add an opt-in beta Compose image override, immutable sha image tags, source revision in About/OCI metadata, and a beta testing/rollback guide
- gate Docker publication on lint, unit tests, backend E2E, and the full build; explicitly republish next after release reconciliation

## Security boundary

SSO remains disabled by default. A valid request requires HTTPS as observed by Companion, exactly one configured identity header, a timing-safe shared-secret match, optional immediate-peer CIDR validation, an exact token-map identity, and matching Technitium token ownership on every reachable node. Mapped tokens remain server-side.

A diff-scoped Codex Security review covered all changed source plus deployment, test, configuration, and documentation artifacts. It found one low-severity CWE-400 session-cardinality issue; this PR fixes it with per-identity bounded eviction and regression coverage. No authentication bypass or secret exposure was found.

## Validation

- backend unit: 436 passed, 9 skipped
- frontend unit: 777 passed, 43 todo
- backend E2E: 12 passed
- frontend and non-mutating backend lint: passed
- full backend + frontend build: passed
- build revision injection: passed
- Docker Compose and workflow YAML parsing: passed
- local Docker image smoke: not run because the configured OrbStack daemon socket was unavailable; the gated Docker workflow supplies multi-arch build proof after merge

## Beta operation

Stable remains `:latest`. Testers opt in with `COMPANION_IMAGE=ghcr.io/fail-safe/technitium-dns-companion:beta`; each publication also receives an immutable `sha-<commit>` tag for reproduction and rollback.