### PR TITLE
chore: sync fast-uri security update to next

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10188,9 +10188,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

- carry the patched fast-uri 3.1.6 lockfile entry from #103 into the active next branch
- preserve main-to-next ancestry after the dependency security hotfix

## Validation

- isolated install, lint, unit tests, backend E2E, and full build passed on the exact Dependabot commit
- Technitium 15.3 and 15.4 compatibility workflow passed
- non-publishing multi-platform Docker build passed