### PR TITLE
ci: update setup-node action runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/technitium-v15-compatibility.yml
+++ b/.github/workflows/technitium-v15-compatibility.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## Summary

- update the three active Node-based validation workflows from actions/setup-node v4 to the current v7 release
- remove the GitHub runner warning that v4 targets deprecated Node 20 and is being force-run on Node 24

## Evidence

The warning was emitted by both merged next workflow runs. Current official setup-node documentation recommends v7; the repository uses none of the removed authentication inputs, and its explicit npm cache configuration remains supported.

## Validation

- workflow YAML parsing passed for all three files
- diff check passed
- pre-push backend tests: 436 passed, 9 skipped
- pre-push frontend tests: 777 passed, 43 todo