### PR TITLE
fix: identify beta builds in About dialog

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -81,6 +81,18 @@ jobs:
           PKG_VERSION: ${{ steps.package-version.outputs.version }}
         run: echo "major_minor=${PKG_VERSION%.*}" >> "$GITHUB_OUTPUT"
 
+      - name: Derive build channel
+        id: build-channel
+        env:
+          BUILD_REF: ${{ github.ref }}
+        run: |
+          case "$BUILD_REF" in
+            refs/heads/next) channel=beta ;;
+            refs/tags/v*) channel=stable ;;
+            *) channel=preview ;;
+          esac
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -127,6 +139,7 @@ jobs:
           build-args: |
             BUILD_VERSION=${{ steps.package-version.outputs.version }}
             BUILD_REVISION=${{ github.sha }}
+            BUILD_CHANNEL=${{ steps.build-channel.outputs.channel }}
           cache-from: ${{ inputs.no_cache && '' || 'type=gha' }}
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Release reconciliation now explicitly republishes the updated `next` branch, preventing GitHub's workflow-token fan-out suppression from leaving the rolling `:beta` image behind the branch.
+- The About dialog now identifies beta and other preview builds explicitly and reports the latest stable release separately instead of saying a beta build is simply “up to date.”
 
 ### Testing
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY apps/frontend/package.json ./apps/frontend/
 FROM --platform=$BUILDPLATFORM node:24-alpine3.22 AS frontend-builder
 ARG BUILDPLATFORM
 ARG BUILD_REVISION=unknown
+ARG BUILD_CHANNEL=development
 ARG NPM_VERSION
 
 WORKDIR /app
@@ -39,7 +40,7 @@ RUN --mount=type=cache,target=/root/.npm \
 COPY apps/frontend/ ./apps/frontend/
 
 # Build frontend
-RUN BUILD_REVISION="$BUILD_REVISION" npm run build --workspace=apps/frontend
+RUN BUILD_REVISION="$BUILD_REVISION" BUILD_CHANNEL="$BUILD_CHANNEL" npm run build --workspace=apps/frontend
 
 # Stage 2: Build backend
 FROM --platform=$BUILDPLATFORM node:24-alpine3.22 AS backend-builder
@@ -81,6 +82,7 @@ FROM node:24-alpine3.22
 
 ARG BUILD_VERSION=unknown
 ARG BUILD_REVISION=unknown
+ARG BUILD_CHANNEL=development
 
 LABEL \
     org.opencontainers.image.title="Technitium DNS Companion" \
@@ -90,7 +92,8 @@ LABEL \
     org.opencontainers.image.documentation="https://fail-safe.github.io/Technitium-DNS-Companion" \
     org.opencontainers.image.licenses="MIT" \
     org.opencontainers.image.version="$BUILD_VERSION" \
-    org.opencontainers.image.revision="$BUILD_REVISION"
+    org.opencontainers.image.revision="$BUILD_REVISION" \
+    io.github.fail-safe.technitium-dns-companion.build-channel="$BUILD_CHANNEL"
 
 WORKDIR /app
 

--- a/apps/frontend/src/components/common/AboutModal.css
+++ b/apps/frontend/src/components/common/AboutModal.css
@@ -116,6 +116,24 @@
   font-size: 0.8rem;
 }
 
+.about-modal__channel {
+  display: inline-block;
+  padding: 0.2rem 0.55rem;
+  border: 1px solid var(--color-warning);
+  border-radius: 999px;
+  background: var(--color-warning-bg);
+  color: var(--color-warning-dark);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+}
+
+.about-modal__channel--development {
+  border-color: var(--color-border);
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-secondary);
+}
+
 .about-modal__update-pill {
   display: inline-flex;
   align-items: center;
@@ -143,6 +161,10 @@
 
 .about-modal__version-status--ok {
   color: var(--color-success-text);
+}
+
+.about-modal__version-status--preview {
+  color: var(--color-warning-dark);
 }
 
 .about-modal__version-status--error {

--- a/apps/frontend/src/components/common/AboutModal.tsx
+++ b/apps/frontend/src/components/common/AboutModal.tsx
@@ -7,6 +7,10 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useLatestRelease } from "../../hooks/useLatestRelease";
+import {
+  describeBuildChannel,
+  formatBuildChannelStatus,
+} from "../../utils/build-channel";
 import "./AboutModal.css";
 
 interface AboutModalProps {
@@ -26,6 +30,12 @@ export function AboutModal({ isOpen, onClose }: AboutModalProps) {
     isUpdateAvailable,
     error: versionCheckError,
   } = useLatestRelease(__APP_VERSION__);
+  const buildChannel = describeBuildChannel(__BUILD_CHANNEL__);
+  const buildChannelStatus = formatBuildChannelStatus(
+    buildChannel,
+    latestVersion,
+    Boolean(versionCheckError),
+  );
 
   if (!isOpen) return null;
 
@@ -71,6 +81,13 @@ export function AboutModal({ isOpen, onClose }: AboutModalProps) {
           </h2>
           <div className="about-modal__version-row">
             <span className="about-modal__version">v{__APP_VERSION__}</span>
+            {buildChannel.badge && (
+              <span
+                className={`about-modal__channel about-modal__channel--${buildChannel.kind}`}
+              >
+                {buildChannel.badge}
+              </span>
+            )}
             {buildRevision && (
               <span
                 className="about-modal__revision"
@@ -81,7 +98,11 @@ export function AboutModal({ isOpen, onClose }: AboutModalProps) {
             )}
           </div>
           <div className="about-modal__version-check">
-            {isUpdateAvailable && latestVersion ?
+            {buildChannelStatus ?
+              <span className="about-modal__version-status about-modal__version-status--preview">
+                {buildChannelStatus}
+              </span>
+            : isUpdateAvailable && latestVersion ?
               <a
                 href={
                   latestReleaseUrl ||

--- a/apps/frontend/src/test/build-channel.test.ts
+++ b/apps/frontend/src/test/build-channel.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  describeBuildChannel,
+  formatBuildChannelStatus,
+} from "../utils/build-channel";
+
+describe("build channel presentation", () => {
+  it("identifies beta builds without treating stable equality as update status", () => {
+    const details = describeBuildChannel("beta");
+
+    expect(details).toEqual({
+      kind: "beta",
+      badge: "BETA",
+      statusLabel: "Running beta preview",
+    });
+    expect(formatBuildChannelStatus(details, "1.10.1", false)).toBe(
+      "Running beta preview · Latest stable: v1.10.1",
+    );
+  });
+
+  it("leaves stable builds on the release update path", () => {
+    const details = describeBuildChannel("stable");
+
+    expect(details).toEqual({
+      kind: "stable",
+      badge: null,
+      statusLabel: null,
+    });
+    expect(formatBuildChannelStatus(details, "1.10.1", false)).toBeNull();
+  });
+
+  it("marks local builds as development builds", () => {
+    const details = describeBuildChannel(" development ");
+
+    expect(details.kind).toBe("development");
+    expect(details.badge).toBe("DEV");
+    expect(formatBuildChannelStatus(details, null, false)).toBe(
+      "Development build",
+    );
+  });
+
+  it("fails unknown channels into an explicit preview state", () => {
+    const details = describeBuildChannel("unexpected-channel");
+
+    expect(details.kind).toBe("preview");
+    expect(details.badge).toBe("PREVIEW");
+    expect(formatBuildChannelStatus(details, null, true)).toBe(
+      "Running preview build · Stable release check unavailable",
+    );
+  });
+});

--- a/apps/frontend/src/utils/build-channel.ts
+++ b/apps/frontend/src/utils/build-channel.ts
@@ -1,0 +1,60 @@
+export type BuildChannelKind =
+  | "stable"
+  | "beta"
+  | "preview"
+  | "development";
+
+export interface BuildChannelDetails {
+  kind: BuildChannelKind;
+  badge: string | null;
+  statusLabel: string | null;
+}
+
+export const describeBuildChannel = (
+  rawChannel: string,
+): BuildChannelDetails => {
+  const channel = rawChannel.trim().toLowerCase();
+
+  switch (channel) {
+    case "stable":
+      return { kind: "stable", badge: null, statusLabel: null };
+    case "beta":
+      return {
+        kind: "beta",
+        badge: "BETA",
+        statusLabel: "Running beta preview",
+      };
+    case "development":
+      return {
+        kind: "development",
+        badge: "DEV",
+        statusLabel: "Development build",
+      };
+    default:
+      return {
+        kind: "preview",
+        badge: "PREVIEW",
+        statusLabel: "Running preview build",
+      };
+  }
+};
+
+export const formatBuildChannelStatus = (
+  details: BuildChannelDetails,
+  latestStableVersion: string | null,
+  stableCheckUnavailable: boolean,
+): string | null => {
+  if (!details.statusLabel) {
+    return null;
+  }
+
+  if (latestStableVersion) {
+    return `${details.statusLabel} · Latest stable: v${latestStableVersion}`;
+  }
+
+  if (stableCheckUnavailable) {
+    return `${details.statusLabel} · Stable release check unavailable`;
+  }
+
+  return details.statusLabel;
+};

--- a/apps/frontend/src/vite-env.d.ts
+++ b/apps/frontend/src/vite-env.d.ts
@@ -6,6 +6,7 @@ declare const __APP_NAME__: string;
 declare const __APP_SHORT_NAME__: string;
 declare const __APP_VERSION__: string;
 declare const __BUILD_REVISION__: string;
+declare const __BUILD_CHANNEL__: string;
 
 interface ImportMetaEnv {
     readonly VITE_API_URL?: string;

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -56,6 +56,9 @@ export default defineConfig({
     __BUILD_REVISION__: JSON.stringify(
       process.env.BUILD_REVISION || "development",
     ),
+    __BUILD_CHANNEL__: JSON.stringify(
+      process.env.BUILD_CHANNEL || "development",
+    ),
   },
   resolve: {
     // Ensure a single React instance to avoid invalid hook calls during dev HMR

--- a/docs/BETA_TESTING.md
+++ b/docs/BETA_TESTING.md
@@ -35,13 +35,14 @@ with the build.
 
 ## Record the exact build
 
-The About dialog shows the application version and short source revision. The
-complete revision is also stored in the image metadata:
+The About dialog labels the build as **BETA**, shows the application version and
+short source revision, and reports the latest stable release separately. The
+complete revision and build channel are also stored in the image metadata:
 
 ```bash
 docker image inspect \
   ghcr.io/fail-safe/technitium-dns-companion:beta \
-  --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}'
+  --format 'revision={{ index .Config.Labels "org.opencontainers.image.revision" }} channel={{ index .Config.Labels "io.github.fail-safe.technitium-dns-companion.build-channel" }}'
 ```
 
 Include that revision, the image digest, your Technitium DNS version, browser,


### PR DESCRIPTION
## Summary

- inject an explicit stable, beta, or preview channel into published frontend builds
- label non-stable builds in the About dialog and report the latest stable release separately
- expose the build channel in container metadata and beta testing guidance

## Validation

- frontend lint
- backend non-mutating lint
- backend 436 tests passed, 9 skipped
- frontend 781 tests passed, 43 todo
- backend E2E 12/12
- full beta-channel build
- workflow YAML parse and Docker Buildx check