### PR TITLE
feat: isolate credentials and routing across Technitium groups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,18 @@ TECHNITIUM_NODE2_NAME="DNS Secondary"
 TECHNITIUM_NODE1_BASE_URL=https://dns-primary.example.com:53443
 TECHNITIUM_NODE2_BASE_URL=https://dns-secondary.example.com:53443
 
+## Node groups - REQUIRED when managing more than one independent cluster
+#
+# A group is Companion's network and credential boundary for one Technitium
+# cluster (or one standalone site). IDs are case-sensitive lowercase slugs:
+# [a-z0-9][a-z0-9._-]{0,62}. Names beginning with "__" are reserved.
+#
+# If every GROUP variable is omitted, all nodes use the internal __default__
+# group and retain legacy single-cluster behavior. If any node declares a
+# group, every node in TECHNITIUM_NODES must declare one or startup fails.
+# TECHNITIUM_NODE1_GROUP=site-a
+# TECHNITIUM_NODE2_GROUP=site-a
+
 ## Legacy only: Per-node tokens (optional)
 # TECHNITIUM_NODE1_TOKEN=token-for-node1
 # TECHNITIUM_NODE2_TOKEN=token-for-node2
@@ -136,7 +148,7 @@ TECHNITIUM_NODE2_BASE_URL=https://dns-secondary.example.com:53443
 #
 # Trusted SSO accepts identity only from an authenticating reverse proxy. It
 # preserves Technitium RBAC by mapping every SSO identity to a distinct
-# Technitium username and one cluster-wide API token created on the Primary.
+# Technitium username and cluster-wide API token for each authorized group.
 # See docs/features/TRUSTED_HEADER_SSO.md before enabling this feature.
 #
 # TRUSTED_SSO_ENABLED=false
@@ -166,11 +178,17 @@ TECHNITIUM_NODE2_BASE_URL=https://dns-secondary.example.com:53443
 # Do NOT reuse a full admin token.
 #
 # TECHNITIUM_BACKGROUND_TOKEN=your-readonly-token
+# Explicit grouped deployments use a strict version-1 group map instead:
+# TECHNITIUM_BACKGROUND_TOKEN_MAP_FILE=/data/background-token-map.json
+# Do not configure both the scalar token and map file.
 
 ## Write-capable automation token (DNS Schedules and Configuration Sync)
 # Create a dedicated Technitium token with Apps: Modify permission.
-# Add Cache: Modify only when DNS Schedules use cache flushing.
+# Add Cache: Delete only when DNS Schedules use cache flushing.
 # TECHNITIUM_SCHEDULE_TOKEN=your-automation-token
+# Explicit grouped deployments use a strict version-1 group map instead:
+# TECHNITIUM_SCHEDULE_TOKEN_MAP_FILE=/data/schedule-token-map.json
+# A map may omit groups where this automation role is intentionally disabled.
 
 ## Scheduled Advanced Blocking Configuration Sync (optional)
 # Copies the complete Advanced Blocking config from one standalone source node

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,10 +19,22 @@ on:
         required: false
         type: boolean
         default: false
+      channel:
+        description: "Publication channel for manual runs"
+        required: true
+        type: choice
+        options:
+          - preview
+          - beta
+        default: preview
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+
+concurrency:
+  group: docker-publish-${{ github.event_name == 'workflow_dispatch' && inputs.channel == 'beta' && 'beta' || github.ref }}
+  cancel-in-progress: false
 
 jobs:
   quality:
@@ -34,6 +46,18 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+
+      - name: Validate beta promotion source
+        if: github.event_name == 'workflow_dispatch' && inputs.channel == 'beta'
+        shell: bash
+        run: |
+          case "$GITHUB_REF" in
+            refs/heads/next|refs/heads/release/*) ;;
+            *)
+              echo "::error::Beta promotions must run from next or a release/* branch, not $GITHUB_REF."
+              exit 1
+              ;;
+          esac
 
       - name: Set up Node.js
         uses: actions/setup-node@v7
@@ -60,8 +84,24 @@ jobs:
       - name: Build all workspaces
         run: npm run build
 
-  build-and-push:
+  approve-beta:
+    name: Approve beta promotion
     needs: quality
+    if: github.event_name == 'workflow_dispatch' && inputs.push_image && inputs.channel == 'beta'
+    runs-on: ubuntu-latest
+    environment: beta
+    permissions:
+      contents: read
+
+    steps:
+      - name: Record approved candidate
+        run: echo "Approved beta promotion for $GITHUB_SHA from $GITHUB_REF."
+
+  build-and-push:
+    needs:
+      - quality
+      - approve-beta
+    if: ${{ !cancelled() && needs.quality.result == 'success' && (needs.approve-beta.result == 'success' || needs.approve-beta.result == 'skipped') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -85,12 +125,16 @@ jobs:
         id: build-channel
         env:
           BUILD_REF: ${{ github.ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          REQUESTED_CHANNEL: ${{ inputs.channel || 'preview' }}
         run: |
-          case "$BUILD_REF" in
-            refs/heads/next) channel=beta ;;
-            refs/tags/v*) channel=stable ;;
-            *) channel=preview ;;
-          esac
+          if [[ "$EVENT_NAME" == "workflow_dispatch" && "$REQUESTED_CHANNEL" == "beta" ]]; then
+            channel=beta
+          elif [[ "$BUILD_REF" == refs/tags/v* ]]; then
+            channel=stable
+          else
+            channel=preview
+          fi
           echo "channel=$channel" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
@@ -119,16 +163,18 @@ jobs:
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=raw,value=${{ steps.package-version.outputs.version }},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=raw,value=${{ steps.package-version-minor.outputs.major_minor }},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-            # next branch: rolling beta channel tags
-            type=raw,value=next,enable=${{ github.ref == 'refs/heads/next' }}
-            type=raw,value=beta,enable=${{ github.ref == 'refs/heads/next' }}
-            type=raw,value=${{ steps.package-version.outputs.version }}-beta,enable=${{ github.ref == 'refs/heads/next' }}
+            # next branch: rolling integration tag
+            type=raw,value=next,enable=${{ github.ref == 'refs/heads/next' && !(github.event_name == 'workflow_dispatch' && inputs.channel == 'beta') }}
+            # beta channel: explicitly promoted, approval-gated candidate
+            type=raw,value=beta,enable=${{ github.event_name == 'workflow_dispatch' && inputs.push_image && inputs.channel == 'beta' }}
+            type=raw,value=${{ steps.package-version.outputs.version }}-beta,enable=${{ github.event_name == 'workflow_dispatch' && inputs.push_image && inputs.channel == 'beta' }}
             # Every published branch/tag image also gets an immutable source-revision tag.
             type=sha,enable=${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
             # Manual runs from non-channel refs retain a discoverable rolling alias.
-            type=raw,value=manual,enable=${{ github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/next' }}
+            type=raw,value=manual,enable=${{ github.event_name == 'workflow_dispatch' && inputs.channel != 'beta' && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/next' }}
 
       - name: Build and push Docker image
+        id: publish-image
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -143,3 +189,27 @@ jobs:
           cache-from: ${{ inputs.no_cache && '' || 'type=gha' }}
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
+
+      - name: Verify promoted beta tags
+        if: github.event_name == 'workflow_dispatch' && inputs.push_image && inputs.channel == 'beta'
+        shell: bash
+        env:
+          EXPECTED_DIGEST: ${{ steps.publish-image.outputs.digest }}
+          PUBLISHED_TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          while IFS= read -r image_ref; do
+            [[ -n "$image_ref" ]] || continue
+            actual_digest=""
+            for attempt in {1..12}; do
+              actual_digest="$(docker buildx imagetools inspect "$image_ref" 2>/dev/null | awk '/^Digest:/ {print $2; exit}' || true)"
+              [[ -n "$actual_digest" ]] && break
+              echo "Tag $image_ref is not resolvable yet (attempt $attempt/12)."
+              sleep 10
+            done
+            if [[ "$actual_digest" != "$EXPECTED_DIGEST" ]]; then
+              echo "::error::Digest mismatch for $image_ref: expected $EXPECTED_DIGEST, got ${actual_digest:-unresolved}."
+              exit 1
+            fi
+            echo "Verified $image_ref at $actual_digest."
+          done <<<"$PUBLISHED_TAGS"

--- a/.github/workflows/sync-next-from-main.yml
+++ b/.github/workflows/sync-next-from-main.yml
@@ -25,7 +25,6 @@ jobs:
     name: Merge main into next
     runs-on: ubuntu-latest
     permissions:
-      actions: write
       contents: write
 
     steps:
@@ -65,11 +64,3 @@ jobs:
       - name: Push updated next
         if: steps.check.outputs.needs_merge == 'true'
         run: git push origin next
-
-      # Pushes made with GITHUB_TOKEN do not trigger other workflows. Dispatch
-      # the beta publisher explicitly so next and :beta cannot silently drift.
-      - name: Publish the reconciled next beta
-        if: steps.check.outputs.needs_merge == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh workflow run docker-publish.yml --ref next -f push_image=true

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ ehthumbs.db
 # Local development files
 .dev-data/
 .sso-test/
+.multi-cluster-sso-test/
 scripts/remote-dev.sh
 scripts/reset-dev-node-modules.sh
 NEXT_STEPS.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,43 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Added explicit node groups and strict per-group trusted-SSO, background, and
+  schedule credential maps for managing independent Technitium clusters in one
+  Companion deployment.
+
+### Security
+
+- Isolated topology discovery, Primary write routing, PTR/DHCP enrichment,
+  cache flushing, retries, and operation-specific node admission by group.
+  Returning nodes must revalidate token ownership, permissions, membership,
+  and topology before first use.
+
+### Changed
+
+- Beta container publication is now an explicit, environment-gated promotion
+  from `next` or `release/*`. The rolling `:next` integration image can advance
+  without replacing a beta candidate under active soak testing.
+- DNS Logs SQLite rows, hostname backfill, known clients, and per-client
+  deduplication now include the source group, preventing identical private IPs
+  in different sites from being combined.
+- Cache flush authorization now checks Technitium `Cache: Delete` and reports
+  partial or skipped physical members without cross-group fallback.
+
+### Fixed
+
+- Cluster role matching accepts the plural `clusterNodes[].ipAddresses` shape
+  returned by Technitium v15 and matches automation probes by each node's
+  self-reported cluster DNS name when configured aliases or origins differ.
+
+### Testing
+
+- Added an opt-in Docker acceptance harness that provisions two independent
+  real Technitium Primary/Secondary clusters and verifies trusted-SSO subsets,
+  cross-cluster token rejection, per-group automation admission, isolated
+  failures, Primary outage behavior, and bounded recovery revalidation.
+
 ## [1.11.0] - 2026-08-29
 
 ### Added
@@ -358,7 +395,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- DNS Schedules: eager `TECHNITIUM_SCHEDULE_TOKEN` validation at startup. The token is now probed against the configured nodes during boot (not just lazily on first UI request) so missing `Apps: Modify` permission, missing `Cache: Modify` permission, an invalid token, or a transient connectivity issue surfaces as a `WARN [TechnitiumService] TECHNITIUM_SCHEDULE_TOKEN …` line in the boot log instead of when the next schedule fires hours later.
+- DNS Schedules: eager `TECHNITIUM_SCHEDULE_TOKEN` validation at startup. The token is now probed against the configured nodes during boot (not just lazily on first UI request) so missing `Apps: Modify` permission, missing `Cache: Delete` permission, an invalid token, or a transient connectivity issue surfaces as a `WARN [TechnitiumService] TECHNITIUM_SCHEDULE_TOKEN …` line in the boot log instead of when the next schedule fires hours later.
 - SQLite query-logs nightly maintenance: one-time `auto_vacuum=INCREMENTAL` migration on first boot (one full `VACUUM` to switch modes — fast on small DBs, may take 30s–2min on multi-GB DBs), then a daily timer at ~3:30 AM ± 10 min local time that runs `PRAGMA wal_checkpoint(TRUNCATE)` + `PRAGMA incremental_vacuum(1000)`. Without this, retention prunes never returned freed pages to the OS and the WAL could grow unbounded behind long-held read transactions. Gated by `QUERY_LOG_SQLITE_AUTO_VACUUM_MIGRATION` (default `true`) so operators with very large existing DBs can defer the migration. `companion.sqlite` gets a smaller treatment: `PRAGMA optimize` on graceful shutdown to keep query plans fresh.
 
 ### Changed
@@ -391,7 +428,7 @@ All notable changes to this project will be documented in this file.
 - DNS Schedules: optional cache flush on window activate and deactivate, ensuring DNS resolvers pick up changes immediately without waiting for TTL expiry.
 - DNS Schedules: email notifications when blocked domains are queried during an active window — configurable recipients, per-schedule debounce interval, and an optional custom message prepended to alert emails. Set `notifyMessageOnly` to send only the custom message body (no technical details).
 - DNS Schedules: Clone button on each schedule card — creates a disabled "Copy of {name}" draft pre-filled with the source schedule's settings, then opens it for editing.
-- DNS Schedules: schedule token status now reports `hasCacheModify` permission so the UI can surface a clear error when the token lacks cache-flush capability.
+- DNS Schedules: schedule token status now reports `hasCacheDelete` permission so the UI can surface a clear error when the token lacks cache-flush capability.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Docs: [docs/features/SESSION_AUTH_AND_TOKEN_MIGRATION.md](docs/features/SESSION_
 |---|---|
 | `latest` | Stable release (default) |
 | `1.6`, `1.6.9` | Pinned version tags |
-| `beta` | Pre-release from the `next` branch — may include features not yet in stable |
-| `next` | Rolling `next` branch head (same image as `beta`, dev-facing alias) |
+| `beta` | Approval-gated release candidate promoted from `next` or `release/*` |
+| `next` | Rolling integration build; may advance independently of `beta` |
 | `sha-<commit>` | Immutable build for reproducing a beta result or rollback |
 
 Want to help soak-test upcoming changes? See the opt-in [Beta Testing
@@ -122,6 +122,10 @@ TECHNITIUM_SECONDARY2_BASE_URL=https://secondary2.home.arpa:53443
 # Background jobs (recommended): least-privilege token
 # TECHNITIUM_BACKGROUND_TOKEN=your-low-privilege-token
 ```
+
+To manage more than one independent cluster, assign every node a lowercase
+`TECHNITIUM_<NODE>_GROUP` and use the per-group SSO/background/schedule token
+maps documented in [`.env.example`](https://github.com/Fail-Safe/Technitium-DNS-Companion/blob/main/.env.example).
 
 **Configuration reference:** [`.env.example`](https://github.com/Fail-Safe/Technitium-DNS-Companion/blob/main/.env.example) contains the current defaults and all supported options.
 

--- a/apps/backend/src/auth/auth-session.service.ts
+++ b/apps/backend/src/auth/auth-session.service.ts
@@ -52,6 +52,11 @@ export class AuthSessionService implements OnModuleDestroy {
     options?: {
       authSource?: AuthSession["authSource"];
       technitiumUser?: string;
+      verifiedUsernamesByGroup?: Record<string, string>;
+      groupCredentials?: AuthSession["groupCredentials"];
+      pendingTokensByNodeId?: Record<string, string>;
+      credentialUsernamesByGroup?: Record<string, string>;
+      topologyDomainsByGroup?: Record<string, string>;
       maxSessionsForUser?: number;
     },
   ): AuthSession {
@@ -65,11 +70,29 @@ export class AuthSessionService implements OnModuleDestroy {
 
     const id = randomUUID();
     const now = Date.now();
+    const authSource = options?.authSource ?? "password";
+    const technitiumUser =
+      options?.technitiumUser ?? (authSource === "password" ? user : undefined);
     const session: AuthSession = {
       id,
       user,
-      authSource: options?.authSource ?? "password",
-      technitiumUser: options?.technitiumUser ?? user,
+      authSource,
+      ...(technitiumUser ? { technitiumUser } : {}),
+      ...(options?.verifiedUsernamesByGroup
+        ? { verifiedUsernamesByGroup: options.verifiedUsernamesByGroup }
+        : {}),
+      ...(options?.groupCredentials
+        ? { groupCredentials: options.groupCredentials }
+        : {}),
+      ...(options?.pendingTokensByNodeId
+        ? { pendingTokensByNodeId: options.pendingTokensByNodeId }
+        : {}),
+      ...(options?.credentialUsernamesByGroup
+        ? { credentialUsernamesByGroup: options.credentialUsernamesByGroup }
+        : {}),
+      ...(options?.topologyDomainsByGroup
+        ? { topologyDomainsByGroup: options.topologyDomainsByGroup }
+        : {}),
       createdAt: new Date(now).toISOString(),
       lastSeenAt: now,
       tokensByNodeId,

--- a/apps/backend/src/auth/auth.controller.ts
+++ b/apps/backend/src/auth/auth.controller.ts
@@ -80,6 +80,8 @@ export class AuthController {
       user: session.user,
       authSource: session.authSource,
       technitiumUser: session.technitiumUser,
+      verifiedUsernamesByGroup: session.verifiedUsernamesByGroup,
+      groupCredentials: session.groupCredentials,
       nodeIds: Object.keys(session.tokensByNodeId),
       unreachableNodeIds,
       failedNodeIds,

--- a/apps/backend/src/auth/auth.types.ts
+++ b/apps/backend/src/auth/auth.types.ts
@@ -4,9 +4,53 @@ export interface AuthSession {
   lastSeenAt: number;
   user: string;
   authSource: "password" | "trusted-sso";
-  technitiumUser: string;
+  technitiumUser?: string;
+  verifiedUsernamesByGroup?: Record<string, string>;
+  groupCredentials?: GroupCredentialStatusEnvelope;
   tokensByNodeId: Record<string, string>;
+  /** Server-only recovery state; never copied into an auth response DTO. */
+  pendingTokensByNodeId?: Record<string, string>;
+  credentialUsernamesByGroup?: Record<string, string>;
+  topologyDomainsByGroup?: Record<string, string>;
+  nodeRetryAfterByNodeId?: Record<string, number>;
+  nodeRetryAttemptsByNodeId?: Record<string, number>;
   nodeAuthStatesByNodeId?: Record<string, AuthNodeSessionState>;
+}
+
+export type GroupCredentialState =
+  | "ready"
+  | "degraded"
+  | "unreachable"
+  | "failed"
+  | "not-authorized";
+
+export interface GroupCredentialStatus {
+  groupId: string;
+  state: GroupCredentialState;
+  verifiedUsername?: string;
+  authenticatedNodeIds: string[];
+  unreachableNodeIds: string[];
+  failedNodeIds: string[];
+  admittedNodeIds: {
+    interactive: string[];
+    ptrRead: string[];
+    dhcpRead: string[];
+    primaryConfigWrite: string[];
+    cacheFlush: string[];
+  };
+  capabilities: {
+    ptrRead: boolean;
+    dhcpRead: boolean;
+    primaryConfigWrite: boolean;
+    cacheFlush: boolean;
+  };
+  reason?: string;
+}
+
+export interface GroupCredentialStatusEnvelope {
+  anyReady: boolean;
+  allReady: boolean;
+  groups: GroupCredentialStatus[];
 }
 
 export type TrustedSsoError =
@@ -71,6 +115,8 @@ export interface AuthMeResponseDto {
   user?: string;
   authSource?: AuthSession["authSource"];
   technitiumUser?: string;
+  verifiedUsernamesByGroup?: Record<string, string>;
+  groupCredentials?: GroupCredentialStatusEnvelope;
   nodeIds?: string[];
   unreachableNodeIds?: string[];
   failedNodeIds?: string[];
@@ -90,5 +136,6 @@ export interface AuthMeResponseDto {
     username?: string;
     reason?: string;
     tooPrivilegedSections?: string[];
+    groups?: GroupCredentialStatusEnvelope;
   };
 }

--- a/apps/backend/src/auth/credential-map.spec.ts
+++ b/apps/backend/src/auth/credential-map.spec.ts
@@ -1,0 +1,75 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadAutomationCredentialMap } from "./credential-map";
+
+describe("automation credential maps", () => {
+  let directory: string;
+
+  beforeEach(() => {
+    directory = mkdtempSync(join(tmpdir(), "credential-map-spec-"));
+  });
+
+  afterEach(() => rmSync(directory, { recursive: true, force: true }));
+
+  const write = (source: string): string => {
+    const path = join(directory, "map.json");
+    writeFileSync(path, source);
+    return path;
+  };
+
+  it("accepts a strict subset of known groups", () => {
+    const result = loadAutomationCredentialMap(
+      write(
+        JSON.stringify({
+          version: 1,
+          groups: {
+            "site-a": { username: "automation-a", token: "token-a" },
+          },
+        }),
+      ),
+      new Set(["site-a", "site-b"]),
+      "TECHNITIUM_BACKGROUND_TOKEN_MAP_FILE",
+    );
+    expect([...result.entries()]).toEqual([
+      ["site-a", { username: "automation-a", token: "token-a" }],
+    ]);
+  });
+
+  it("rejects unknown groups, malformed entries, empty maps, and duplicate keys", () => {
+    expect(() =>
+      loadAutomationCredentialMap(
+        write(
+          '{"version":1,"groups":{"unknown":{"username":"user","token":"token"}}}',
+        ),
+        new Set(["site-a"]),
+        "TECHNITIUM_BACKGROUND_TOKEN_MAP_FILE",
+      ),
+    ).toThrow(/unknown group/);
+    expect(() =>
+      loadAutomationCredentialMap(
+        write('{"version":1,"groups":{}}'),
+        new Set(["site-a"]),
+        "TECHNITIUM_BACKGROUND_TOKEN_MAP_FILE",
+      ),
+    ).toThrow(/at least one group/);
+    expect(() =>
+      loadAutomationCredentialMap(
+        write(
+          '{"version":1,"groups":{"site-a":{"username":"user","token":"one"},"site-a":{"username":"user","token":"two"}}}',
+        ),
+        new Set(["site-a"]),
+        "TECHNITIUM_BACKGROUND_TOKEN_MAP_FILE",
+      ),
+    ).toThrow(/readable, valid JSON/);
+    expect(() =>
+      loadAutomationCredentialMap(
+        write(
+          '{"version":1,"groups":{"site-a":{"username":"user","token":"token","extra":true}}}',
+        ),
+        new Set(["site-a"]),
+        "TECHNITIUM_BACKGROUND_TOKEN_MAP_FILE",
+      ),
+    ).toThrow(/invalid schema/);
+  });
+});

--- a/apps/backend/src/auth/credential-map.ts
+++ b/apps/backend/src/auth/credential-map.ts
@@ -1,0 +1,111 @@
+import { readFileSync } from "node:fs";
+import { parseTree } from "jsonc-parser";
+import type { Node as JsonNode, ParseError } from "jsonc-parser";
+import type { GroupCredential } from "./group-credentials";
+
+const IDENTITY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._@+-]{0,254}$/;
+
+export function readStrictJsonFile(path: string, label: string): unknown {
+  try {
+    const source = readFileSync(path, "utf8");
+    assertStrictJson(source);
+    return JSON.parse(source) as unknown;
+  } catch {
+    throw new Error(`${label} must reference a readable, valid JSON file.`);
+  }
+}
+
+export function requireObject(
+  value: unknown,
+  label: string,
+): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be a JSON object.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+export function assertExactKeys(
+  object: Record<string, unknown>,
+  allowed: string[],
+  label: string,
+): void {
+  const unexpected = Object.keys(object).filter(
+    (key) => !allowed.includes(key),
+  );
+  const missing = allowed.filter((key) => !(key in object));
+  if (unexpected.length > 0 || missing.length > 0) {
+    throw new Error(`${label} has an invalid schema.`);
+  }
+}
+
+export function parseGroupCredential(
+  value: unknown,
+  label: string,
+): GroupCredential {
+  const entry = requireObject(value, label);
+  assertExactKeys(entry, ["username", "token"], label);
+  if (
+    typeof entry.username !== "string" ||
+    !IDENTITY_PATTERN.test(entry.username)
+  ) {
+    throw new Error(`${label} has an invalid username.`);
+  }
+  if (typeof entry.token !== "string" || entry.token.length === 0) {
+    throw new Error(`${label} contains an empty or invalid cluster API token.`);
+  }
+  return { username: entry.username, token: entry.token };
+}
+
+export function loadAutomationCredentialMap(
+  path: string,
+  knownGroupIds: ReadonlySet<string>,
+  label: string,
+): Map<string, GroupCredential> {
+  const root = requireObject(readStrictJsonFile(path, label), label);
+  assertExactKeys(root, ["version", "groups"], label);
+  if (root.version !== 1) {
+    throw new Error(`${label} version must be 1.`);
+  }
+  const groups = requireObject(root.groups, `${label} groups`);
+  if (Object.keys(groups).length === 0) {
+    throw new Error(`${label} must contain at least one group.`);
+  }
+  const result = new Map<string, GroupCredential>();
+  for (const [groupId, value] of Object.entries(groups)) {
+    if (!knownGroupIds.has(groupId)) {
+      throw new Error(`${label} contains an unknown group.`);
+    }
+    result.set(groupId, parseGroupCredential(value, `${label} group mapping`));
+  }
+  return result;
+}
+
+export function isValidIdentity(value: string): boolean {
+  return IDENTITY_PATTERN.test(value);
+}
+
+function assertStrictJson(source: string): void {
+  const errors: ParseError[] = [];
+  const root = parseTree(source, errors, {
+    allowTrailingComma: false,
+    disallowComments: true,
+  });
+  if (!root || errors.length > 0) {
+    throw new Error("Invalid JSON");
+  }
+  const walk = (node: JsonNode): void => {
+    if (node.type === "object") {
+      const keys = new Set<string>();
+      for (const property of node.children ?? []) {
+        const key = property.children?.[0]?.value as unknown;
+        if (typeof key !== "string" || keys.has(key)) {
+          throw new Error("Duplicate JSON object key");
+        }
+        keys.add(key);
+      }
+    }
+    for (const child of node.children ?? []) walk(child);
+  };
+  walk(root);
+}

--- a/apps/backend/src/auth/group-credentials.ts
+++ b/apps/backend/src/auth/group-credentials.ts
@@ -1,0 +1,64 @@
+import type {
+  GroupCredentialStatus,
+  GroupCredentialStatusEnvelope,
+} from "./auth.types";
+
+export interface GroupCredential {
+  username: string;
+  token: string;
+}
+
+export function emptyAdmissions(): GroupCredentialStatus["admittedNodeIds"] {
+  return {
+    interactive: [],
+    ptrRead: [],
+    dhcpRead: [],
+    primaryConfigWrite: [],
+    cacheFlush: [],
+  };
+}
+
+export function notAuthorizedGroupStatus(
+  groupId: string,
+  reason = "No credential is configured for this group.",
+): GroupCredentialStatus {
+  return {
+    groupId,
+    state: "not-authorized",
+    authenticatedNodeIds: [],
+    unreachableNodeIds: [],
+    failedNodeIds: [],
+    admittedNodeIds: emptyAdmissions(),
+    capabilities: {
+      ptrRead: false,
+      dhcpRead: false,
+      primaryConfigWrite: false,
+      cacheFlush: false,
+    },
+    reason,
+  };
+}
+
+export function buildGroupCredentialEnvelope(
+  groups: GroupCredentialStatus[],
+): GroupCredentialStatusEnvelope {
+  const authorized = groups.filter((group) => group.state !== "not-authorized");
+  return {
+    anyReady: authorized.some(
+      (group) =>
+        (group.state === "ready" || group.state === "degraded") &&
+        group.admittedNodeIds.interactive.length > 0,
+    ),
+    allReady:
+      authorized.length > 0 &&
+      authorized.every((group) => group.state === "ready"),
+    groups,
+  };
+}
+
+export function singularVerifiedUsername(
+  usernamesByGroup: Record<string, string>,
+): string | undefined {
+  const usernames = [...new Set(Object.values(usernamesByGroup))];
+  return usernames.length === 1 ? usernames[0] : undefined;
+}

--- a/apps/backend/src/auth/trusted-sso.service.spec.ts
+++ b/apps/backend/src/auth/trusted-sso.service.spec.ts
@@ -329,6 +329,12 @@ describe("TrustedSsoService", () => {
     expect(result.session.nodeAuthStatesByNodeId?.nodeB.status).toBe(
       "unreachable",
     );
+    expect(result.session.pendingTokensByNodeId).toEqual({
+      nodeB: "cluster-token",
+    });
+    expect(result.session.credentialUsernamesByGroup).toEqual({
+      __default__: "alice",
+    });
   });
 
   it("fails the whole login on invalid tokens or owner mismatch", async () => {
@@ -374,5 +380,100 @@ describe("TrustedSsoService", () => {
       status: HttpStatus.TOO_MANY_REQUESTS,
     });
     expect(validate).toHaveBeenCalledTimes(2);
+  });
+
+  it("authorizes a v2 identity for a subset of explicit groups", async () => {
+    const mapPath = writeMap({
+      version: 2,
+      identities: {
+        "alice@example.test": {
+          groups: {
+            "site-a": { username: "alice-a", token: "site-a-token" },
+          },
+        },
+      },
+    });
+    enable({ TRUSTED_SSO_TOKEN_MAP_FILE: mapPath });
+    const explicitNodes: TechnitiumNodeConfig[] = [
+      { ...nodes[0], groupId: "site-a" },
+      { ...nodes[1], groupId: "site-b" },
+    ];
+    const validate = jest.fn().mockResolvedValue({
+      username: "alice-a",
+      permissions: {
+        DnsClient: { canView: true },
+        DhcpServer: { canView: true },
+      },
+      clusterInitialized: false,
+      clusterNodes: [],
+    });
+    const sessions = new AuthSessionService();
+    sessionServices.push(sessions);
+    const service = new TrustedSsoService(
+      explicitNodes,
+      {
+        validateExplicitSessionToken: validate,
+      } as unknown as TechnitiumService,
+      sessions,
+    );
+
+    const result = await service.loginForRequest(
+      makeRequest({ identity: "alice@example.test", secret: SECRET }),
+    );
+    expect(result.session.tokensByNodeId).toEqual({ nodeA: "site-a-token" });
+    expect(result.session.verifiedUsernamesByGroup).toEqual({
+      "site-a": "alice-a",
+    });
+    expect(result.session.groupCredentials).toMatchObject({
+      anyReady: true,
+      allReady: true,
+      groups: [
+        { groupId: "site-a", state: "ready" },
+        { groupId: "site-b", state: "not-authorized" },
+      ],
+    });
+    expect(validate).toHaveBeenCalledTimes(1);
+    expect(validate).toHaveBeenCalledWith("nodeA", "site-a-token");
+  });
+
+  it("rejects unknown v2 groups and duplicate JSON keys at startup", () => {
+    enable({
+      TRUSTED_SSO_TOKEN_MAP_FILE: writeMap({
+        version: 2,
+        identities: {
+          "alice@example.test": {
+            groups: {
+              unknown: { username: "alice", token: "token" },
+            },
+          },
+        },
+      }),
+    });
+    const explicitNodes: TechnitiumNodeConfig[] = [
+      { ...nodes[0], groupId: "site-a" },
+    ];
+    expect(
+      () =>
+        new TrustedSsoService(
+          explicitNodes,
+          {} as TechnitiumService,
+          new AuthSessionService(),
+        ),
+    ).toThrow(/unknown group/);
+
+    const duplicatePath = join(TEST_DIR, `map-${fileIndex++}.json`);
+    writeFileSync(
+      duplicatePath,
+      '{"version":2,"identities":{"alice@example.test":{"groups":{"site-a":{"username":"alice","token":"one"},"site-a":{"username":"alice","token":"two"}}}}}',
+    );
+    process.env.TRUSTED_SSO_TOKEN_MAP_FILE = duplicatePath;
+    expect(
+      () =>
+        new TrustedSsoService(
+          explicitNodes,
+          {} as TechnitiumService,
+          new AuthSessionService(),
+        ),
+    ).toThrow(/readable, valid JSON/);
   });
 });

--- a/apps/backend/src/auth/trusted-sso.service.ts
+++ b/apps/backend/src/auth/trusted-sso.service.ts
@@ -9,18 +9,40 @@ import {
   UnauthorizedException,
 } from "@nestjs/common";
 import { createHash, timingSafeEqual } from "node:crypto";
-import { readFileSync } from "node:fs";
 import { isIP } from "node:net";
 import type { Request } from "express";
-import { parseTree } from "jsonc-parser";
-import type { Node as JsonNode, ParseError } from "jsonc-parser";
 import { TECHNITIUM_NODES_TOKEN } from "../technitium/technitium.constants";
+import {
+  configuredGroupIds,
+  hasImplicitNodeGrouping,
+  INTERNAL_DEFAULT_GROUP_ID,
+  nodeGroupId,
+} from "../technitium/technitium-config";
 import { TechnitiumService } from "../technitium/technitium.service";
-import type { TechnitiumNodeConfig } from "../technitium/technitium.types";
+import type {
+  TechnitiumCredentialProbe,
+  TechnitiumNodeConfig,
+} from "../technitium/technitium.types";
 import { getEnvOrFile } from "../utils/env-file";
 import { AuthRequestContext } from "./auth-request-context";
 import { AuthSessionService } from "./auth-session.service";
+import {
+  assertExactKeys,
+  isValidIdentity,
+  parseGroupCredential,
+  readStrictJsonFile,
+  requireObject,
+} from "./credential-map";
+import {
+  buildGroupCredentialEnvelope,
+  emptyAdmissions,
+  notAuthorizedGroupStatus,
+  singularVerifiedUsername,
+} from "./group-credentials";
+import type { GroupCredential } from "./group-credentials";
 import type {
+  GroupCredentialStatus,
+  GroupCredentialStatusEnvelope,
   AuthNodeSessionState,
   AuthSession,
   TrustedSsoRequestClassification,
@@ -32,11 +54,8 @@ const DEFAULT_SECRET_HEADER = "x-trusted-proxy-secret";
 const FAILURE_COOLDOWN_MS = 5_000;
 const MAX_SESSIONS_PER_IDENTITY = 8;
 const HEADER_NAME_PATTERN = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
-const IDENTITY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._@+-]{0,254}$/;
-
 interface TrustedSsoIdentityMapping {
-  username: string;
-  token: string;
+  groups: Map<string, GroupCredential>;
 }
 
 interface TrustedSsoConfig {
@@ -58,7 +77,9 @@ interface ParsedCidr {
 interface TrustedSsoValidation {
   mapping: TrustedSsoIdentityMapping;
   nodeAuthStatesByNodeId: Record<string, AuthNodeSessionState>;
-  authenticatedNodeIds: string[];
+  groupCredentials: GroupCredentialStatusEnvelope;
+  verifiedUsernamesByGroup: Record<string, string>;
+  topologyDomainsByGroup: Record<string, string>;
 }
 
 export interface TrustedSsoLoginResult {
@@ -119,7 +140,7 @@ export class TrustedSsoService {
     const suppliedSecret = this.readSingleHeader(req, this.config.secretHeader);
     if (
       !identity ||
-      !IDENTITY_PATTERN.test(identity) ||
+      !isValidIdentity(identity) ||
       !suppliedSecret ||
       !this.secretMatches(suppliedSecret)
     ) {
@@ -221,11 +242,24 @@ export class TrustedSsoService {
     }
 
     const validation = await validationPromise;
-    const tokensByNodeId = Object.fromEntries(
-      validation.authenticatedNodeIds.map((nodeId) => [
-        nodeId,
-        validation.mapping.token,
-      ]),
+    const tokensByNodeId: Record<string, string> = {};
+    const pendingTokensByNodeId: Record<string, string> = {};
+    const credentialUsernamesByGroup: Record<string, string> = {};
+    for (const group of validation.groupCredentials.groups) {
+      const credential = validation.mapping.groups.get(group.groupId);
+      if (!credential) continue;
+      credentialUsernamesByGroup[group.groupId] = credential.username;
+      for (const nodeId of group.admittedNodeIds.interactive) {
+        tokensByNodeId[nodeId] = credential.token;
+      }
+      if (group.state === "degraded" || group.state === "unreachable") {
+        for (const nodeId of group.unreachableNodeIds) {
+          pendingTokensByNodeId[nodeId] = credential.token;
+        }
+      }
+    }
+    const technitiumUser = singularVerifiedUsername(
+      validation.verifiedUsernamesByGroup,
     );
     const session = this.sessionService.create(
       classification.identity,
@@ -233,7 +267,12 @@ export class TrustedSsoService {
       validation.nodeAuthStatesByNodeId,
       {
         authSource: "trusted-sso",
-        technitiumUser: validation.mapping.username,
+        technitiumUser,
+        verifiedUsernamesByGroup: validation.verifiedUsernamesByGroup,
+        groupCredentials: validation.groupCredentials,
+        pendingTokensByNodeId,
+        credentialUsernamesByGroup,
+        topologyDomainsByGroup: validation.topologyDomainsByGroup,
         maxSessionsForUser: MAX_SESSIONS_PER_IDENTITY,
       },
     );
@@ -243,7 +282,10 @@ export class TrustedSsoService {
       response: {
         authenticated: true,
         nodes: this.nodeConfigs.map((node) => {
-          const state = validation.nodeAuthStatesByNodeId[node.id];
+          const state = validation.nodeAuthStatesByNodeId[node.id] ?? {
+            status: "failed" as const,
+            error: "SSO identity is not authorized for this node group",
+          };
           return {
             nodeId: node.id,
             success: state.status === "authenticated",
@@ -258,27 +300,77 @@ export class TrustedSsoService {
   private async validateMapping(
     mapping: TrustedSsoIdentityMapping,
   ): Promise<TrustedSsoValidation> {
+    const statuses: GroupCredentialStatus[] = [];
+    const nodeAuthStatesByNodeId: Record<string, AuthNodeSessionState> = {};
+    const verifiedUsernamesByGroup: Record<string, string> = {};
+    const topologyDomainsByGroup: Record<string, string> = {};
+
+    for (const groupId of configuredGroupIds(this.nodeConfigs)) {
+      const credential = mapping.groups.get(groupId);
+      if (!credential) {
+        statuses.push(notAuthorizedGroupStatus(groupId));
+        continue;
+      }
+      const groupNodes = this.nodeConfigs.filter(
+        (node) => nodeGroupId(node) === groupId,
+      );
+      const status = await this.validateGroupCredential(
+        groupId,
+        groupNodes,
+        credential,
+        nodeAuthStatesByNodeId,
+        topologyDomainsByGroup,
+      );
+      statuses.push(status);
+      if (status.verifiedUsername) {
+        verifiedUsernamesByGroup[groupId] = status.verifiedUsername;
+      }
+    }
+
+    const groupCredentials = buildGroupCredentialEnvelope(statuses);
+    if (!groupCredentials.anyReady) {
+      if (statuses.some((status) => status.state === "failed")) {
+        throw new UnauthorizedException({
+          message: "Trusted SSO token validation failed",
+          groups: statuses.map(({ groupId, state, reason }) => ({
+            groupId,
+            state,
+            reason,
+          })),
+        });
+      }
+      throw new ServiceUnavailableException(
+        "No authorized Technitium group has usable validated nodes",
+      );
+    }
+    return {
+      mapping,
+      nodeAuthStatesByNodeId,
+      groupCredentials,
+      verifiedUsernamesByGroup,
+      topologyDomainsByGroup,
+    };
+  }
+
+  private async validateGroupCredential(
+    groupId: string,
+    nodes: TechnitiumNodeConfig[],
+    credential: GroupCredential,
+    nodeStates: Record<string, AuthNodeSessionState>,
+    topologyDomainsByGroup: Record<string, string>,
+  ): Promise<GroupCredentialStatus> {
     const results = await Promise.all(
-      this.nodeConfigs.map(async (node) => {
+      nodes.map(async (node) => {
         try {
-          const tokenOwner =
+          const probe =
             await this.technitiumService.validateExplicitSessionToken(
               node.id,
-              mapping.token,
+              credential.token,
             );
-          if (tokenOwner.username !== mapping.username) {
-            return {
-              nodeId: node.id,
-              state: {
-                status: "failed" as const,
-                error: "Mapped token owner does not match configured username",
-              },
-            };
+          if (probe.username !== credential.username) {
+            throw new UnauthorizedException("Mapped token owner mismatch");
           }
-          return {
-            nodeId: node.id,
-            state: { status: "authenticated" as const },
-          };
+          return { node, probe };
         } catch (error) {
           const unreachable =
             error instanceof HttpException &&
@@ -286,47 +378,164 @@ export class TrustedSsoService {
               HttpStatus.SERVICE_UNAVAILABLE,
               HttpStatus.GATEWAY_TIMEOUT,
             ].includes(error.getStatus());
-          return {
-            nodeId: node.id,
-            state: {
-              status: unreachable
-                ? ("unreachable" as const)
-                : ("failed" as const),
-              error: unreachable
-                ? "Technitium node is unreachable"
-                : "Mapped token validation failed",
-            },
+          const state: AuthNodeSessionState = {
+            status: unreachable ? "unreachable" : "failed",
+            error: unreachable
+              ? "Technitium node is unreachable"
+              : "Mapped token validation failed",
           };
+          nodeStates[node.id] = state;
+          return { node, state };
         }
       }),
     );
-
-    const nodeAuthStatesByNodeId = Object.fromEntries(
-      results.map(({ nodeId, state }) => [nodeId, state]),
+    const successful = results.filter(
+      (
+        result,
+      ): result is {
+        node: TechnitiumNodeConfig;
+        probe: TechnitiumCredentialProbe;
+      } => "probe" in result,
     );
-    const failed = results.filter(({ state }) => state.status === "failed");
-    if (failed.length > 0) {
-      throw new UnauthorizedException({
-        message: "Trusted SSO token validation failed",
-        nodes: failed.map(({ nodeId, state }) => ({
-          nodeId,
-          success: false,
-          authState: state.status,
-          error: state.error,
-        })),
-      });
+    const unreachableNodeIds = results.flatMap((result) =>
+      result.state?.status === "unreachable" ? [result.node.id] : [],
+    );
+    const failedNodeIds = results.flatMap((result) =>
+      result.state?.status === "failed" ? [result.node.id] : [],
+    );
+
+    const topologyFailure = this.getTopologyFailure(nodes, successful);
+    if (topologyFailure || failedNodeIds.length > 0) {
+      for (const { node } of successful) {
+        nodeStates[node.id] = {
+          status: "failed",
+          error: topologyFailure ?? "Group credential validation failed",
+        };
+      }
+      return {
+        groupId,
+        state: "failed",
+        authenticatedNodeIds: [],
+        unreachableNodeIds,
+        failedNodeIds: [
+          ...new Set([
+            ...failedNodeIds,
+            ...successful.map(({ node }) => node.id),
+          ]),
+        ],
+        admittedNodeIds: emptyAdmissions(),
+        capabilities: {
+          ptrRead: false,
+          dhcpRead: false,
+          primaryConfigWrite: false,
+          cacheFlush: false,
+        },
+        reason:
+          topologyFailure ?? "Mapped token validation failed for this group.",
+      };
     }
 
-    const authenticatedNodeIds = results
-      .filter(({ state }) => state.status === "authenticated")
-      .map(({ nodeId }) => nodeId);
-    if (authenticatedNodeIds.length === 0) {
-      throw new ServiceUnavailableException(
-        "No configured Technitium node is currently reachable",
-      );
-    }
+    const topologyDomain = successful.find(
+      ({ probe }) => probe.clusterInitialized && probe.clusterDomain,
+    )?.probe.clusterDomain;
+    if (topologyDomain) topologyDomainsByGroup[groupId] = topologyDomain;
 
-    return { mapping, nodeAuthStatesByNodeId, authenticatedNodeIds };
+    const admitted = emptyAdmissions();
+    for (const { node, probe } of successful) {
+      nodeStates[node.id] = { status: "authenticated" };
+      admitted.interactive.push(node.id);
+      if (probe.permissions?.["DnsClient"]?.canView === true) {
+        admitted.ptrRead.push(node.id);
+      }
+      if (probe.permissions?.["DhcpServer"]?.canView === true) {
+        admitted.dhcpRead.push(node.id);
+      }
+      const role = this.getConfiguredNodeRole(node, probe);
+      if (
+        probe.permissions?.["Apps"]?.canModify === true &&
+        (role === "Primary" || !probe.clusterInitialized)
+      ) {
+        admitted.primaryConfigWrite.push(node.id);
+      }
+      if (probe.permissions?.["Cache"]?.canDelete === true) {
+        admitted.cacheFlush.push(node.id);
+      }
+    }
+    const state: GroupCredentialStatus["state"] =
+      successful.length === 0
+        ? "unreachable"
+        : unreachableNodeIds.length > 0
+          ? "degraded"
+          : "ready";
+    return {
+      groupId,
+      state,
+      verifiedUsername: successful.length > 0 ? credential.username : undefined,
+      authenticatedNodeIds: successful.map(({ node }) => node.id),
+      unreachableNodeIds,
+      failedNodeIds: [],
+      admittedNodeIds: admitted,
+      capabilities: {
+        ptrRead: admitted.ptrRead.length > 0,
+        dhcpRead: admitted.dhcpRead.length > 0,
+        primaryConfigWrite: admitted.primaryConfigWrite.length > 0,
+        cacheFlush: admitted.cacheFlush.length > 0,
+      },
+      ...(state === "unreachable"
+        ? { reason: "Every configured node in this group is unreachable." }
+        : {}),
+    };
+  }
+
+  private getTopologyFailure(
+    nodes: TechnitiumNodeConfig[],
+    successful: Array<{
+      node: TechnitiumNodeConfig;
+      probe: TechnitiumCredentialProbe;
+    }>,
+  ): string | undefined {
+    if (hasImplicitNodeGrouping(this.nodeConfigs)) return undefined;
+    const domains = new Set(
+      successful
+        .filter(({ probe }) => probe.clusterInitialized)
+        .map(({ probe }) => probe.clusterDomain ?? ""),
+    );
+    if (domains.size > 1) {
+      return "Configured group members reported different cluster topology.";
+    }
+    if (
+      nodes.length > 1 &&
+      successful.some(({ probe }) => !probe.clusterInitialized)
+    ) {
+      return "A multi-node group contains a node that is not in the declared cluster.";
+    }
+    if (
+      successful.some(
+        ({ node, probe }) =>
+          probe.clusterInitialized && !this.getConfiguredNodeRole(node, probe),
+      )
+    ) {
+      return "A configured node could not be matched to its declared group topology.";
+    }
+    return undefined;
+  }
+
+  private getConfiguredNodeRole(
+    node: TechnitiumNodeConfig,
+    probe: TechnitiumCredentialProbe,
+  ): "Primary" | "Secondary" | undefined {
+    if (!probe.clusterInitialized) return undefined;
+    const origin = safeOrigin(node.baseUrl);
+    return (probe.clusterNodes ?? []).find((member) => {
+      if (
+        probe.dnsServerDomain &&
+        member.name?.toLowerCase() === probe.dnsServerDomain.toLowerCase()
+      )
+        return true;
+      if (member.name === node.id || member.name?.startsWith(`${node.id}.`))
+        return true;
+      return origin !== undefined && safeOrigin(member.url) === origin;
+    })?.type;
   }
 
   private isManualLoginAllowed(req: Request): boolean {
@@ -436,21 +645,13 @@ export class TrustedSsoService {
   }
 
   private loadTokenMap(path: string): Map<string, TrustedSsoIdentityMapping> {
-    let parsed: unknown;
-    try {
-      const source = readFileSync(path, "utf8");
-      assertStrictJson(source);
-      parsed = JSON.parse(source) as unknown;
-    } catch {
-      throw new Error(
-        "TRUSTED_SSO_TOKEN_MAP_FILE must reference a readable, valid JSON file.",
-      );
-    }
-
-    const root = requireObject(parsed, "token map");
+    const root = requireObject(
+      readStrictJsonFile(path, "TRUSTED_SSO_TOKEN_MAP_FILE"),
+      "Trusted SSO token map",
+    );
     assertExactKeys(root, ["version", "identities"], "token map");
-    if (root.version !== 1) {
-      throw new Error("Trusted SSO token map version must be 1.");
+    if (root.version !== 1 && root.version !== 2) {
+      throw new Error("Trusted SSO token map version must be 1 or 2.");
     }
     const identities = requireObject(root.identities, "token map identities");
     if (Object.keys(identities).length === 0) {
@@ -467,63 +668,54 @@ export class TrustedSsoService {
 
     const mappings = new Map<string, TrustedSsoIdentityMapping>();
     for (const [identity, value] of Object.entries(identities)) {
-      if (!IDENTITY_PATTERN.test(identity)) {
+      if (!isValidIdentity(identity)) {
         throw new Error(
           `Trusted SSO token map contains a malformed identity key.`,
         );
       }
-      const entry = requireObject(value, `identity mapping for ${identity}`);
-      assertExactKeys(
-        entry,
-        ["username", "token"],
-        `identity mapping for ${identity}`,
-      );
-      if (
-        typeof entry.username !== "string" ||
-        !IDENTITY_PATTERN.test(entry.username)
-      ) {
-        throw new Error(`Trusted SSO mapping has an invalid username.`);
+      if (root.version === 1) {
+        if (!hasImplicitNodeGrouping(this.nodeConfigs)) {
+          throw new Error(
+            "Trusted SSO token map version 1 is valid only with implicit single-group node configuration.",
+          );
+        }
+        mappings.set(identity, {
+          groups: new Map([
+            [
+              INTERNAL_DEFAULT_GROUP_ID,
+              parseGroupCredential(value, "Trusted SSO identity mapping"),
+            ],
+          ]),
+        });
+        continue;
       }
-      if (typeof entry.token !== "string" || entry.token.length === 0) {
+
+      const entry = requireObject(value, "Trusted SSO identity mapping");
+      assertExactKeys(entry, ["groups"], "Trusted SSO identity mapping");
+      const rawGroups = requireObject(
+        entry.groups,
+        "Trusted SSO identity groups",
+      );
+      if (Object.keys(rawGroups).length === 0) {
         throw new Error(
-          "Trusted SSO mapping contains an empty or invalid cluster API token.",
+          "Trusted SSO identities must authorize at least one group.",
         );
       }
-      mappings.set(identity, {
-        username: entry.username,
-        token: entry.token,
-      });
+      const knownGroups = new Set(configuredGroupIds(this.nodeConfigs));
+      const groups = new Map<string, GroupCredential>();
+      for (const [groupId, groupValue] of Object.entries(rawGroups)) {
+        if (!knownGroups.has(groupId)) {
+          throw new Error("Trusted SSO token map contains an unknown group.");
+        }
+        groups.set(
+          groupId,
+          parseGroupCredential(groupValue, "Trusted SSO group mapping"),
+        );
+      }
+      mappings.set(identity, { groups });
     }
     return mappings;
   }
-}
-
-function assertStrictJson(source: string): void {
-  const errors: ParseError[] = [];
-  const root = parseTree(source, errors, {
-    allowTrailingComma: false,
-    disallowComments: true,
-  });
-  if (!root || errors.length > 0) {
-    throw new Error("Invalid JSON");
-  }
-
-  const walk = (node: JsonNode): void => {
-    if (node.type === "object") {
-      const keys = new Set<string>();
-      for (const property of node.children ?? []) {
-        const key = property.children?.[0]?.value as unknown;
-        if (typeof key !== "string" || keys.has(key)) {
-          throw new Error("Duplicate JSON object key");
-        }
-        keys.add(key);
-      }
-    }
-    for (const child of node.children ?? []) {
-      walk(child);
-    }
-  };
-  walk(root);
 }
 
 function readBoolean(name: string, defaultValue: boolean): boolean {
@@ -571,26 +763,12 @@ function parseLogoutUrl(raw: string | undefined): string | undefined {
   );
 }
 
-function requireObject(value: unknown, label: string): Record<string, unknown> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error(`Trusted SSO ${label} must be a JSON object.`);
-  }
-  return value as Record<string, unknown>;
-}
-
-function assertExactKeys(
-  object: Record<string, unknown>,
-  allowed: string[],
-  label: string,
-): void {
-  const unexpected = Object.keys(object).filter(
-    (key) => !allowed.includes(key),
-  );
-  const missing = allowed.filter((key) => !(key in object));
-  if (unexpected.length > 0 || missing.length > 0) {
-    throw new Error(
-      `Trusted SSO ${label} has an invalid schema (missing: ${missing.join(", ") || "none"}; unexpected: ${unexpected.join(", ") || "none"}).`,
-    );
+function safeOrigin(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  try {
+    return new URL(value).origin.toLowerCase();
+  } catch {
+    return undefined;
   }
 }
 

--- a/apps/backend/src/technitium/automation-credential-configuration.spec.ts
+++ b/apps/backend/src/technitium/automation-credential-configuration.spec.ts
@@ -1,0 +1,285 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import axios from "axios";
+import type { GroupCredentialStatus } from "../auth/auth.types";
+import { DhcpSnapshotService } from "./dhcp-snapshot.service";
+import { TechnitiumService } from "./technitium.service";
+import type { TechnitiumNodeConfig } from "./technitium.types";
+
+describe("TechnitiumService automation credential configuration", () => {
+  const originalEnv = { ...process.env };
+  let directory: string;
+  const nodes: TechnitiumNodeConfig[] = [
+    {
+      id: "node-a",
+      baseUrl: "https://node-a.example.test",
+      token: "",
+      groupId: "site-a",
+    },
+    {
+      id: "node-b",
+      baseUrl: "https://node-b.example.test",
+      token: "",
+      groupId: "site-b",
+    },
+  ];
+
+  beforeEach(() => {
+    process.env = { ...originalEnv, NODE_ENV: "test" };
+    delete process.env.TECHNITIUM_BACKGROUND_TOKEN;
+    delete process.env.TECHNITIUM_BACKGROUND_TOKEN_FILE;
+    delete process.env.TECHNITIUM_BACKGROUND_TOKEN_MAP_FILE;
+    delete process.env.TECHNITIUM_SCHEDULE_TOKEN;
+    delete process.env.TECHNITIUM_SCHEDULE_TOKEN_FILE;
+    delete process.env.TECHNITIUM_SCHEDULE_TOKEN_MAP_FILE;
+    directory = mkdtempSync(join(tmpdir(), "automation-credential-spec-"));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    process.env = { ...originalEnv };
+    rmSync(directory, { recursive: true, force: true });
+  });
+
+  const readyGroup = (
+    groupId: string,
+    nodeId: string,
+  ): GroupCredentialStatus => ({
+    groupId,
+    state: "ready",
+    verifiedUsername: `automation-${groupId}`,
+    authenticatedNodeIds: [nodeId],
+    unreachableNodeIds: [],
+    failedNodeIds: [],
+    admittedNodeIds: {
+      interactive: [nodeId],
+      ptrRead: [nodeId],
+      dhcpRead: [],
+      primaryConfigWrite: [nodeId],
+      cacheFlush: [],
+    },
+    capabilities: {
+      ptrRead: true,
+      dhcpRead: false,
+      primaryConfigWrite: true,
+      cacheFlush: false,
+    },
+  });
+
+  it("disables a scalar role in explicit grouped mode without stopping startup", () => {
+    process.env.TECHNITIUM_BACKGROUND_TOKEN = "sensitive-background-token";
+    const service = new TechnitiumService(nodes, new DhcpSnapshotService());
+
+    const status = service.getBackgroundPtrTokenValidationSummary();
+    expect(status).toMatchObject({
+      configured: true,
+      validated: true,
+      okForPtr: false,
+      groups: {
+        anyReady: false,
+        allReady: false,
+        groups: [
+          { groupId: "site-a", state: "failed" },
+          { groupId: "site-b", state: "failed" },
+        ],
+      },
+    });
+    expect(JSON.stringify(status)).not.toContain("sensitive-background-token");
+    service.onModuleDestroy();
+  });
+
+  it("sanitizes scalar-plus-map and malformed-map failures", () => {
+    const path = join(directory, "schedule-map.json");
+    writeFileSync(path, '{"token":"do-not-expose-map-content"}');
+    process.env.TECHNITIUM_SCHEDULE_TOKEN = "do-not-expose-scalar";
+    process.env.TECHNITIUM_SCHEDULE_TOKEN_MAP_FILE = path;
+    const conflicting = new TechnitiumService(nodes, new DhcpSnapshotService());
+    const conflictStatus = conflicting.getScheduleTokenStatus();
+    expect(conflictStatus.valid).toBe(false);
+    expect(conflictStatus.groups?.groups).toHaveLength(2);
+    expect(JSON.stringify(conflictStatus)).not.toContain("do-not-expose");
+    expect(JSON.stringify(conflictStatus)).not.toContain(directory);
+    conflicting.onModuleDestroy();
+
+    delete process.env.TECHNITIUM_SCHEDULE_TOKEN;
+    const malformed = new TechnitiumService(nodes, new DhcpSnapshotService());
+    const malformedStatus = malformed.getScheduleTokenStatus();
+    expect(malformedStatus.valid).toBe(false);
+    expect(malformedStatus.groups?.groups).toHaveLength(2);
+    expect(JSON.stringify(malformedStatus)).not.toContain(
+      "do-not-expose-map-content",
+    );
+    expect(JSON.stringify(malformedStatus)).not.toContain(directory);
+    malformed.onModuleDestroy();
+  });
+
+  it("revalidates an unreachable automation node before readmitting it", async () => {
+    const service = new TechnitiumService(nodes, new DhcpSnapshotService());
+    const siteA = readyGroup("site-a", "node-a");
+    siteA.state = "unreachable";
+    siteA.authenticatedNodeIds = [];
+    siteA.unreachableNodeIds = ["node-a"];
+    siteA.admittedNodeIds = {
+      interactive: [],
+      ptrRead: [],
+      dhcpRead: [],
+      primaryConfigWrite: [],
+      cacheFlush: [],
+    };
+    siteA.capabilities = {
+      ptrRead: false,
+      dhcpRead: false,
+      primaryConfigWrite: false,
+      cacheFlush: false,
+    };
+    const internal = service as unknown as {
+      backgroundCredentials: unknown;
+      backgroundGroupCredentials: {
+        anyReady: boolean;
+        allReady: boolean;
+        groups: GroupCredentialStatus[];
+      };
+      backgroundTokenValidation: unknown;
+      validateExplicitSessionToken: jest.Mock;
+      assertAutomationNodeAdmitted: (
+        authMode: "background",
+        node: TechnitiumNodeConfig,
+        role: "ptrRead",
+      ) => Promise<void>;
+    };
+    internal.backgroundCredentials = {
+      configured: true,
+      source: "map",
+      credentialsByGroup: new Map([
+        ["site-a", { username: "automation-site-a", token: "token-a" }],
+      ]),
+    };
+    internal.backgroundGroupCredentials = {
+      anyReady: false,
+      allReady: false,
+      groups: [siteA, readyGroup("site-b", "node-b")],
+    };
+    internal.backgroundTokenValidation = {
+      validated: true,
+      okForPtr: true,
+    };
+    internal.validateExplicitSessionToken = jest.fn(() =>
+      Promise.resolve({
+        username: "automation-site-a",
+        permissions: { DnsClient: { canView: true } },
+        clusterInitialized: false,
+        clusterNodes: [],
+      }),
+    );
+
+    await internal.assertAutomationNodeAdmitted(
+      "background",
+      nodes[0],
+      "ptrRead",
+    );
+
+    expect(internal.validateExplicitSessionToken).toHaveBeenCalledWith(
+      "node-a",
+      "token-a",
+    );
+    expect(siteA.state).toBe("ready");
+    expect(siteA.admittedNodeIds.ptrRead).toEqual(["node-a"]);
+    service.onModuleDestroy();
+  });
+
+  it("matches an automation node by its self-reported cluster DNS name", () => {
+    const service = new TechnitiumService(nodes, new DhcpSnapshotService());
+    const role = (
+      service as unknown as {
+        getCredentialProbeNodeRole: (
+          node: TechnitiumNodeConfig,
+          probe: {
+            clusterInitialized: boolean;
+            dnsServerDomain?: string;
+            clusterNodes: Array<{
+              name?: string;
+              url?: string;
+              type?: "Primary" | "Secondary";
+            }>;
+          },
+        ) => "Primary" | "Secondary" | undefined;
+      }
+    ).getCredentialProbeNodeRole(nodes[0], {
+      clusterInitialized: true,
+      dnsServerDomain: "A-PRIMARY.SITE-A.TEST",
+      clusterNodes: [
+        {
+          name: "a-primary.site-a.test",
+          url: "https://a-primary.site-a.test:53443/",
+          type: "Primary",
+        },
+      ],
+    });
+
+    expect(role).toBe("Primary");
+    service.onModuleDestroy();
+  });
+
+  it("invalidates only the automation group rejected with HTTP 403", async () => {
+    const service = new TechnitiumService(nodes, new DhcpSnapshotService());
+    const siteA = readyGroup("site-a", "node-a");
+    const siteB = readyGroup("site-b", "node-b");
+    const internal = service as unknown as {
+      scheduleCredentials: unknown;
+      scheduleGroupCredentials: {
+        anyReady: boolean;
+        allReady: boolean;
+        groups: GroupCredentialStatus[];
+      };
+      scheduleTokenValidation: unknown;
+    };
+    internal.scheduleCredentials = {
+      configured: true,
+      source: "map",
+      credentialsByGroup: new Map([
+        ["site-a", { username: "automation-site-a", token: "token-a" }],
+        ["site-b", { username: "automation-site-b", token: "token-b" }],
+      ]),
+    };
+    internal.scheduleGroupCredentials = {
+      anyReady: true,
+      allReady: true,
+      groups: [siteA, siteB],
+    };
+    internal.scheduleTokenValidation = {
+      validated: true,
+      valid: true,
+      hasAppsModify: true,
+      hasCacheDelete: false,
+    };
+    jest.spyOn(axios, "request").mockRejectedValue({
+      isAxiosError: true,
+      response: { status: 403, statusText: "Forbidden", data: {} },
+    });
+
+    await expect(
+      service.request(
+        nodes[0],
+        { method: "GET", url: "/api/apps/config/get" },
+        { authMode: "schedule" },
+      ),
+    ).rejects.toMatchObject({ status: 403 });
+
+    expect(siteA.state).toBe("failed");
+    expect(siteA.admittedNodeIds.primaryConfigWrite).toEqual([]);
+    expect(siteB.state).toBe("ready");
+    expect(service.getScheduleTokenStatus()).toMatchObject({
+      valid: true,
+      groups: {
+        anyReady: true,
+        allReady: false,
+        groups: [
+          { groupId: "site-a", state: "failed" },
+          { groupId: "site-b", state: "ready" },
+        ],
+      },
+    });
+    service.onModuleDestroy();
+  });
+});

--- a/apps/backend/src/technitium/dns-schedules-evaluator.service.spec.ts
+++ b/apps/backend/src/technitium/dns-schedules-evaluator.service.spec.ts
@@ -420,6 +420,7 @@ describe("DnsSchedulesEvaluatorService — snapshot-error handling", () => {
           s: DnsSchedule,
           n: string,
           flushNodeIds: string[],
+          skippedFlushNodeIds: string[],
           stateNodeIds: string[],
           now: Date,
           dryRun: boolean,
@@ -429,6 +430,7 @@ describe("DnsSchedulesEvaluatorService — snapshot-error handling", () => {
       makeSchedule({ startTime: "09:00", endTime: "17:00", timezone: "UTC" }),
       "nodeA",
       ["nodeA"],
+      [],
       ["nodeA"],
       utcDate(2024, 1, 15, 12, 0),
       false,
@@ -463,6 +465,7 @@ describe("DnsSchedulesEvaluatorService — snapshot-error handling", () => {
           s: DnsSchedule,
           n: string,
           flushNodeIds: string[],
+          skippedFlushNodeIds: string[],
           stateNodeIds: string[],
           now: Date,
           dryRun: boolean,
@@ -472,6 +475,7 @@ describe("DnsSchedulesEvaluatorService — snapshot-error handling", () => {
       makeSchedule({ startTime: "09:00", endTime: "17:00", timezone: "UTC" }),
       "nodeA",
       ["nodeA"],
+      [],
       ["nodeA"],
       utcDate(2024, 1, 15, 18, 0),
       false,
@@ -654,6 +658,7 @@ describe("DnsSchedulesEvaluatorService — cluster state aliases", () => {
           s: DnsSchedule,
           n: string,
           flushNodeIds: string[],
+          skippedFlushNodeIds: string[],
           stateNodeIds: string[],
           now: Date,
           dryRun: boolean,
@@ -671,6 +676,7 @@ describe("DnsSchedulesEvaluatorService — cluster state aliases", () => {
       }),
       "nodeA",
       ["nodeA", "nodeB", "nodeC"],
+      [],
       ["nodeA", "nodeB"],
       new Date("2026-06-25T00:15:00.000Z"),
       false,
@@ -706,6 +712,7 @@ describe("DnsSchedulesEvaluatorService — cluster state aliases", () => {
           s: DnsSchedule,
           n: string,
           flushNodeIds: string[],
+          skippedFlushNodeIds: string[],
           stateNodeIds: string[],
           now: Date,
           dryRun: boolean,
@@ -723,6 +730,7 @@ describe("DnsSchedulesEvaluatorService — cluster state aliases", () => {
       }),
       "nodeA",
       ["nodeA", "nodeB", "nodeC"],
+      [],
       ["nodeA", "nodeB"],
       new Date("2026-06-25T01:15:00.000Z"),
       false,
@@ -1591,5 +1599,40 @@ describe("DnsSchedulesEvaluatorService — temporary override alert window", () 
         enabled: true,
       }),
     );
+  });
+});
+
+describe("DnsSchedulesEvaluatorService — cache flush admission results", () => {
+  it("reports admitted successes and unavailable or unauthorized members separately", async () => {
+    const service = new DnsSchedulesEvaluatorService(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+    );
+    const internal = service as unknown as {
+      flushDomainsCache: jest.Mock<Promise<boolean>, [DnsSchedule, string]>;
+      flushAdmittedCaches: (
+        schedule: DnsSchedule,
+        admitted: string[],
+        skipped: string[],
+      ) => Promise<{ flushedNodeIds: string[]; skippedNodeIds: string[] }>;
+    };
+    internal.flushDomainsCache = jest
+      .fn()
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+
+    await expect(
+      internal.flushAdmittedCaches(
+        makeSchedule({ flushCacheOnChange: true }),
+        ["primary", "secondary-a"],
+        ["secondary-b"],
+      ),
+    ).resolves.toEqual({
+      flushedNodeIds: ["primary"],
+      skippedNodeIds: ["secondary-b", "secondary-a"],
+    });
   });
 });

--- a/apps/backend/src/technitium/dns-schedules-evaluator.service.ts
+++ b/apps/backend/src/technitium/dns-schedules-evaluator.service.ts
@@ -35,6 +35,7 @@ type AppliedEntryTuple = {
 type ClusterWriteOperation = {
   writeTarget: string;
   flushNodes: string[];
+  skippedFlushNodes: string[];
 };
 
 type ActiveOverrideSource = {
@@ -362,10 +363,17 @@ export class DnsSchedulesEvaluatorService
           // `entry.nodeId` could be a secondary. Resolve it so the remove goes
           // to the cluster Primary (writes to secondaries race replication and
           // get reverted). Cache flush still hits all physical nodes.
-          const resolved = perCandidate.get(entry.nodeId) ?? {
-            writeTarget: entry.nodeId,
-            flushNodes: [entry.nodeId],
-          };
+          const resolved = perCandidate.get(entry.nodeId);
+          if (!resolved?.writeTarget) {
+            results.push({
+              scheduleId: schedule.id,
+              scheduleName: schedule.name,
+              nodeId: entry.nodeId,
+              action: "skipped",
+              reason: resolved?.reason ?? "no-validated-primary",
+            });
+            continue;
+          }
           try {
             await this.removeScheduleFromNode(
               schedule,
@@ -436,13 +444,24 @@ export class DnsSchedulesEvaluatorService
         const seenWriteTargets = new Set<string>();
         const operations: ClusterWriteOperation[] = [];
         for (const candidateId of candidateNodeIds) {
-          const resolved = perCandidate.get(candidateId) ?? {
-            writeTarget: candidateId,
-            flushNodes: [candidateId],
-          };
+          const resolved = perCandidate.get(candidateId);
+          if (!resolved?.writeTarget) {
+            results.push({
+              scheduleId: schedule.id,
+              scheduleName: schedule.name,
+              nodeId: candidateId,
+              action: "skipped",
+              reason: resolved?.reason ?? "no-validated-primary",
+            });
+            continue;
+          }
           if (seenWriteTargets.has(resolved.writeTarget)) continue;
           seenWriteTargets.add(resolved.writeTarget);
-          operations.push(resolved);
+          operations.push({
+            writeTarget: resolved.writeTarget,
+            flushNodes: resolved.flushNodes,
+            skippedFlushNodes: resolved.skippedFlushNodes ?? [],
+          });
         }
 
         for (const op of operations) {
@@ -450,6 +469,7 @@ export class DnsSchedulesEvaluatorService
             schedule,
             op.writeTarget,
             op.flushNodes,
+            op.skippedFlushNodes,
             this.getStateNodeIdsForWriteTarget(
               schedule.id,
               op.writeTarget,
@@ -510,7 +530,15 @@ export class DnsSchedulesEvaluatorService
     scheduleId: string,
     writeTarget: string,
     candidateNodeIds: string[],
-    perCandidate: Map<string, { writeTarget: string; flushNodes: string[] }>,
+    perCandidate: Map<
+      string,
+      {
+        writeTarget?: string;
+        flushNodes: string[];
+        skippedFlushNodes?: string[];
+        reason?: string;
+      }
+    >,
   ): string[] {
     const stateNodeIds = new Set<string>([writeTarget]);
     const candidateSet = new Set(candidateNodeIds);
@@ -519,11 +547,8 @@ export class DnsSchedulesEvaluatorService
       if (!candidateSet.has(entry.nodeId) && entry.nodeId !== writeTarget) {
         continue;
       }
-      const resolved = perCandidate.get(entry.nodeId) ?? {
-        writeTarget: entry.nodeId,
-        flushNodes: [entry.nodeId],
-      };
-      if (resolved.writeTarget === writeTarget) {
+      const resolved = perCandidate.get(entry.nodeId);
+      if (resolved?.writeTarget === writeTarget) {
         stateNodeIds.add(entry.nodeId);
       }
     }
@@ -613,6 +638,7 @@ export class DnsSchedulesEvaluatorService
     schedule: DnsSchedule,
     nodeId: string,
     flushNodeIds: string[],
+    skippedFlushNodeIds: string[],
     stateNodeIds: string[],
     now: Date,
     dryRun: boolean,
@@ -701,17 +727,21 @@ export class DnsSchedulesEvaluatorService
           // everything we want. Drift episode (if any) has resolved.
           this.resetDriftState(schedule.id, nodeId);
         }
-        if (changed && schedule.flushCacheOnChange) {
-          for (const flushNodeId of flushNodeIds) {
-            await this.flushDomainsCache(schedule, flushNodeId);
-          }
-        }
+        const cacheFlush =
+          changed && schedule.flushCacheOnChange
+            ? await this.flushAdmittedCaches(
+                schedule,
+                flushNodeIds,
+                skippedFlushNodeIds,
+              )
+            : undefined;
         if (!isCurrentlyApplied || changed) {
           return {
             scheduleId: schedule.id,
             scheduleName: schedule.name,
             nodeId,
             action: "applied",
+            ...(cacheFlush ? { cacheFlush } : {}),
           };
         }
         return {
@@ -730,16 +760,19 @@ export class DnsSchedulesEvaluatorService
         // Window closed — drop any drift bookkeeping for this pair. Next
         // window opens with a clean counter.
         this.resetDriftState(schedule.id, nodeId);
-        if (schedule.flushCacheOnChange) {
-          for (const flushNodeId of flushNodeIds) {
-            await this.flushDomainsCache(schedule, flushNodeId);
-          }
-        }
+        const cacheFlush = schedule.flushCacheOnChange
+          ? await this.flushAdmittedCaches(
+              schedule,
+              flushNodeIds,
+              skippedFlushNodeIds,
+            )
+          : undefined;
         return {
           scheduleId: schedule.id,
           scheduleName: schedule.name,
           nodeId,
           action: "removed",
+          ...(cacheFlush ? { cacheFlush } : {}),
         };
       }
     } catch (error) {
@@ -852,10 +885,13 @@ export class DnsSchedulesEvaluatorService
 
     const seenWriteTargets = new Set<string>();
     for (const entry of applied) {
-      const resolved = perCandidate.get(entry.nodeId) ?? {
-        writeTarget: entry.nodeId,
-        flushNodes: [entry.nodeId],
-      };
+      const resolved = perCandidate.get(entry.nodeId);
+      if (!resolved?.writeTarget) {
+        this.logger.warn(
+          `Skipped deactivation for schedule "${schedule.name}" on node "${entry.nodeId}": ${resolved?.reason ?? "no validated Primary is available"}.`,
+        );
+        continue;
+      }
       // Skip duplicate Primary writes when multiple secondaries of the same
       // cluster have legacy state rows for this schedule.
       const skipWrite = seenWriteTargets.has(resolved.writeTarget);
@@ -1276,29 +1312,56 @@ export class DnsSchedulesEvaluatorService
    * Technitium evaluates Advanced Blocking rules on cache misses only —
    * stale subdomain entries (e.g. www.youtube.com when youtube.com is
    * blocked) survive a per-domain flush and continue resolving from cache.
-   * Failures (e.g. missing Cache: Modify permission) are logged as
+   * Failures (e.g. missing Cache: Delete permission) are logged as
    * warnings and never propagate to callers.
    */
   private async flushDomainsCache(
     schedule: DnsSchedule,
     nodeId: string,
-  ): Promise<void> {
+  ): Promise<boolean> {
     try {
       await this.technitiumService.executeAction(
         nodeId,
-        { method: "GET", url: "/api/cache/flush" },
+        { method: "GET", url: "/api/cache/delete" },
         { authMode: "schedule" },
       );
       this.logger.log(
         `Full cache flush completed on node "${nodeId}" after schedule "${schedule.name}" change.`,
       );
+      return true;
     } catch (error) {
       this.logger.warn(
         `Cache flush failed for schedule "${schedule.name}" on node "${nodeId}": ` +
           `${error instanceof Error ? error.message : String(error)} ` +
-          `(token may lack Cache: Modify permission).`,
+          `(token may lack Cache: Delete permission).`,
       );
+      return false;
     }
+  }
+
+  private async flushAdmittedCaches(
+    schedule: DnsSchedule,
+    flushNodeIds: string[],
+    skippedFlushNodeIds: string[],
+  ): Promise<{ flushedNodeIds: string[]; skippedNodeIds: string[] }> {
+    const flushedNodeIds: string[] = [];
+    const skippedNodeIds = [...skippedFlushNodeIds];
+    for (const nodeId of flushNodeIds) {
+      try {
+        const flushed = await this.flushDomainsCache(schedule, nodeId);
+        if (!flushed) {
+          skippedNodeIds.push(nodeId);
+          continue;
+        }
+        flushedNodeIds.push(nodeId);
+      } catch (error) {
+        skippedNodeIds.push(nodeId);
+        this.logger.warn(
+          `Skipped cache flush for schedule "${schedule.name}" on node "${nodeId}": ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+    return { flushedNodeIds, skippedNodeIds };
   }
 
   /**

--- a/apps/backend/src/technitium/dns-schedules.types.ts
+++ b/apps/backend/src/technitium/dns-schedules.types.ts
@@ -1,3 +1,5 @@
+import type { GroupCredentialStatusEnvelope } from "../auth/auth.types";
+
 export type DnsScheduleAction = "block" | "allow";
 export type DnsScheduleTargetType = "advanced-blocking" | "built-in";
 
@@ -122,7 +124,7 @@ export interface DnsSchedulesStorageStatus {
 
 export interface DnsScheduleTokenStatus {
   /**
-   * Whether TECHNITIUM_SCHEDULE_TOKEN is set in the environment.
+   * Whether a scalar or per-group schedule automation credential is configured.
    */
   configured: boolean;
   /**
@@ -137,10 +139,11 @@ export interface DnsScheduleTokenStatus {
    */
   hasAppsModify: boolean | null;
   /**
-   * Whether the token has Cache: Modify permission needed to flush DNS cache.
+   * Whether the token has Cache: Delete permission needed to flush DNS cache.
    * null when not yet validated.
    */
-  hasCacheModify: boolean | null;
+  hasCacheDelete: boolean | null;
+  groups?: GroupCredentialStatusEnvelope;
 }
 
 export interface DnsScheduleEvaluatorStatus {
@@ -164,6 +167,10 @@ export interface DnsScheduleApplicationResult {
   action: "applied" | "removed" | "skipped" | "error";
   reason?: string;
   error?: string;
+  cacheFlush?: {
+    flushedNodeIds: string[];
+    skippedNodeIds: string[];
+  };
 }
 
 export interface RunDnsScheduleEvaluatorRequest {

--- a/apps/backend/src/technitium/query-log-sqlite.bench.spec.ts
+++ b/apps/backend/src/technitium/query-log-sqlite.bench.spec.ts
@@ -84,9 +84,21 @@ const START_MS = NOW_MS - WINDOW_MS;
 const UNIQUE_DOMAINS = 5_000;
 const ZIPF_EXPONENT = 1.1; // standard DNS popularity distribution
 const NODES = [
-  { id: "nodeA", baseUrl: "https://nodeA.example.com:53443" },
-  { id: "nodeB", baseUrl: "https://nodeB.example.com:53443" },
-  { id: "nodeC", baseUrl: "https://nodeC.example.com:53443" },
+  {
+    id: "nodeA",
+    baseUrl: "https://nodeA.example.com:53443",
+    groupId: "site-a",
+  },
+  {
+    id: "nodeB",
+    baseUrl: "https://nodeB.example.com:53443",
+    groupId: "site-a",
+  },
+  {
+    id: "nodeC",
+    baseUrl: "https://nodeC.example.com:53443",
+    groupId: "site-b",
+  },
 ];
 const CLIENTS: Array<{ ip: string; name: string }> = [
   { ip: "10.0.1.10", name: "parent-laptop" },
@@ -245,6 +257,7 @@ function generateSyntheticDb(path: string, rowCount: number): void {
     `CREATE TABLE IF NOT EXISTS query_log_entries (
       nodeId TEXT NOT NULL,
       baseUrl TEXT NOT NULL,
+      groupId TEXT NOT NULL DEFAULT '__default__',
       ts INTEGER NOT NULL,
       timestamp TEXT NOT NULL,
       qname TEXT,
@@ -268,6 +281,7 @@ function generateSyntheticDb(path: string, rowCount: number): void {
   for (const idx of [
     "CREATE INDEX IF NOT EXISTS idx_query_log_ts ON query_log_entries(ts)",
     "CREATE INDEX IF NOT EXISTS idx_query_log_node_ts ON query_log_entries(nodeId, ts)",
+    "CREATE INDEX IF NOT EXISTS idx_query_log_group_ts ON query_log_entries(groupId, ts)",
     "CREATE INDEX IF NOT EXISTS idx_query_log_qnameLc_ts ON query_log_entries(qnameLc, ts)",
     "CREATE INDEX IF NOT EXISTS idx_query_log_clientIpLc_ts ON query_log_entries(clientIpLc, ts)",
     "CREATE INDEX IF NOT EXISTS idx_query_log_clientNameLc_ts ON query_log_entries(clientNameLc, ts)",
@@ -284,7 +298,7 @@ function generateSyntheticDb(path: string, rowCount: number): void {
 
   const insert = db.prepare(
     `INSERT OR IGNORE INTO query_log_entries (
-      nodeId, baseUrl, ts, timestamp,
+      nodeId, baseUrl, groupId, ts, timestamp,
       qname, qnameLc,
       clientIpAddress, clientIpLc,
       clientName, clientNameLc,
@@ -292,7 +306,7 @@ function generateSyntheticDb(path: string, rowCount: number): void {
       blockedRank, aRank,
       entryHash, data
     ) VALUES (
-      ?, ?, ?, ?,
+      ?, ?, ?, ?, ?,
       ?, ?,
       ?, ?,
       ?, ?,
@@ -353,6 +367,7 @@ function generateSyntheticDb(path: string, rowCount: number): void {
         insert.run(
           node.id,
           node.baseUrl,
+          node.groupId,
           ts,
           iso,
           qname,
@@ -424,6 +439,7 @@ function applyBenchmarkStage(db: DatabaseSync): void {
       CREATE INDEX IF NOT EXISTS idx_query_log_dedup_rank
       ON query_log_entries(
         qnameLc,
+        groupId,
         clientIpLc,
         blockedRank DESC,
         aRank DESC,
@@ -474,7 +490,7 @@ function buildQueryCases(): QueryCase[] {
 
   const buildDedupPageSql = (
     whereSql: string,
-    partition: "qnameLc" | "qnameLc, clientIpLc" = "qnameLc",
+    partition: "qnameLc" | "qnameLc, groupId, clientIpLc" = "qnameLc",
     offset = 0,
     hasEntryFilters = false,
   ): string => {
@@ -670,7 +686,7 @@ function buildQueryCases(): QueryCase[] {
     },
     {
       name: "20 recent page 1 (dedup per client)",
-      sql: buildDedupPageSql(tsClause, "qnameLc, clientIpLc"),
+      sql: buildDedupPageSql(tsClause, "qnameLc, groupId, clientIpLc"),
       params: [...tsParams],
     },
   ];

--- a/apps/backend/src/technitium/query-log-sqlite.service.spec.ts
+++ b/apps/backend/src/technitium/query-log-sqlite.service.spec.ts
@@ -38,6 +38,10 @@ interface SchemaShape {
   initializeSchema: () => void;
 }
 
+interface HostnameBackfillShape extends SchemaShape {
+  backfillMissingClientNames: (hostnames: Map<string, string>) => void;
+}
+
 interface DedupSelectShape extends SchemaShape {
   selectDeduplicatedRows: (
     base: { whereSql: string; params: Array<string | number> },
@@ -247,6 +251,7 @@ describe("QueryLogSqliteService — deduplicated counts", () => {
       `CREATE TABLE query_log_entries (
         ts INTEGER NOT NULL,
         qnameLc TEXT,
+        groupId TEXT NOT NULL DEFAULT '__default__',
         clientIpLc TEXT
       )`,
     );
@@ -287,6 +292,18 @@ describe("QueryLogSqliteService — deduplicated counts", () => {
         true,
       ),
     ).toBe(3);
+  });
+
+  it("keeps identical private clients in different groups distinct", () => {
+    db.prepare(
+      "INSERT INTO query_log_entries (ts, qnameLc, groupId, clientIpLc) VALUES (?, ?, ?, ?)",
+    ).run(15, "one.example", "site-b", "192.0.2.1");
+    expect(
+      internal.countDeduplicatedEntries(
+        { whereSql: "WHERE ts >= ? AND ts <= ?", params: [0, 100] },
+        true,
+      ),
+    ).toBe(4);
   });
 });
 
@@ -351,11 +368,59 @@ describe("QueryLogSqliteService — query indexes", () => {
         .map((column) => [column.name, column.desc]),
     ).toEqual([
       ["qnameLc", 0],
+      ["groupId", 0],
       ["clientIpLc", 0],
       ["blockedRank", 1],
       ["aRank", 1],
       ["ts", 1],
     ]);
+  });
+
+  it("migrates and synchronizes group IDs for existing databases", () => {
+    runSql(
+      db,
+      `CREATE TABLE query_log_entries (
+        nodeId TEXT NOT NULL, baseUrl TEXT NOT NULL, ts INTEGER NOT NULL,
+        timestamp TEXT NOT NULL, qname TEXT, qnameLc TEXT,
+        clientIpAddress TEXT, clientIpLc TEXT, clientName TEXT,
+        clientNameLc TEXT, protocol TEXT, responseType TEXT, rcode TEXT,
+        qtype TEXT, qclass TEXT,
+        blockedRank INTEGER NOT NULL DEFAULT 0, aRank INTEGER NOT NULL DEFAULT 0,
+        entryHash TEXT NOT NULL, data TEXT NOT NULL,
+        PRIMARY KEY (nodeId, entryHash)
+      )`,
+    );
+    db.prepare(
+      "INSERT INTO query_log_entries (nodeId, baseUrl, ts, timestamp, entryHash, data) VALUES (?, ?, ?, ?, ?, ?)",
+    ).run("node-a", "https://node-a.example.test", 1, "ts", "hash", "{}");
+    const internal = new QueryLogSqliteService(
+      {} as never,
+      [
+        {
+          id: "node-a",
+          baseUrl: "https://node-a.example.test",
+          token: "",
+          groupId: "site-a",
+        },
+      ] as never,
+    ) as unknown as SchemaShape;
+    internal.db = db;
+    internal.initializeSchema();
+
+    expect(db.prepare("SELECT groupId FROM query_log_entries").get()).toEqual({
+      groupId: "site-a",
+    });
+
+    const schemaVersionBefore = db.prepare("PRAGMA schema_version").get() as {
+      schema_version: number;
+    };
+    internal.initializeSchema();
+    const schemaVersionAfter = db.prepare("PRAGMA schema_version").get() as {
+      schema_version: number;
+    };
+    expect(schemaVersionAfter.schema_version).toBe(
+      schemaVersionBefore.schema_version,
+    );
   });
 });
 
@@ -747,5 +812,58 @@ describe("QueryLogSqliteService — stored hostname isolation", () => {
     expect(result.entries).toHaveLength(1);
     expect(cachedEnrichment).toHaveBeenCalledTimes(1);
     expect(liveEnrichment).not.toHaveBeenCalled();
+  });
+
+  it("backfills a hostname only inside its group namespace", () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "qlogs-group-backfill-spec-"));
+    db = new DatabaseSync(join(tmpDir, "query-logs.sqlite"));
+    const internal = new QueryLogSqliteService(
+      {} as never,
+      [] as never,
+    ) as unknown as HostnameBackfillShape;
+    internal.db = db;
+    internal.initializeSchema();
+    const insert = db.prepare(
+      `INSERT INTO query_log_entries (
+        nodeId, baseUrl, groupId, ts, timestamp,
+        clientIpAddress, clientIpLc, entryHash, data
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    insert.run(
+      "node-a",
+      "https://node-a.example.test",
+      "site-a",
+      1,
+      "ts-a",
+      "192.168.1.20",
+      "192.168.1.20",
+      "a",
+      "{}",
+    );
+    insert.run(
+      "node-b",
+      "https://node-b.example.test",
+      "site-b",
+      2,
+      "ts-b",
+      "192.168.1.20",
+      "192.168.1.20",
+      "b",
+      "{}",
+    );
+
+    internal.backfillMissingClientNames(
+      new Map([["site-a\u0000192.168.1.20", "client-at-site-a"]]),
+    );
+    expect(
+      db
+        .prepare(
+          "SELECT groupId, clientName FROM query_log_entries ORDER BY groupId",
+        )
+        .all(),
+    ).toEqual([
+      { groupId: "site-a", clientName: "client-at-site-a" },
+      { groupId: "site-b", clientName: null },
+    ]);
   });
 });

--- a/apps/backend/src/technitium/query-log-sqlite.service.ts
+++ b/apps/backend/src/technitium/query-log-sqlite.service.ts
@@ -10,6 +10,7 @@ import { accessSync, constants, existsSync, mkdirSync } from "fs";
 import { DatabaseSync } from "node:sqlite";
 import { dirname } from "path";
 import { TECHNITIUM_NODES_TOKEN } from "./technitium.constants";
+import { nodeGroupId } from "./technitium-config";
 import { TechnitiumService } from "./technitium.service";
 import type {
   TechnitiumCombinedQueryLogEntry,
@@ -38,10 +39,16 @@ export interface QueryLogSqliteStatus {
   };
 }
 
-type StoredLogRow = { nodeId: string; baseUrl: string; data: string };
+type StoredLogRow = {
+  nodeId: string;
+  baseUrl: string;
+  groupId: string;
+  data: string;
+};
 type StoredLogRowWithClient = {
   nodeId: string;
   baseUrl: string;
+  groupId: string;
   clientIpAddress: string | null;
   clientName: string | null;
   data: string;
@@ -338,6 +345,7 @@ export class QueryLogSqliteService implements OnModuleInit, OnModuleDestroy {
       CREATE TABLE IF NOT EXISTS query_log_entries (
         nodeId TEXT NOT NULL,
         baseUrl TEXT NOT NULL,
+        groupId TEXT NOT NULL DEFAULT '__default__',
         ts INTEGER NOT NULL,
         timestamp TEXT NOT NULL,
         qname TEXT,
@@ -366,14 +374,64 @@ export class QueryLogSqliteService implements OnModuleInit, OnModuleDestroy {
       CREATE INDEX IF NOT EXISTS idx_query_log_responseType_ts ON query_log_entries(responseType, ts);
       CREATE INDEX IF NOT EXISTS idx_query_log_qtype_ts ON query_log_entries(qtype, ts);
       CREATE INDEX IF NOT EXISTS idx_query_log_blockedRank_ts ON query_log_entries(blockedRank, ts);
-      CREATE INDEX IF NOT EXISTS idx_query_log_dedup_rank ON query_log_entries(
-        qnameLc,
-        clientIpLc,
-        blockedRank DESC,
-        aRank DESC,
-        ts DESC
-      );
     `);
+    // Existing databases do not have groupId until the migration below. Any
+    // index that references it must be created after the column is present.
+    this.migrateQueryLogGroupIds();
+  }
+
+  private migrateQueryLogGroupIds(): void {
+    if (!this.db) return;
+    const columns = this.db
+      .prepare("PRAGMA table_info(query_log_entries)")
+      .all() as Array<{
+      name?: string;
+    }>;
+    if (!columns.some((column) => column.name === "groupId")) {
+      this.db.exec(
+        "ALTER TABLE query_log_entries ADD COLUMN groupId TEXT NOT NULL DEFAULT '__default__'",
+      );
+    }
+    const update = this.db.prepare(
+      "UPDATE query_log_entries SET groupId = ? WHERE nodeId = ? AND groupId <> ?",
+    );
+    for (const node of this.nodeConfigs) {
+      const groupId = nodeGroupId(node);
+      update.run(groupId, node.id, groupId);
+    }
+    const expectedDedupColumns = [
+      "qnameLc",
+      "groupId",
+      "clientIpLc",
+      "blockedRank",
+      "aRank",
+      "ts",
+    ];
+    const currentDedupColumns = this.db
+      .prepare("PRAGMA index_info(idx_query_log_dedup_rank)")
+      .all()
+      .map((column) => (column as { name?: string }).name ?? "");
+    if (
+      currentDedupColumns.length !== expectedDedupColumns.length ||
+      currentDedupColumns.some(
+        (column, index) => column !== expectedDedupColumns[index],
+      )
+    ) {
+      this.db.exec(`
+        DROP INDEX IF EXISTS idx_query_log_dedup_rank;
+        CREATE INDEX idx_query_log_dedup_rank ON query_log_entries(
+          qnameLc,
+          groupId,
+          clientIpLc,
+          blockedRank DESC,
+          aRank DESC,
+          ts DESC
+        );
+      `);
+    }
+    this.db.exec(
+      "CREATE INDEX IF NOT EXISTS idx_query_log_group_ts ON query_log_entries(groupId, ts)",
+    );
   }
 
   /**
@@ -802,7 +860,7 @@ export class QueryLogSqliteService implements OnModuleInit, OnModuleDestroy {
       const enrichedEntries =
         await this.technitiumService.enrichQueryLogEntriesWithHostnames(
           entries,
-          { authMode: "background" },
+          { authMode: "background", sourceGroupId: nodeGroupId(node) },
         );
 
       let newestTs = this.lastIngestedTsByNode.get(node.id) ?? 0;
@@ -812,7 +870,7 @@ export class QueryLogSqliteService implements OnModuleInit, OnModuleDestroy {
       try {
         const insert = this.db.prepare(
           `INSERT OR IGNORE INTO query_log_entries (
-            nodeId, baseUrl, ts, timestamp,
+            nodeId, baseUrl, groupId, ts, timestamp,
             qname, qnameLc,
             clientIpAddress, clientIpLc,
             clientName, clientNameLc,
@@ -820,7 +878,7 @@ export class QueryLogSqliteService implements OnModuleInit, OnModuleDestroy {
             blockedRank, aRank,
             entryHash, data
           ) VALUES (
-            ?, ?, ?, ?,
+            ?, ?, ?, ?, ?,
             ?, ?,
             ?, ?,
             ?, ?,
@@ -853,7 +911,10 @@ export class QueryLogSqliteService implements OnModuleInit, OnModuleDestroy {
             clientName.trim().length > 0 &&
             (!clientIpAddress || clientName !== clientIpAddress)
           ) {
-            hostnamesByIpLc.set(clientIpLc, clientName);
+            hostnamesByIpLc.set(
+              this.clientNamespaceKey(nodeGroupId(node), clientIpLc),
+              clientName,
+            );
           }
 
           const responseType = entry.responseType ?? null;
@@ -869,6 +930,7 @@ export class QueryLogSqliteService implements OnModuleInit, OnModuleDestroy {
           insert.run(
             node.id,
             node.baseUrl,
+            nodeGroupId(node),
             ts,
             entry.timestamp ?? "",
             qname,
@@ -885,7 +947,7 @@ export class QueryLogSqliteService implements OnModuleInit, OnModuleDestroy {
             blockedRank,
             aRank,
             entryHash,
-            JSON.stringify(entry),
+            JSON.stringify({ ...entry, groupId: nodeGroupId(node) }),
           );
 
           if (ts > newestTs) {
@@ -923,7 +985,7 @@ export class QueryLogSqliteService implements OnModuleInit, OnModuleDestroy {
     const update = this.db.prepare(
       `UPDATE query_log_entries
        SET clientName = ?, clientNameLc = ?
-       WHERE clientIpLc = ?
+       WHERE groupId = ? AND clientIpLc = ?
          AND (
            clientName IS NULL OR clientName = '' OR clientName = clientIpAddress
            OR clientNameLc IS NULL OR clientNameLc = '' OR clientNameLc = clientIpLc
@@ -932,7 +994,7 @@ export class QueryLogSqliteService implements OnModuleInit, OnModuleDestroy {
 
     let updatedIps = 0;
 
-    for (const [ipLc, hostname] of hostnamesByIpLc.entries()) {
+    for (const [clientKey, hostname] of hostnamesByIpLc.entries()) {
       if (updatedIps >= MAX_UPDATES_PER_POLL) {
         this.logger.debug(
           `Hostname backfill capped at ${MAX_UPDATES_PER_POLL} IPs per poll (skipped ${hostnamesByIpLc.size - updatedIps}).`,
@@ -943,9 +1005,25 @@ export class QueryLogSqliteService implements OnModuleInit, OnModuleDestroy {
       const name = hostname.trim();
       if (!name) continue;
 
-      update.run(name, name.toLowerCase(), ipLc);
+      const { groupId, ipLc } = this.parseClientNamespaceKey(clientKey);
+      update.run(name, name.toLowerCase(), groupId, ipLc);
       updatedIps += 1;
     }
+  }
+
+  private clientNamespaceKey(groupId: string, ipLc: string): string {
+    return `${groupId}\u0000${ipLc}`;
+  }
+
+  private parseClientNamespaceKey(key: string): {
+    groupId: string;
+    ipLc: string;
+  } {
+    const separator = key.indexOf("\u0000");
+    return {
+      groupId: separator === -1 ? "__default__" : key.slice(0, separator),
+      ipLc: separator === -1 ? key : key.slice(separator + 1),
+    };
   }
 
   private computeEntryHash(
@@ -1185,11 +1263,11 @@ export class QueryLogSqliteService implements OnModuleInit, OnModuleDestroy {
 
     const sql = deduplicatePerClient
       ? `SELECT COUNT(*) AS count FROM (
-           SELECT qnameLc, clientIpLc
+           SELECT qnameLc, groupId, clientIpLc
            FROM query_log_entries
            ${base.whereSql}
            AND qnameLc IS NOT NULL
-           GROUP BY qnameLc, clientIpLc
+           GROUP BY qnameLc, groupId, clientIpLc
          )`
       : `SELECT COUNT(DISTINCT qnameLc) AS count
          FROM query_log_entries
@@ -1210,13 +1288,15 @@ export class QueryLogSqliteService implements OnModuleInit, OnModuleDestroy {
   ): StoredLogRowWithClient[] {
     if (!this.db) return [];
 
-    const partition = deduplicatePerClient ? "qnameLc, clientIpLc" : "qnameLc";
+    const partition = deduplicatePerClient
+      ? "qnameLc, groupId, clientIpLc"
+      : "qnameLc";
 
     if (!useIndexedGrouping) {
       return this.db
         .prepare(
           `WITH ranked AS (
-            SELECT nodeId, baseUrl, clientIpAddress, clientName, data, ts,
+            SELECT nodeId, baseUrl, groupId, clientIpAddress, clientName, data, ts,
               ROW_NUMBER() OVER (
                 PARTITION BY ${partition}
                 ORDER BY blockedRank DESC, aRank DESC, ts DESC
@@ -1225,7 +1305,7 @@ export class QueryLogSqliteService implements OnModuleInit, OnModuleDestroy {
             ${base.whereSql}
             AND qnameLc IS NOT NULL
           )
-          SELECT nodeId, baseUrl, clientIpAddress, clientName, data
+          SELECT nodeId, baseUrl, groupId, clientIpAddress, clientName, data
           FROM ranked
           WHERE rn = 1
           ORDER BY ts ${sortDir}
@@ -1244,7 +1324,7 @@ export class QueryLogSqliteService implements OnModuleInit, OnModuleDestroy {
     return this.db
       .prepare(
         `WITH best AS (
-          SELECT nodeId, baseUrl, clientIpAddress, clientName, data, ts,
+          SELECT nodeId, baseUrl, groupId, clientIpAddress, clientName, data, ts,
             MAX(
               blockedRank * 4000000000000000 +
               aRank * 2000000000000000 +
@@ -1255,7 +1335,7 @@ export class QueryLogSqliteService implements OnModuleInit, OnModuleDestroy {
           AND qnameLc IS NOT NULL
           GROUP BY ${partition}
         )
-        SELECT nodeId, baseUrl, clientIpAddress, clientName, data
+        SELECT nodeId, baseUrl, groupId, clientIpAddress, clientName, data
         FROM best
         ORDER BY ts ${sortDir}
         LIMIT ? OFFSET ?`,
@@ -1310,6 +1390,7 @@ export class QueryLogSqliteService implements OnModuleInit, OnModuleDestroy {
           ...parsedUnknown,
           nodeId: row.nodeId,
           baseUrl: row.baseUrl,
+          groupId: row.groupId,
         };
 
         if (
@@ -1467,7 +1548,7 @@ export class QueryLogSqliteService implements OnModuleInit, OnModuleDestroy {
     if (!deduplicateDomains) {
       rows = this.db
         .prepare(
-          `SELECT nodeId, baseUrl, clientIpAddress, clientName, data
+          `SELECT nodeId, baseUrl, groupId, clientIpAddress, clientName, data
            FROM query_log_entries
            ${base.whereSql}
            ORDER BY ts ${sortDir}
@@ -1644,7 +1725,7 @@ export class QueryLogSqliteService implements OnModuleInit, OnModuleDestroy {
     if (!deduplicateDomains) {
       rows = this.db
         .prepare(
-          `SELECT nodeId, baseUrl, clientIpAddress, clientName, data
+          `SELECT nodeId, baseUrl, groupId, clientIpAddress, clientName, data
            FROM query_log_entries
            ${base.whereSql}
            ORDER BY ts ${sortDir}

--- a/apps/backend/src/technitium/technitium-config.spec.ts
+++ b/apps/backend/src/technitium/technitium-config.spec.ts
@@ -1,0 +1,69 @@
+import {
+  INTERNAL_DEFAULT_GROUP_ID,
+  loadTechnitiumNodeConfigs,
+} from "./technitium-config";
+
+describe("Technitium node group configuration", () => {
+  const logger = { warn: jest.fn() };
+
+  beforeEach(() => logger.warn.mockClear());
+
+  it("preserves implicit single-cluster behavior in the internal default group", () => {
+    const nodes = loadTechnitiumNodeConfigs(
+      {
+        TECHNITIUM_NODES: "node-a,node-b",
+        TECHNITIUM_NODEA_BASE_URL: "https://node-a.example.test",
+        TECHNITIUM_NODEB_BASE_URL: "https://node-b.example.test",
+      },
+      logger,
+    );
+    expect(nodes.map((node) => node.groupId)).toEqual([
+      INTERNAL_DEFAULT_GROUP_ID,
+      INTERNAL_DEFAULT_GROUP_ID,
+    ]);
+  });
+
+  it("accepts explicit lowercase group slugs", () => {
+    const nodes = loadTechnitiumNodeConfigs(
+      {
+        TECHNITIUM_NODES: "node-a,node-b",
+        TECHNITIUM_NODEA_BASE_URL: "https://node-a.example.test",
+        TECHNITIUM_NODEA_GROUP: "site-a",
+        TECHNITIUM_NODEB_BASE_URL: "https://node-b.example.test",
+        TECHNITIUM_NODEB_GROUP: "site.b_2",
+      },
+      logger,
+    );
+    expect(nodes.map((node) => node.groupId)).toEqual(["site-a", "site.b_2"]);
+  });
+
+  it("rejects mixed explicit and implicit grouping", () => {
+    expect(() =>
+      loadTechnitiumNodeConfigs(
+        {
+          TECHNITIUM_NODES: "node-a,node-b",
+          TECHNITIUM_NODEA_BASE_URL: "https://node-a.example.test",
+          TECHNITIUM_NODEA_GROUP: "site-a",
+          TECHNITIUM_NODEB_BASE_URL: "https://node-b.example.test",
+        },
+        logger,
+      ),
+    ).toThrow(/grouping is mixed/);
+  });
+
+  it.each(["Site-A", "-site", "__default__", "", "a".repeat(64)])(
+    "rejects malformed or reserved group ID %p",
+    (groupId) => {
+      expect(() =>
+        loadTechnitiumNodeConfigs(
+          {
+            TECHNITIUM_NODES: "node-a",
+            TECHNITIUM_NODEA_BASE_URL: "https://node-a.example.test",
+            TECHNITIUM_NODEA_GROUP: groupId,
+          },
+          logger,
+        ),
+      ).toThrow(/group IDs must be lowercase slugs/);
+    },
+  );
+});

--- a/apps/backend/src/technitium/technitium-config.ts
+++ b/apps/backend/src/technitium/technitium-config.ts
@@ -1,0 +1,117 @@
+import type { Logger } from "@nestjs/common";
+import type { TechnitiumNodeConfig } from "./technitium.types";
+
+export const INTERNAL_DEFAULT_GROUP_ID = "__default__";
+export const TECHNITIUM_GROUP_ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,62}$/;
+
+export function hasImplicitNodeGrouping(
+  nodes: readonly TechnitiumNodeConfig[],
+): boolean {
+  return (
+    nodes.length > 0 &&
+    nodes.every((node) => nodeGroupId(node) === INTERNAL_DEFAULT_GROUP_ID)
+  );
+}
+
+export function nodeGroupId(
+  node: Pick<TechnitiumNodeConfig, "groupId">,
+): string {
+  return node.groupId ?? INTERNAL_DEFAULT_GROUP_ID;
+}
+
+export function configuredGroupIds(
+  nodes: readonly TechnitiumNodeConfig[],
+): string[] {
+  return [...new Set(nodes.map((node) => nodeGroupId(node)))].sort((a, b) =>
+    a.localeCompare(b),
+  );
+}
+
+export function loadTechnitiumNodeConfigs(
+  env: NodeJS.ProcessEnv,
+  logger: Pick<Logger, "warn">,
+): TechnitiumNodeConfig[] {
+  const rawNodes = env.TECHNITIUM_NODES;
+  if (!rawNodes) {
+    logger.warn("No Technitium DNS nodes configured via TECHNITIUM_NODES");
+    return [];
+  }
+
+  const ids = rawNodes
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  const entries = ids.map((id) => {
+    const sanitizedKey = id.replace(/[^A-Za-z0-9]/g, "").toUpperCase();
+    return {
+      id,
+      sanitizedKey,
+      groupId: env[`TECHNITIUM_${sanitizedKey}_GROUP`]?.trim(),
+    };
+  });
+  const hasExplicitGroup = entries.some((entry) => entry.groupId !== undefined);
+
+  if (
+    hasExplicitGroup &&
+    entries.some((entry) => entry.groupId === undefined)
+  ) {
+    throw new Error(
+      "Technitium node grouping is mixed: when any TECHNITIUM_<NODE>_GROUP is set, every configured node must declare a group.",
+    );
+  }
+
+  if (hasExplicitGroup) {
+    for (const entry of entries) {
+      const groupId = entry.groupId ?? "";
+      if (
+        groupId.startsWith("__") ||
+        !TECHNITIUM_GROUP_ID_PATTERN.test(groupId)
+      ) {
+        throw new Error(
+          "Technitium node group IDs must be lowercase slugs of 1-63 characters and may not begin with a reserved double underscore.",
+        );
+      }
+    }
+  }
+
+  const configs: TechnitiumNodeConfig[] = [];
+  for (const entry of entries) {
+    const { id, sanitizedKey } = entry;
+    const name = env[`TECHNITIUM_${sanitizedKey}_NAME`];
+    const baseUrl = env[`TECHNITIUM_${sanitizedKey}_BASE_URL`];
+    const token = env[`TECHNITIUM_${sanitizedKey}_TOKEN`];
+    const queryLoggerAppName =
+      env[`TECHNITIUM_${sanitizedKey}_QUERY_LOGGER_APP_NAME`];
+    const queryLoggerClassPath =
+      env[`TECHNITIUM_${sanitizedKey}_QUERY_LOGGER_CLASS_PATH`];
+
+    if (!baseUrl) {
+      logger.warn(
+        `Skipping node "${id}" because TECHNITIUM_${sanitizedKey}_BASE_URL is not set.`,
+      );
+      continue;
+    }
+    if (!token) {
+      logger.warn(
+        `Node "${id}" has no env token configured; it will require user login sessions for interactive access (v1.4+).`,
+      );
+    }
+
+    configs.push({
+      id,
+      name: name || id,
+      baseUrl,
+      token: token ?? "",
+      groupId: entry.groupId ?? INTERNAL_DEFAULT_GROUP_ID,
+      queryLoggerAppName,
+      queryLoggerClassPath,
+    });
+  }
+
+  if (configs.length === 0) {
+    logger.warn(
+      "Technitium DNS configuration contained node ids but none were fully configured.",
+    );
+  }
+  return configs;
+}

--- a/apps/backend/src/technitium/technitium.controller.ts
+++ b/apps/backend/src/technitium/technitium.controller.ts
@@ -12,6 +12,7 @@ import {
   Post,
   Query,
   Res,
+  ServiceUnavailableException,
   UseInterceptors,
 } from "@nestjs/common";
 import { Throttle } from "@nestjs/throttler";
@@ -52,6 +53,35 @@ export class TechnitiumController {
     private readonly advancedBlockingService: AdvancedBlockingService,
     private readonly dnsFilteringSnapshotService: DnsFilteringSnapshotService,
   ) {}
+
+  private requireWritePlan(
+    perCandidate: Map<
+      string,
+      {
+        writeTarget?: string;
+        flushNodes: string[];
+        skippedFlushNodes?: string[];
+        reason?: string;
+      }
+    >,
+    nodeId: string,
+  ): {
+    writeTarget: string;
+    flushNodes: string[];
+    skippedFlushNodes: string[];
+  } {
+    const plan = perCandidate.get(nodeId);
+    if (!plan?.writeTarget) {
+      throw new ServiceUnavailableException(
+        plan?.reason ?? "No validated Primary is available for this group.",
+      );
+    }
+    return {
+      writeTarget: plan.writeTarget,
+      flushNodes: plan.flushNodes,
+      skippedFlushNodes: plan.skippedFlushNodes ?? [],
+    };
+  }
 
   @Get("logs/storage")
   getQueryLogStorageStatus() {
@@ -549,7 +579,7 @@ export class TechnitiumController {
   async getAdvancedBlockingRawConfig(@Param("nodeId") nodeId: string) {
     const { perCandidate } =
       await this.technitiumService.resolveClusterWriteTargets([nodeId]);
-    const writeNodeId = perCandidate.get(nodeId)?.writeTarget ?? nodeId;
+    const writeNodeId = this.requireWritePlan(perCandidate, nodeId).writeTarget;
     return this.advancedBlockingService.getRawConfig(writeNodeId);
   }
 
@@ -570,7 +600,7 @@ export class TechnitiumController {
 
     const { perCandidate } =
       await this.technitiumService.resolveClusterWriteTargets([nodeId]);
-    const writeNodeId = perCandidate.get(nodeId)?.writeTarget ?? nodeId;
+    const writeNodeId = this.requireWritePlan(perCandidate, nodeId).writeTarget;
 
     try {
       await this.dnsFilteringSnapshotService.saveSnapshot(
@@ -609,7 +639,7 @@ export class TechnitiumController {
 
     const { perCandidate } =
       await this.technitiumService.resolveClusterWriteTargets([nodeId]);
-    const writeNodeId = perCandidate.get(nodeId)?.writeTarget ?? nodeId;
+    const writeNodeId = this.requireWritePlan(perCandidate, nodeId).writeTarget;
     return this.advancedBlockingService.mutateDomainComment(writeNodeId, body);
   }
 
@@ -629,9 +659,9 @@ export class TechnitiumController {
 
     const { perCandidate } =
       await this.technitiumService.resolveClusterWriteTargets([nodeId]);
-    const writePlan = perCandidate.get(nodeId);
-    const writeNodeId = writePlan?.writeTarget ?? nodeId;
-    const flushNodeIds = writePlan?.flushNodes ?? [writeNodeId];
+    const writePlan = this.requireWritePlan(perCandidate, nodeId);
+    const writeNodeId = writePlan.writeTarget;
+    const flushNodeIds = writePlan.flushNodes;
 
     // Best-effort automatic snapshot for rollback before applying changes.
     // Do not block the save if snapshot creation fails.
@@ -640,6 +670,12 @@ export class TechnitiumController {
     const snapshotNote = requestNote.length > 0 ? requestNote : undefined;
     const cacheDomain =
       typeof body.cacheDomain === "string" ? body.cacheDomain.trim() : "";
+    const cacheFlush = cacheDomain
+      ? {
+          flushedNodeIds: [] as string[],
+          skippedNodeIds: [...writePlan.skippedFlushNodes],
+        }
+      : undefined;
 
     try {
       await this.dnsFilteringSnapshotService.saveSnapshot(
@@ -671,7 +707,9 @@ export class TechnitiumController {
               url: "/api/cache/delete",
               params: { domain: cacheDomain },
             });
+            cacheFlush?.flushedNodeIds.push(flushNodeId);
           } catch (error) {
+            cacheFlush?.skippedNodeIds.push(flushNodeId);
             this.logger.warn(
               `Failed to invalidate cached domain ${cacheDomain} on node ${flushNodeId} after Advanced Blocking save: ${error instanceof Error ? error.message : String(error)}`,
             );
@@ -680,7 +718,10 @@ export class TechnitiumController {
       );
     }
 
-    return snapshot;
+    return {
+      ...snapshot,
+      ...(cacheFlush ? { cacheFlush } : {}),
+    };
   }
 
   @Post(":nodeId/dhcp/scopes/:scopeName/clone")

--- a/apps/backend/src/technitium/technitium.module.ts
+++ b/apps/backend/src/technitium/technitium.module.ts
@@ -33,6 +33,7 @@ import { SplitHorizonPtrStateService } from "./split-horizon-ptr/split-horizon-p
 import { SplitHorizonPtrController } from "./split-horizon-ptr/split-horizon-ptr.controller";
 import { SplitHorizonPtrService } from "./split-horizon-ptr/split-horizon-ptr.service";
 import { TECHNITIUM_NODES_TOKEN } from "./technitium.constants";
+import { loadTechnitiumNodeConfigs } from "./technitium-config";
 import { TechnitiumController } from "./technitium.controller";
 import { TechnitiumService } from "./technitium.service";
 import { TechnitiumNodeConfig } from "./technitium.types";
@@ -93,62 +94,7 @@ import { ZoneSnapshotService } from "./zone-snapshot.service";
           return [];
         }
 
-        const rawNodes = process.env.TECHNITIUM_NODES;
-        if (!rawNodes) {
-          logger.warn(
-            "No Technitium DNS nodes configured via TECHNITIUM_NODES",
-          );
-          return [];
-        }
-
-        const ids = rawNodes
-          .split(",")
-          .map((value) => value.trim())
-          .filter(Boolean);
-
-        const configs: TechnitiumNodeConfig[] = [];
-
-        for (const id of ids) {
-          const sanitizedKey = id.replace(/[^A-Za-z0-9]/g, "").toUpperCase();
-          const name = process.env[`TECHNITIUM_${sanitizedKey}_NAME`];
-          const baseUrl = process.env[`TECHNITIUM_${sanitizedKey}_BASE_URL`];
-          // Legacy env-token mode uses per-node tokens only (Technitium DNS < v14 / migration).
-          const token = process.env[`TECHNITIUM_${sanitizedKey}_TOKEN`];
-          const queryLoggerAppName =
-            process.env[`TECHNITIUM_${sanitizedKey}_QUERY_LOGGER_APP_NAME`];
-          const queryLoggerClassPath =
-            process.env[`TECHNITIUM_${sanitizedKey}_QUERY_LOGGER_CLASS_PATH`];
-
-          if (!baseUrl) {
-            logger.warn(
-              `Skipping node "${id}" because TECHNITIUM_${sanitizedKey}_BASE_URL is not set.`,
-            );
-            continue;
-          }
-
-          if (!token) {
-            logger.warn(
-              `Node "${id}" has no env token configured; it will require user login sessions for interactive access (v1.4+).`,
-            );
-          }
-
-          configs.push({
-            id,
-            name: name || id, // Use name if provided, otherwise fall back to id
-            baseUrl,
-            token: token ?? "",
-            queryLoggerAppName,
-            queryLoggerClassPath,
-          });
-        }
-
-        if (configs.length === 0) {
-          logger.warn(
-            "Technitium DNS configuration contained node ids but none were fully configured.",
-          );
-        }
-
-        return configs;
+        return loadTechnitiumNodeConfigs(process.env, logger);
       },
     },
   ],

--- a/apps/backend/src/technitium/technitium.service.spec.ts
+++ b/apps/backend/src/technitium/technitium.service.spec.ts
@@ -5,6 +5,7 @@ import { promises as fs } from "fs";
 import os from "os";
 import path from "path";
 import { AuthRequestContext } from "../auth/auth-request-context";
+import type { AuthSession } from "../auth/auth.types";
 import { DhcpSnapshotService } from "./dhcp-snapshot.service";
 import { TechnitiumService } from "./technitium.service";
 import {
@@ -930,7 +931,7 @@ describe("TechnitiumService — logScheduleTokenValidationOutcome", () => {
           validated: true;
           valid: boolean;
           hasAppsModify: boolean;
-          hasCacheModify: boolean;
+          hasCacheDelete: boolean;
           username?: string;
           reason?: string;
           transient?: boolean;
@@ -953,7 +954,7 @@ describe("TechnitiumService — logScheduleTokenValidationOutcome", () => {
       validated: true,
       valid: true,
       hasAppsModify: true,
-      hasCacheModify: true,
+      hasCacheDelete: true,
       username: "companion-schedule",
     };
     s.logScheduleTokenValidationOutcome();
@@ -970,7 +971,7 @@ describe("TechnitiumService — logScheduleTokenValidationOutcome", () => {
       validated: true,
       valid: true,
       hasAppsModify: false,
-      hasCacheModify: true,
+      hasCacheDelete: true,
       username: "low-priv",
       reason:
         "Token authenticated but lacks Apps: Modify permission needed to update Advanced Blocking config.",
@@ -985,20 +986,20 @@ describe("TechnitiumService — logScheduleTokenValidationOutcome", () => {
     );
   });
 
-  it("warns when Cache: Modify is missing (flushCacheOnChange will fail)", () => {
+  it("warns when Cache: Delete is missing (flushCacheOnChange will fail)", () => {
     const s = build();
     s.scheduleTokenValidation = {
       validated: true,
       valid: true,
       hasAppsModify: true,
-      hasCacheModify: false,
+      hasCacheDelete: false,
       username: "apps-only",
     };
     s.logScheduleTokenValidationOutcome();
     expect(s.logger.log).not.toHaveBeenCalled();
     expect(s.logger.warn).toHaveBeenCalledTimes(1);
     const msg = s.logger.warn.mock.calls[0][0];
-    expect(msg).toContain("missing Cache: Modify");
+    expect(msg).toContain("missing Cache: Delete");
     expect(msg).toContain("flushCacheOnChange=true");
     expect(msg).toContain("apply/remove will otherwise work");
   });
@@ -1009,7 +1010,7 @@ describe("TechnitiumService — logScheduleTokenValidationOutcome", () => {
       validated: true,
       valid: false,
       hasAppsModify: false,
-      hasCacheModify: false,
+      hasCacheDelete: false,
       transient: true,
       reason: `Failed to validate TECHNITIUM_SCHEDULE_TOKEN against node "nodeB": read ECONNRESET`,
     };
@@ -1029,7 +1030,7 @@ describe("TechnitiumService — logScheduleTokenValidationOutcome", () => {
       validated: true,
       valid: false,
       hasAppsModify: false,
-      hasCacheModify: false,
+      hasCacheDelete: false,
       reason: `TECHNITIUM_SCHEDULE_TOKEN was rejected by node "nodeB": invalid token.`,
     };
     s.logScheduleTokenValidationOutcome();
@@ -1046,7 +1047,7 @@ describe("TechnitiumService — logScheduleTokenValidationOutcome", () => {
       validated: true,
       valid: false,
       hasAppsModify: false,
-      hasCacheModify: false,
+      hasCacheDelete: false,
       reason: "TECHNITIUM_SCHEDULE_TOKEN is not set.",
     };
     s.logScheduleTokenValidationOutcome();
@@ -1185,12 +1186,18 @@ describe("TechnitiumService — resolveClusterWriteTargets", () => {
 
   function summary(
     id: string,
-    opts: { domain?: string; primary?: boolean; clustered?: boolean } = {},
+    opts: {
+      domain?: string;
+      groupId?: string;
+      primary?: boolean;
+      clustered?: boolean;
+    } = {},
   ): TechnitiumNodeSummary {
     const clustered = opts.clustered ?? !!opts.domain;
     return {
       id,
       baseUrl: `https://${id}.test`,
+      groupId: opts.groupId ?? "__default__",
       clusterState: clustered
         ? {
             initialized: true,
@@ -1238,10 +1245,10 @@ describe("TechnitiumService — resolveClusterWriteTargets", () => {
 
   it("handles two independent clusters — each writes to its own Primary", async () => {
     const nodes = [
-      summary("a1", { domain: "A", primary: true }),
-      summary("a2", { domain: "A" }),
-      summary("b1", { domain: "B", primary: true }),
-      summary("b2", { domain: "B" }),
+      summary("a1", { domain: "A", groupId: "site-a", primary: true }),
+      summary("a2", { domain: "A", groupId: "site-a" }),
+      summary("b1", { domain: "B", groupId: "site-b", primary: true }),
+      summary("b2", { domain: "B", groupId: "site-b" }),
     ];
     const { perCandidate, writeTargets } =
       await service.resolveClusterWriteTargets(["a1", "a2", "b1", "b2"], nodes);
@@ -1304,6 +1311,300 @@ describe("TechnitiumService — resolveClusterWriteTargets", () => {
       flushNodes: ["ghost"],
     });
     expect(writeTargets).toEqual(["ghost"]);
+  });
+
+  it("never crosses explicit groups even when cluster domains are identical", async () => {
+    const configs: TechnitiumNodeConfig[] = [
+      {
+        id: "a-primary",
+        baseUrl: "https://a-primary.test",
+        token: "",
+        groupId: "site-a",
+      },
+      {
+        id: "a-secondary",
+        baseUrl: "https://a-secondary.test",
+        token: "",
+        groupId: "site-a",
+      },
+      {
+        id: "b-primary",
+        baseUrl: "https://b-primary.test",
+        token: "",
+        groupId: "site-b",
+      },
+      {
+        id: "b-secondary",
+        baseUrl: "https://b-secondary.test",
+        token: "",
+        groupId: "site-b",
+      },
+    ];
+    service.onModuleDestroy();
+    service = new TechnitiumService(configs, new DhcpSnapshotService());
+    (
+      service as unknown as { scheduleGroupCredentials: unknown }
+    ).scheduleGroupCredentials = {
+      anyReady: true,
+      allReady: true,
+      groups: ["site-a", "site-b"].map((groupId) => {
+        const ids = configs
+          .filter((node) => node.groupId === groupId)
+          .map((node) => node.id);
+        return {
+          groupId,
+          state: "ready",
+          authenticatedNodeIds: ids,
+          unreachableNodeIds: [],
+          failedNodeIds: [],
+          admittedNodeIds: {
+            interactive: ids,
+            ptrRead: ids,
+            dhcpRead: ids,
+            primaryConfigWrite: ids,
+            cacheFlush: ids,
+          },
+          capabilities: {
+            ptrRead: true,
+            dhcpRead: true,
+            primaryConfigWrite: true,
+            cacheFlush: true,
+          },
+        };
+      }),
+    };
+    const summaries: TechnitiumNodeSummary[] = configs.map((node) => ({
+      id: node.id,
+      baseUrl: node.baseUrl,
+      groupId: node.groupId,
+      clusterState: {
+        initialized: true,
+        domain: "same-reported-domain.example",
+        type: node.id.endsWith("primary") ? "Primary" : "Secondary",
+      },
+      isPrimary: node.id.endsWith("primary"),
+    }));
+
+    const { perCandidate } = await service.resolveClusterWriteTargets(
+      configs.map((node) => node.id),
+      summaries,
+    );
+    expect(perCandidate.get("a-secondary")).toEqual({
+      writeTarget: "a-primary",
+      flushNodes: ["a-primary", "a-secondary"],
+    });
+    expect(perCandidate.get("b-secondary")).toEqual({
+      writeTarget: "b-primary",
+      flushNodes: ["b-primary", "b-secondary"],
+    });
+  });
+
+  it("does not direct-write when an explicit group has no admitted Primary", async () => {
+    const configs: TechnitiumNodeConfig[] = [
+      {
+        id: "secondary",
+        baseUrl: "https://secondary.test",
+        token: "",
+        groupId: "site-a",
+      },
+    ];
+    service.onModuleDestroy();
+    service = new TechnitiumService(configs, new DhcpSnapshotService());
+    const result = await service.resolveClusterWriteTargets(
+      ["secondary"],
+      [
+        {
+          id: "secondary",
+          baseUrl: "https://secondary.test",
+          groupId: "site-a",
+          clusterState: {
+            initialized: true,
+            domain: "site",
+            type: "Secondary",
+          },
+          isPrimary: false,
+        },
+      ],
+    );
+    expect(result.perCandidate.get("secondary")?.writeTarget).toBeUndefined();
+    expect(result.perCandidate.get("secondary")?.reason).toContain(
+      "no reachable, validated, admitted Primary",
+    );
+  });
+});
+
+describe("TechnitiumService — trusted SSO node readmission", () => {
+  const configs: TechnitiumNodeConfig[] = [
+    {
+      id: "a-primary",
+      baseUrl: "https://a-primary.test",
+      token: "",
+      groupId: "site-a",
+    },
+    {
+      id: "a-secondary",
+      baseUrl: "https://a-secondary.test",
+      token: "",
+      groupId: "site-a",
+    },
+    {
+      id: "b-primary",
+      baseUrl: "https://b-primary.test",
+      token: "",
+      groupId: "site-b",
+    },
+  ];
+  let service: TechnitiumService;
+
+  const group = (
+    groupId: string,
+    authenticatedNodeIds: string[],
+    unreachableNodeIds: string[],
+  ) => ({
+    groupId,
+    state:
+      unreachableNodeIds.length > 0
+        ? ("degraded" as const)
+        : ("ready" as const),
+    verifiedUsername: `${groupId}-operator`,
+    authenticatedNodeIds,
+    unreachableNodeIds,
+    failedNodeIds: [],
+    admittedNodeIds: {
+      interactive: [...authenticatedNodeIds],
+      ptrRead: [...authenticatedNodeIds],
+      dhcpRead: [...authenticatedNodeIds],
+      primaryConfigWrite: groupId === "site-b" ? [...authenticatedNodeIds] : [],
+      cacheFlush: [...authenticatedNodeIds],
+    },
+    capabilities: {
+      ptrRead: authenticatedNodeIds.length > 0,
+      dhcpRead: authenticatedNodeIds.length > 0,
+      primaryConfigWrite: groupId === "site-b",
+      cacheFlush: authenticatedNodeIds.length > 0,
+    },
+  });
+
+  const session = (): AuthSession => ({
+    id: "session",
+    createdAt: new Date().toISOString(),
+    lastSeenAt: Date.now(),
+    user: "operator@example.test",
+    authSource: "trusted-sso",
+    tokensByNodeId: {
+      "a-secondary": "site-a-token",
+      "b-primary": "site-b-token",
+    },
+    pendingTokensByNodeId: { "a-primary": "site-a-token" },
+    credentialUsernamesByGroup: {
+      "site-a": "site-a-operator",
+      "site-b": "site-b-operator",
+    },
+    verifiedUsernamesByGroup: {
+      "site-a": "site-a-operator",
+      "site-b": "site-b-operator",
+    },
+    topologyDomainsByGroup: {
+      "site-a": "a.example.test",
+      "site-b": "b.example.test",
+    },
+    groupCredentials: {
+      anyReady: true,
+      allReady: false,
+      groups: [
+        group("site-a", ["a-secondary"], ["a-primary"]),
+        group("site-b", ["b-primary"], []),
+      ],
+    },
+    nodeAuthStatesByNodeId: {
+      "a-primary": { status: "unreachable" },
+      "a-secondary": { status: "authenticated" },
+      "b-primary": { status: "authenticated" },
+    },
+  });
+
+  beforeEach(() => {
+    process.env.NODE_ENV = "test";
+    service = new TechnitiumService(configs, new DhcpSnapshotService());
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    service.onModuleDestroy();
+  });
+
+  it("revalidates a returning Primary before admitting group-scoped writes", async () => {
+    jest.spyOn(service, "validateExplicitSessionToken").mockResolvedValue({
+      username: "site-a-operator",
+      permissions: {
+        DnsClient: { canView: true },
+        DhcpServer: { canView: true },
+        Apps: { canModify: true },
+        Cache: { canDelete: true },
+      },
+      clusterInitialized: true,
+      clusterDomain: "a.example.test",
+      dnsServerDomain: "a-primary.example.test",
+      clusterNodes: [
+        {
+          name: "a-primary.example.test",
+          url: "https://a-primary.test",
+          type: "Primary",
+        },
+      ],
+    });
+    const current = session();
+
+    await (
+      service as unknown as {
+        revalidatePendingSessionNode: (
+          session: AuthSession,
+          node: TechnitiumNodeConfig,
+        ) => Promise<void>;
+      }
+    ).revalidatePendingSessionNode(current, configs[0]);
+
+    expect(current.tokensByNodeId["a-primary"]).toBe("site-a-token");
+    expect(current.pendingTokensByNodeId?.["a-primary"]).toBeUndefined();
+    expect(
+      current.groupCredentials?.groups[0].admittedNodeIds.primaryConfigWrite,
+    ).toEqual(["a-primary"]);
+    expect(current.groupCredentials?.groups[0].state).toBe("ready");
+    expect(current.tokensByNodeId["b-primary"]).toBe("site-b-token");
+  });
+
+  it("fails only the returning node's group on a topology mismatch", async () => {
+    jest.spyOn(service, "validateExplicitSessionToken").mockResolvedValue({
+      username: "site-a-operator",
+      permissions: { Apps: { canModify: true } },
+      clusterInitialized: true,
+      clusterDomain: "wrong.example.test",
+      dnsServerDomain: "a-primary.example.test",
+      clusterNodes: [
+        {
+          name: "a-primary.example.test",
+          url: "https://a-primary.test",
+          type: "Primary",
+        },
+      ],
+    });
+    const current = session();
+
+    await expect(
+      (
+        service as unknown as {
+          revalidatePendingSessionNode: (
+            session: AuthSession,
+            node: TechnitiumNodeConfig,
+          ) => Promise<void>;
+        }
+      ).revalidatePendingSessionNode(current, configs[0]),
+    ).rejects.toBeInstanceOf(UnauthorizedException);
+
+    expect(current.groupCredentials?.groups[0].state).toBe("failed");
+    expect(current.tokensByNodeId["a-secondary"]).toBeUndefined();
+    expect(current.tokensByNodeId["b-primary"]).toBe("site-b-token");
+    expect(current.groupCredentials?.groups[1].state).toBe("ready");
   });
 });
 
@@ -1368,6 +1669,71 @@ describe("TechnitiumService — cluster probe failover", () => {
       true,
     );
   });
+
+  it("matches current plural cluster node IP addresses returned by v15", async () => {
+    const nodes: TechnitiumNodeConfig[] = [
+      {
+        id: "site-a-primary",
+        baseUrl: "http://site-a-primary:5380",
+        token: "token",
+        groupId: "site-a",
+      },
+      {
+        id: "site-a-secondary",
+        baseUrl: "http://site-a-secondary:5380",
+        token: "token",
+        groupId: "site-a",
+      },
+    ];
+    service = new TechnitiumService(nodes, new DhcpSnapshotService());
+    const internals = service as unknown as {
+      request: jest.Mock;
+      resolveHostname: jest.Mock;
+    };
+    internals.request = jest.fn().mockResolvedValue({
+      status: "ok",
+      info: {
+        clusterInitialized: true,
+        clusterDomain: "site-a.test",
+        clusterNodes: [
+          {
+            id: 1,
+            name: "a-primary.site-a.test",
+            url: "https://a-primary.site-a.test:53443/",
+            ipAddresses: ["172.30.111.10"],
+            type: "Primary",
+            state: "Self",
+          },
+          {
+            id: 2,
+            name: "a-secondary.site-a.test",
+            url: "https://a-secondary.site-a.test:53443/",
+            ipAddresses: ["172.30.111.11"],
+            type: "Secondary",
+            state: "Connected",
+          },
+        ],
+      },
+    });
+    internals.resolveHostname = jest
+      .fn()
+      .mockImplementation((hostname: string) =>
+        Promise.resolve(
+          hostname === "site-a-primary"
+            ? "172.30.111.10"
+            : hostname === "site-a-secondary"
+              ? "172.30.111.11"
+              : undefined,
+        ),
+      );
+
+    const summaries = await service.listNodes({ authMode: "background" });
+
+    expect(summaries).toEqual([
+      expect.objectContaining({ id: "site-a-primary", isPrimary: true }),
+      expect.objectContaining({ id: "site-a-secondary", isPrimary: false }),
+    ]);
+  });
 });
 
 describe("TechnitiumService — DHCP scope capability routing", () => {
@@ -1395,16 +1761,17 @@ describe("TechnitiumService — DHCP scope capability routing", () => {
     >;
     getAllDhcpLeasesWithOptions: (options: {
       authMode: "session" | "background";
+      sourceGroupId?: string;
     }) => Promise<Map<string, string>>;
     refreshDhcpScopeCapabilitiesIfNeeded: () => Promise<void>;
     enrichQueryLogEntriesWithCachedHostnames: <T>(entries: T[]) => T[];
     invalidateDhcpScopeCapability: (nodeId: string) => void;
     isDhcpScopeMutation: (url: string | undefined) => boolean;
     dhcpScopeCapabilities: Map<string, CapabilityState>;
-    dhcpLeaseCacheForBackground?: {
-      map: Map<string, string>;
-      fetchedAt: number;
-    };
+    dhcpLeaseCacheForBackground: Map<
+      string,
+      { map: Map<string, string>; fetchedAt: number }
+    >;
     logger: { log: jest.Mock; warn: jest.Mock };
   }
 
@@ -1516,7 +1883,7 @@ describe("TechnitiumService — DHCP scope capability routing", () => {
     );
 
     await internal.getAllDhcpLeasesWithOptions({ authMode: "background" });
-    internal.dhcpLeaseCacheForBackground = undefined;
+    internal.dhcpLeaseCacheForBackground.clear();
     for (const state of internal.dhcpScopeCapabilities.values()) {
       state.checkedAt = 0;
     }
@@ -1537,10 +1904,10 @@ describe("TechnitiumService — DHCP scope capability routing", () => {
   });
 
   it("enriches stored entries from local caches without node requests", () => {
-    internal.dhcpLeaseCacheForBackground = {
+    internal.dhcpLeaseCacheForBackground.set("__all__", {
       map: new Map([["192.0.2.30", "cached-client"]]),
       fetchedAt: Date.now(),
-    };
+    });
     internal.getDhcpLeases = jest.fn(() =>
       Promise.reject(new Error("must not be called")),
     );
@@ -1565,16 +1932,168 @@ describe("TechnitiumService — DHCP scope capability routing", () => {
       retryAfter: 0,
       hasSuccessfulScan: true,
     });
-    internal.dhcpLeaseCacheForBackground = {
+    internal.dhcpLeaseCacheForBackground.set("__all__", {
       map: new Map([["192.0.2.30", "cached-client"]]),
       fetchedAt: Date.now(),
-    };
+    });
 
     expect(internal.isDhcpScopeMutation("/api/dhcp/scopes/enable")).toBe(true);
     expect(internal.isDhcpScopeMutation("/api/dhcp/scopes/list")).toBe(false);
     internal.invalidateDhcpScopeCapability("active");
 
     expect(internal.dhcpScopeCapabilities.has("active")).toBe(false);
-    expect(internal.dhcpLeaseCacheForBackground).toBeUndefined();
+    expect(internal.dhcpLeaseCacheForBackground.size).toBe(0);
+  });
+});
+
+describe("TechnitiumService — grouped hostname isolation", () => {
+  it("uses groupId as the DHCP and cached PTR namespace for the same IP", async () => {
+    const nodes: TechnitiumNodeConfig[] = [
+      {
+        id: "site-a-node",
+        baseUrl: "https://site-a.example.test",
+        token: "",
+        groupId: "site-a",
+      },
+      {
+        id: "site-b-node",
+        baseUrl: "https://site-b.example.test",
+        token: "",
+        groupId: "site-b",
+      },
+      {
+        id: "site-a-unadmitted",
+        baseUrl: "https://site-a-unadmitted.example.test",
+        token: "",
+        groupId: "site-a",
+      },
+    ];
+    const service = new TechnitiumService(nodes, new DhcpSnapshotService());
+    const internal = service as unknown as {
+      enrichWithHostnames: <
+        T extends { clientIpAddress?: string; groupId?: string },
+      >(
+        entries: T[],
+        names: Map<string, string>,
+      ) => Array<T & { clientName?: string }>;
+      hostnameCache: Map<
+        string,
+        { hostname: string; lastUpdated: number; source: "ptr" }
+      >;
+      recentClientIps: Set<string>;
+      getAllDhcpLeases: jest.Mock;
+      getPtrLookupCandidateNodes: (
+        preferred: TechnitiumNodeConfig,
+      ) => TechnitiumNodeConfig[];
+      getDhcpLeaseCandidateNodes: (
+        authMode: "session" | "background",
+        sourceGroupId?: string,
+      ) => TechnitiumNodeConfig[];
+      performPtrLookup: (
+        node: TechnitiumNodeConfig,
+        ipAddress: string,
+      ) => Promise<void>;
+      request: jest.Mock;
+      backgroundGroupCredentials: {
+        anyReady: boolean;
+        allReady: boolean;
+        groups: Array<{
+          groupId: string;
+          admittedNodeIds: {
+            interactive: string[];
+            ptrRead: string[];
+            dhcpRead: string[];
+            primaryConfigWrite: string[];
+            cacheFlush: string[];
+          };
+        }>;
+      };
+      dhcpScopeCapabilities: Map<
+        string,
+        {
+          enabledScopeNames: Set<string>;
+          checkedAt: number;
+          retryAfter: number;
+          hasSuccessfulScan: boolean;
+        }
+      >;
+    };
+    internal.backgroundGroupCredentials = {
+      anyReady: true,
+      allReady: true,
+      groups: [
+        {
+          groupId: "site-a",
+          admittedNodeIds: {
+            interactive: ["site-a-node"],
+            ptrRead: ["site-a-node"],
+            dhcpRead: ["site-a-node"],
+            primaryConfigWrite: [],
+            cacheFlush: [],
+          },
+        },
+      ],
+    };
+    internal.hostnameCache.set("site-b\u0000192.168.1.20", {
+      hostname: "ptr-site-b",
+      lastUpdated: Date.now(),
+      source: "ptr",
+    });
+    const enriched = internal.enrichWithHostnames(
+      [
+        { groupId: "site-a", clientIpAddress: "192.168.1.20" },
+        { groupId: "site-b", clientIpAddress: "192.168.1.20" },
+      ],
+      new Map([["site-a\u0000192.168.1.20", "dhcp-site-a"]]),
+    );
+
+    expect(enriched.map((entry) => entry.clientName)).toEqual([
+      "dhcp-site-a",
+      "ptr-site-b",
+    ]);
+    expect(internal.recentClientIps).toEqual(
+      new Set(["site-a\u0000192.168.1.20", "site-b\u0000192.168.1.20"]),
+    );
+    internal.getAllDhcpLeases = jest.fn(() =>
+      Promise.resolve(new Map([["site-a\u0000192.168.1.20", "dhcp-site-a"]])),
+    );
+    await expect(service.getKnownClients()).resolves.toEqual([
+      {
+        groupId: "site-a",
+        ip: "192.168.1.20",
+        hostname: "dhcp-site-a",
+      },
+      {
+        groupId: "site-b",
+        ip: "192.168.1.20",
+        hostname: "ptr-site-b",
+      },
+    ]);
+    expect(
+      internal.getPtrLookupCandidateNodes(nodes[0]).map((node) => node.id),
+    ).toEqual(["site-a-node"]);
+    for (const node of nodes) {
+      internal.dhcpScopeCapabilities.set(node.id, {
+        enabledScopeNames: new Set(["scope"]),
+        checkedAt: Date.now(),
+        retryAfter: 0,
+        hasSuccessfulScan: true,
+      });
+    }
+    expect(
+      internal
+        .getDhcpLeaseCandidateNodes("background", "site-a")
+        .map((node) => node.id),
+    ).toEqual(["site-a-node"]);
+    internal.request = jest.fn(() =>
+      Promise.resolve({ status: "ok", response: {} }),
+    );
+    await internal.performPtrLookup(nodes[0], "192.168.1.21");
+    expect(internal.request).toHaveBeenCalledWith(
+      nodes[0],
+      expect.objectContaining({ url: "/api/dnsClient/resolve" }),
+      { authMode: "background", suppressNetworkErrorLog: true },
+    );
+    service.onModuleDestroy();
   });
 });

--- a/apps/backend/src/technitium/technitium.service.ts
+++ b/apps/backend/src/technitium/technitium.service.ts
@@ -1,6 +1,8 @@
 import {
   BadRequestException,
+  ForbiddenException,
   HttpException,
+  HttpStatus,
   Inject,
   Injectable,
   Logger,
@@ -13,8 +15,28 @@ import * as dns from "dns";
 import * as https from "https";
 import { promisify } from "util";
 import { AuthRequestContext } from "../auth/auth-request-context";
+import { loadAutomationCredentialMap } from "../auth/credential-map";
+import {
+  buildGroupCredentialEnvelope,
+  emptyAdmissions,
+  notAuthorizedGroupStatus,
+  singularVerifiedUsername,
+} from "../auth/group-credentials";
+import type { GroupCredential } from "../auth/group-credentials";
+import type {
+  AuthSession,
+  GroupCredentialStatus,
+  GroupCredentialStatusEnvelope,
+} from "../auth/auth.types";
+import { getEnvOrFile } from "../utils/env-file";
 import { DhcpSnapshotService } from "./dhcp-snapshot.service";
 import { TECHNITIUM_NODES_TOKEN } from "./technitium.constants";
+import {
+  configuredGroupIds,
+  hasImplicitNodeGrouping,
+  INTERNAL_DEFAULT_GROUP_ID,
+  nodeGroupId,
+} from "./technitium-config";
 import {
   DhcpSnapshot,
   DhcpSnapshotMetadata,
@@ -35,6 +57,7 @@ import {
   TechnitiumCombinedZoneRecordsOverview,
   TechnitiumCreateDhcpScopeRequest,
   TechnitiumCreateDhcpScopeResult,
+  TechnitiumCredentialProbe,
   TechnitiumDashboardStatsData,
   TechnitiumDhcpLeaseList,
   TechnitiumDhcpScope,
@@ -86,6 +109,7 @@ interface TechnitiumAppsListPayload {
 interface TechnitiumNodeQueryLogSnapshot {
   nodeId: string;
   baseUrl: string;
+  groupId: string;
   fetchedAt: string;
   data?: TechnitiumQueryLogPage;
   error?: string;
@@ -236,14 +260,39 @@ interface DhcpScopeCapabilityState {
   hasSuccessfulScan: boolean;
 }
 
+interface AutomationCredentialConfig {
+  configured: boolean;
+  source: "none" | "scalar" | "map" | "invalid";
+  credentialsByGroup: Map<string, GroupCredential>;
+  reason?: string;
+}
+
 @Injectable()
 export class TechnitiumService {
   private readonly logger = new Logger(TechnitiumService.name);
   private readonly sessionAuthEnabled = true;
-  private readonly backgroundToken =
-    (process.env.TECHNITIUM_BACKGROUND_TOKEN ?? "").trim() || undefined;
-  private readonly scheduleToken =
-    (process.env.TECHNITIUM_SCHEDULE_TOKEN ?? "").trim() || undefined;
+  private readonly backgroundToken = getEnvOrFile(
+    "TECHNITIUM_BACKGROUND_TOKEN",
+  );
+  private readonly scheduleToken = getEnvOrFile("TECHNITIUM_SCHEDULE_TOKEN");
+  private readonly backgroundCredentials: AutomationCredentialConfig;
+  private readonly scheduleCredentials: AutomationCredentialConfig;
+  private backgroundGroupCredentials?: GroupCredentialStatusEnvelope;
+  private scheduleGroupCredentials?: GroupCredentialStatusEnvelope;
+  private readonly sessionNodeReadmissionFlights = new Map<
+    string,
+    Promise<void>
+  >();
+  private readonly automationNodeReadmissionFlights = new Map<
+    string,
+    Promise<void>
+  >();
+  private readonly automationNodeRetryAfter = new Map<string, number>();
+  private readonly automationNodeRetryAttempts = new Map<string, number>();
+  private readonly backgroundTopologyDomainsByGroup = new Map<string, string>();
+  private readonly scheduleTopologyDomainsByGroup = new Map<string, string>();
+  private readonly SESSION_NODE_RETRY_BASE_MS = 5_000;
+  private readonly SESSION_NODE_RETRY_MAX_MS = 60_000;
 
   // Reuse a single Agent so Node can reuse sockets (and DNS results) instead of
   // resolving/reconnecting for every Technitium request.
@@ -269,7 +318,7 @@ export class TechnitiumService {
         validated: true;
         valid: boolean;
         hasAppsModify: boolean;
-        hasCacheModify: boolean;
+        hasCacheDelete: boolean;
         username?: string;
         reason?: string;
         transient?: boolean;
@@ -279,7 +328,7 @@ export class TechnitiumService {
     string,
     TechnitiumQueryLoggerMetadata
   >();
-  private lastClusterTopologyFingerprint?: string;
+  private readonly clusterTopologyFingerprints = new Map<string, string>();
   private readonly nodeClusterMappingFingerprints = new Map<string, string>();
 
   // Hostname resolution cache: IP → { hostname, lastUpdated, source }
@@ -300,10 +349,10 @@ export class TechnitiumService {
   private readonly DHCP_SCOPE_CAPABILITY_TTL_MS = 5 * 60 * 1000; // 5 minutes
   private readonly DHCP_SCOPE_DISCOVERY_RETRY_MS = 30 * 1000; // 30 seconds
   private readonly DHCP_SCOPE_DISCOVERY_TIMEOUT_MS = 5 * 1000; // 5 seconds
-  private dhcpLeaseCacheForBackground?: {
-    map: Map<string, string>;
-    fetchedAt: number;
-  };
+  private readonly dhcpLeaseCacheForBackground = new Map<
+    string,
+    { map: Map<string, string>; fetchedAt: number }
+  >();
   private readonly dhcpScopeCapabilities = new Map<
     string,
     DhcpScopeCapabilityState
@@ -344,9 +393,34 @@ export class TechnitiumService {
     private readonly dhcpSnapshotService: DhcpSnapshotService,
     private readonly zoneSnapshotService: ZoneSnapshotService,
   ) {
+    this.backgroundCredentials = this.loadAutomationCredentials("background");
+    this.scheduleCredentials = this.loadAutomationCredentials("schedule");
+
+    if (this.backgroundCredentials.reason) {
+      this.backgroundTokenValidation = {
+        validated: true,
+        okForPtr: false,
+        reason: this.backgroundCredentials.reason,
+      };
+      this.logger.warn(this.backgroundCredentials.reason);
+    }
+    if (this.scheduleCredentials.reason) {
+      this.scheduleTokenValidation = {
+        validated: true,
+        valid: false,
+        hasAppsModify: false,
+        hasCacheDelete: false,
+        reason: this.scheduleCredentials.reason,
+      };
+      this.logger.warn(this.scheduleCredentials.reason);
+    }
+
     // If TECHNITIUM_BACKGROUND_TOKEN is set, validate it so the UI can surface
     // scope/access issues globally. Only session-auth mode uses it for background PTR.
-    if (this.backgroundToken) {
+    if (
+      this.backgroundCredentials.configured &&
+      !this.backgroundCredentials.reason
+    ) {
       this.validateBackgroundTokenForPtr()
         .then((result) => {
           if (!result.okForPtr) {
@@ -391,6 +465,68 @@ export class TechnitiumService {
     this.startPtrTimer();
   }
 
+  private loadAutomationCredentials(
+    role: "background" | "schedule",
+  ): AutomationCredentialConfig {
+    const scalarName =
+      role === "background"
+        ? "TECHNITIUM_BACKGROUND_TOKEN"
+        : "TECHNITIUM_SCHEDULE_TOKEN";
+    const mapName = `${scalarName}_MAP_FILE`;
+    const scalar =
+      role === "background" ? this.backgroundToken : this.scheduleToken;
+    const mapPath = process.env[mapName]?.trim();
+    const configured = !!scalar || !!mapPath;
+    const disabled = (reason: string): AutomationCredentialConfig => ({
+      configured,
+      source: "invalid",
+      credentialsByGroup: new Map(),
+      reason,
+    });
+
+    if (scalar && mapPath) {
+      return disabled(
+        `${scalarName} and ${mapName} cannot both be configured; ${role} automation is disabled.`,
+      );
+    }
+    if (scalar) {
+      if (!hasImplicitNodeGrouping(this.nodeConfigs)) {
+        return disabled(
+          `${scalarName} is valid only with implicit single-group node configuration; ${role} automation is disabled.`,
+        );
+      }
+      return {
+        configured: true,
+        source: "scalar",
+        credentialsByGroup: new Map([
+          [INTERNAL_DEFAULT_GROUP_ID, { username: "", token: scalar }],
+        ]),
+      };
+    }
+    if (mapPath) {
+      try {
+        return {
+          configured: true,
+          source: "map",
+          credentialsByGroup: loadAutomationCredentialMap(
+            mapPath,
+            new Set(configuredGroupIds(this.nodeConfigs)),
+            mapName,
+          ),
+        };
+      } catch {
+        return disabled(
+          `${mapName} is malformed or contains an unknown group; ${role} automation is disabled.`,
+        );
+      }
+    }
+    return {
+      configured: false,
+      source: "none",
+      credentialsByGroup: new Map(),
+    };
+  }
+
   /**
    * Eagerly validates TECHNITIUM_SCHEDULE_TOKEN at startup so operators see
    * permission or connectivity problems in the boot log instead of discovering
@@ -399,7 +535,8 @@ export class TechnitiumService {
    * on the cached result.
    */
   private scheduleEagerScheduleTokenValidation(): void {
-    if (!this.scheduleToken) return;
+    if (!this.scheduleCredentials.configured || this.scheduleCredentials.reason)
+      return;
     this.validateScheduleToken().catch((error) => {
       this.logger.warn(
         `TECHNITIUM_SCHEDULE_TOKEN validation threw: ${error instanceof Error ? error.message : String(error)}`,
@@ -430,8 +567,9 @@ export class TechnitiumService {
     reason?: string;
     tooPrivilegedSections?: string[];
     transient?: boolean;
+    groups?: GroupCredentialStatusEnvelope;
   } {
-    const configured = !!this.backgroundToken;
+    const configured = this.backgroundCredentials.configured;
     const sessionAuthEnabled = this.sessionAuthEnabled;
 
     if (!configured) {
@@ -440,11 +578,23 @@ export class TechnitiumService {
         sessionAuthEnabled,
         validated: true,
         okForPtr: true,
+        groups: this.getAutomationGroupEnvelope(
+          this.backgroundCredentials,
+          this.backgroundGroupCredentials,
+        ),
       };
     }
 
     if (!this.backgroundTokenValidation.validated) {
-      return { configured, sessionAuthEnabled, validated: false };
+      return {
+        configured,
+        sessionAuthEnabled,
+        validated: false,
+        groups: this.getAutomationGroupEnvelope(
+          this.backgroundCredentials,
+          this.backgroundGroupCredentials,
+        ),
+      };
     }
 
     return {
@@ -457,6 +607,10 @@ export class TechnitiumService {
       tooPrivilegedSections:
         this.backgroundTokenValidation.tooPrivilegedSections,
       transient: this.backgroundTokenValidation.transient,
+      groups: this.getAutomationGroupEnvelope(
+        this.backgroundCredentials,
+        this.backgroundGroupCredentials,
+      ),
     };
   }
 
@@ -470,9 +624,10 @@ export class TechnitiumService {
     username?: string;
     reason?: string;
     hasAppsModify: boolean | null;
-    hasCacheModify: boolean | null;
+    hasCacheDelete: boolean | null;
+    groups?: GroupCredentialStatusEnvelope;
   } {
-    const configured = !!this.scheduleToken;
+    const configured = this.scheduleCredentials.configured;
 
     if (!configured) {
       return {
@@ -480,7 +635,11 @@ export class TechnitiumService {
         valid: false,
         reason: "TECHNITIUM_SCHEDULE_TOKEN is not set.",
         hasAppsModify: null,
-        hasCacheModify: null,
+        hasCacheDelete: null,
+        groups: this.getAutomationGroupEnvelope(
+          this.scheduleCredentials,
+          this.scheduleGroupCredentials,
+        ),
       };
     }
 
@@ -491,7 +650,11 @@ export class TechnitiumService {
         configured,
         valid: null,
         hasAppsModify: null,
-        hasCacheModify: null,
+        hasCacheDelete: null,
+        groups: this.getAutomationGroupEnvelope(
+          this.scheduleCredentials,
+          this.scheduleGroupCredentials,
+        ),
       };
     }
 
@@ -501,7 +664,11 @@ export class TechnitiumService {
       username: this.scheduleTokenValidation.username,
       reason: this.scheduleTokenValidation.reason,
       hasAppsModify: this.scheduleTokenValidation.hasAppsModify,
-      hasCacheModify: this.scheduleTokenValidation.hasCacheModify,
+      hasCacheDelete: this.scheduleTokenValidation.hasCacheDelete,
+      groups: this.getAutomationGroupEnvelope(
+        this.scheduleCredentials,
+        this.scheduleGroupCredentials,
+      ),
     };
   }
 
@@ -523,9 +690,18 @@ export class TechnitiumService {
   async validateExplicitSessionToken(
     nodeId: string,
     token: string,
-  ): Promise<{ username: string }> {
+  ): Promise<TechnitiumCredentialProbe> {
     const node = this.findNode(nodeId);
-    type SessionInfo = { username?: string };
+    type SessionInfo = {
+      username?: string;
+      info?: {
+        permissions?: TechnitiumCredentialProbe["permissions"];
+        clusterInitialized?: boolean;
+        clusterDomain?: string;
+        dnsServerDomain?: string;
+        clusterNodes?: TechnitiumCredentialProbe["clusterNodes"];
+      };
+    };
     const envelope = await this.requestWithExplicitToken<
       TechnitiumApiResponse<SessionInfo>
     >(node, { method: "GET", url: "/api/user/session/get" }, token, {
@@ -544,21 +720,32 @@ export class TechnitiumService {
       );
     }
 
-    const username =
-      envelopeObject.response?.username ?? envelopeObject.username;
+    const sessionInfo = envelopeObject.response ?? envelopeObject;
+    const username = sessionInfo.username;
     if (!username) {
       throw new UnauthorizedException(
         `Technitium DNS node "${node.id}" did not identify the mapped token owner.`,
       );
     }
-    return { username };
+    const info = sessionInfo.info ?? {};
+    return {
+      username,
+      permissions: info.permissions ?? {},
+      clusterInitialized: info.clusterInitialized === true,
+      clusterDomain: info.clusterDomain,
+      dnsServerDomain: info.dnsServerDomain,
+      clusterNodes: Array.isArray(info.clusterNodes) ? info.clusterNodes : [],
+    };
   }
 
   /**
    * Resolve a hostname to IP address with timeout.
    * Used to match cluster nodes when hostnames don't resolve to the configured baseUrl IPs.
    */
-  private async resolveHostname(hostname: string): Promise<string | undefined> {
+  private async resolveHostname(
+    hostname: string,
+    groupId = INTERNAL_DEFAULT_GROUP_ID,
+  ): Promise<string | undefined> {
     if (!hostname) return undefined;
 
     // If it's already an IP address, return it
@@ -566,7 +753,7 @@ export class TechnitiumService {
       return hostname;
     }
 
-    const cacheKey = hostname.toLowerCase();
+    const cacheKey = `${groupId}\u0000${hostname.toLowerCase()}`;
     const cached = this.hostnameResolutionCache.get(cacheKey);
     if (cached && cached.expiresAt > Date.now()) {
       return cached.ip;
@@ -602,7 +789,8 @@ export class TechnitiumService {
     clusterNodes: Array<{
       name: string;
       url: string;
-      ipAddress: string;
+      ipAddress?: string;
+      ipAddresses?: string[];
       type: "Primary" | "Secondary";
       state: string;
     }>,
@@ -612,25 +800,36 @@ export class TechnitiumService {
         name: node.name || "",
         url: node.url || "",
         ipAddress: node.ipAddress || "",
+        ipAddresses: [...(node.ipAddresses ?? [])].sort(),
         type: node.type || "Secondary",
         state: node.state || "",
       }))
       .sort((a, b) =>
-        [a.name, a.url, a.ipAddress, a.type, a.state]
+        [a.name, a.url, a.ipAddress, a.ipAddresses.join(","), a.type, a.state]
           .join("|")
           .localeCompare(
-            [b.name, b.url, b.ipAddress, b.type, b.state].join("|"),
+            [
+              b.name,
+              b.url,
+              b.ipAddress,
+              b.ipAddresses.join(","),
+              b.type,
+              b.state,
+            ].join("|"),
           ),
       );
 
     return JSON.stringify({ domain: domain || "", nodes: normalizedNodes });
   }
 
-  private shouldLogClusterTopology(fingerprint: string): boolean {
-    if (this.lastClusterTopologyFingerprint === fingerprint) {
+  private shouldLogClusterTopology(
+    groupId: string,
+    fingerprint: string,
+  ): boolean {
+    if (this.clusterTopologyFingerprints.get(groupId) === fingerprint) {
       return false;
     }
-    this.lastClusterTopologyFingerprint = fingerprint;
+    this.clusterTopologyFingerprints.set(groupId, fingerprint);
     return true;
   }
 
@@ -657,18 +856,23 @@ export class TechnitiumService {
     // OPTIMIZATION: Only query ONE node for cluster state since any node can tell us about the entire cluster
     // This reduces N API calls to 1, dramatically improving performance (e.g., 3 nodes: 3x faster)
     const authMode = opts?.authMode ?? "session";
-    let sharedClusterInfo: {
+    type SharedClusterInfo = {
       initialized: boolean;
       domain?: string;
       clusterNodes?: Array<{
         id: number;
         name: string;
         url: string;
-        ipAddress: string;
+        ipAddress?: string;
+        ipAddresses?: string[];
         type: "Primary" | "Secondary";
         state: string;
       }>;
-    } | null = null;
+    };
+    const sharedClusterInfoByGroup = new Map<
+      string,
+      SharedClusterInfo | null
+    >();
 
     // Try to get cluster info from a node we are authenticated to.
     // - "session" mode (default, request-scoped): require a per-user session
@@ -680,20 +884,21 @@ export class TechnitiumService {
     //   would see all nodes as Standalone and skip cluster-aware behavior.
     if (this.nodeConfigs.length > 0) {
       const session = AuthRequestContext.getSession();
-      const probeNodes =
-        authMode === "session"
-          ? this.sessionAuthEnabled
-            ? this.nodeConfigs.filter(
-                (node) => !!session?.tokensByNodeId?.[node.id],
-              )
-            : this.nodeConfigs
-          : this.nodeConfigs;
-
-      if (probeNodes.length === 0) {
-        // No authenticated nodes available (or no nodes configured)
-        // -> treat as standalone.
-        sharedClusterInfo = null;
-      } else {
+      for (const groupId of configuredGroupIds(this.nodeConfigs)) {
+        const groupNodes = this.nodeConfigs.filter(
+          (node) => nodeGroupId(node) === groupId,
+        );
+        const probeNodes =
+          authMode === "session"
+            ? this.sessionAuthEnabled
+              ? groupNodes.filter(
+                  (node) =>
+                    !!session?.tokensByNodeId?.[node.id] ||
+                    !!session?.pendingTokensByNodeId?.[node.id],
+                )
+              : groupNodes
+            : groupNodes;
+        sharedClusterInfoByGroup.set(groupId, null);
         for (const probeNode of probeNodes) {
           try {
             // Get full cluster state from first node
@@ -708,7 +913,8 @@ export class TechnitiumService {
                   id: number;
                   name: string;
                   url: string;
-                  ipAddress: string;
+                  ipAddress?: string;
+                  ipAddresses?: string[];
                   type: "Primary" | "Secondary";
                   state: string;
                 }>;
@@ -724,24 +930,31 @@ export class TechnitiumService {
               { authMode },
             );
 
+            if (
+              response.status === "ok" &&
+              !response.info?.clusterInitialized
+            ) {
+              sharedClusterInfoByGroup.set(groupId, { initialized: false });
+              break;
+            }
             if (response.status === "ok" && response.info?.clusterInitialized) {
               const clusterNodes = response.info.clusterNodes || [];
-              sharedClusterInfo = {
+              sharedClusterInfoByGroup.set(groupId, {
                 initialized: true,
                 domain: response.info.clusterDomain,
                 clusterNodes,
-              };
+              });
               const topologyFingerprint = this.buildClusterTopologyFingerprint(
                 response.info.clusterDomain,
                 clusterNodes,
               );
-              if (this.shouldLogClusterTopology(topologyFingerprint)) {
+              if (this.shouldLogClusterTopology(groupId, topologyFingerprint)) {
                 this.logger.log(
-                  `Cluster detected: ${response.info.clusterDomain} with ${clusterNodes.length} nodes`,
+                  `Cluster detected for group "${groupId}": ${response.info.clusterDomain} with ${clusterNodes.length} nodes`,
                 );
                 for (const cn of clusterNodes) {
                   this.logger.debug(
-                    `  Cluster node: name="${cn.name}", url="${cn.url}", ip="${cn.ipAddress}", type="${cn.type}"`,
+                    `  Cluster node: name="${cn.name}", url="${cn.url}", ips="${[cn.ipAddress, ...(cn.ipAddresses ?? [])].filter(Boolean).join(",")}", type="${cn.type}"`,
                   );
                 }
               }
@@ -759,7 +972,10 @@ export class TechnitiumService {
     // Build node summaries using shared cluster info
     // Note: This needs to be async for DNS resolution
     const nodeSummariesPromise = this.nodeConfigs.map(
-      async ({ id, name, baseUrl }) => {
+      async ({ id, name, baseUrl, groupId }) => {
+        const configuredGroupId = groupId ?? INTERNAL_DEFAULT_GROUP_ID;
+        const sharedClusterInfo =
+          sharedClusterInfoByGroup.get(configuredGroupId) ?? null;
         try {
           if (!sharedClusterInfo?.initialized) {
             // No clustering or failed to detect - return standalone
@@ -767,6 +983,7 @@ export class TechnitiumService {
               id,
               name: name || id,
               baseUrl,
+              groupId: configuredGroupId,
               clusterState: { initialized: false, type: "Standalone" as const },
               isPrimary: false,
             };
@@ -774,7 +991,7 @@ export class TechnitiumService {
 
           // Try to find this node in the cluster topology using multiple matching strategies:
           // 1. Match by name prefix (our node ID "node1" should match "node1.home.arpa")
-          // 2. Match by IP address (extract IP from baseUrl and compare to clusterNode.ipAddress/resolved IP)
+          // 2. Match by IP address (supports legacy singular and current plural fields)
           // 3. Match by URL hostname (compare baseUrl hostname to cluster node URL hostname)
 
           // Extract IP/hostname from our baseUrl for matching
@@ -793,7 +1010,11 @@ export class TechnitiumService {
             }
 
             // Strategy 2: IP address match (direct)
-            if (baseUrlHost && n.ipAddress && baseUrlHost === n.ipAddress) {
+            if (
+              baseUrlHost &&
+              (baseUrlHost === n.ipAddress ||
+                n.ipAddresses?.includes(baseUrlHost) === true)
+            ) {
               return true;
             }
 
@@ -825,8 +1046,10 @@ export class TechnitiumService {
                     const clusterHostname = clusterUrl.hostname;
                     // Skip if cluster URL is also an IP (already checked in Strategy 3)
                     if (!/^\d+\.\d+\.\d+\.\d+$/.test(clusterHostname)) {
-                      const resolvedClusterIp =
-                        await this.resolveHostname(clusterHostname);
+                      const resolvedClusterIp = await this.resolveHostname(
+                        clusterHostname,
+                        configuredGroupId,
+                      );
                       if (resolvedClusterIp === baseUrlHost) {
                         clusterNode = cn;
                         this.logger.debug(
@@ -842,15 +1065,21 @@ export class TechnitiumService {
               }
             } else {
               // baseUrl is a hostname - resolve it and compare to cluster node IPs/resolved hostnames
-              const resolvedBaseUrlIp = await this.resolveHostname(baseUrlHost);
+              const resolvedBaseUrlIp = await this.resolveHostname(
+                baseUrlHost,
+                configuredGroupId,
+              );
 
               if (resolvedBaseUrlIp) {
                 for (const cn of sharedClusterInfo.clusterNodes || []) {
-                  // Check against cluster node's ipAddress field
-                  if (cn.ipAddress && cn.ipAddress === resolvedBaseUrlIp) {
+                  // Check against legacy singular and current plural IP fields.
+                  if (
+                    cn.ipAddress === resolvedBaseUrlIp ||
+                    cn.ipAddresses?.includes(resolvedBaseUrlIp) === true
+                  ) {
                     clusterNode = cn;
                     this.logger.debug(
-                      `  DNS match: ${baseUrlHost} → ${resolvedBaseUrlIp} matches cluster node IP ${cn.ipAddress}`,
+                      `  DNS match: ${baseUrlHost} → ${resolvedBaseUrlIp} matches cluster node ${cn.name}`,
                     );
                     break;
                   }
@@ -861,6 +1090,7 @@ export class TechnitiumService {
                       const clusterUrl = new URL(cn.url);
                       const resolvedClusterIp = await this.resolveHostname(
                         clusterUrl.hostname,
+                        configuredGroupId,
                       );
                       if (resolvedClusterIp === resolvedBaseUrlIp) {
                         clusterNode = cn;
@@ -891,6 +1121,7 @@ export class TechnitiumService {
             id,
             name: name || id,
             baseUrl,
+            groupId: configuredGroupId,
             clusterState: {
               initialized: true,
               domain: sharedClusterInfo.domain,
@@ -909,6 +1140,7 @@ export class TechnitiumService {
             id,
             name: name || id,
             baseUrl,
+            groupId: configuredGroupId,
             clusterState: {
               initialized: false,
               type: "Standalone" as const,
@@ -939,8 +1171,8 @@ export class TechnitiumService {
    *   flushNodes  = every physical node in the cluster (Primary + secondaries)
    *
    * Standalone candidates are passed through unchanged (write == flush == self).
-   * If a candidate is part of a cluster but no Primary is discoverable, falls
-   * back to direct-write with a WARN so the caller still makes progress.
+   * Direct-write fallback is limited to the implicit legacy group. Explicit
+   * groups fail closed when no validated, admitted Primary is available.
    *
    * Pre-fetched `summaries` can be passed to avoid a duplicate `listNodes()`
    * call when the caller already has them.
@@ -949,30 +1181,57 @@ export class TechnitiumService {
     candidateNodeIds: string[],
     summaries?: TechnitiumNodeSummary[],
   ): Promise<{
-    perCandidate: Map<string, { writeTarget: string; flushNodes: string[] }>;
+    perCandidate: Map<
+      string,
+      {
+        writeTarget?: string;
+        flushNodes: string[];
+        skippedFlushNodes?: string[];
+        reason?: string;
+      }
+    >;
     writeTargets: string[];
   }> {
     const nodes = summaries ?? (await this.listNodes());
     const byId = new Map(nodes.map((s) => [s.id, s]));
 
-    // Index: clusterDomain → Primary summary. Multiple Primaries per domain
-    // shouldn't happen; we take the first one encountered.
-    const primaryByDomain = new Map<string, TechnitiumNodeSummary>();
-    // Index: clusterDomain → all physical node IDs in that cluster.
+    const primaryByGroup = new Map<string, TechnitiumNodeSummary>();
     const clusterMembers = new Map<string, string[]>();
+    const skippedClusterMembers = new Map<string, string[]>();
+    let admittedWriteNodeIds = this.getAdmittedNodeIds("primaryConfigWrite");
+    let admittedFlushNodeIds = this.getAdmittedNodeIds("cacheFlush");
+    if (this.nodeConfigs.length === 0) {
+      admittedWriteNodeIds = new Set(nodes.map((node) => node.id));
+      admittedFlushNodeIds = new Set(nodes.map((node) => node.id));
+    }
     for (const s of nodes) {
-      const domain = s.clusterState?.domain;
-      if (!s.clusterState?.initialized || !domain) continue;
-      if (s.isPrimary && !primaryByDomain.has(domain)) {
-        primaryByDomain.set(domain, s);
+      const groupId = s.groupId ?? INTERNAL_DEFAULT_GROUP_ID;
+      if (
+        s.isPrimary &&
+        !primaryByGroup.has(groupId) &&
+        admittedWriteNodeIds.has(s.id)
+      ) {
+        primaryByGroup.set(groupId, s);
       }
-      if (!clusterMembers.has(domain)) clusterMembers.set(domain, []);
-      clusterMembers.get(domain)!.push(s.id);
+      if (!clusterMembers.has(groupId)) clusterMembers.set(groupId, []);
+      if (admittedFlushNodeIds.has(s.id)) {
+        clusterMembers.get(groupId)!.push(s.id);
+      } else {
+        if (!skippedClusterMembers.has(groupId)) {
+          skippedClusterMembers.set(groupId, []);
+        }
+        skippedClusterMembers.get(groupId)!.push(s.id);
+      }
     }
 
     const perCandidate = new Map<
       string,
-      { writeTarget: string; flushNodes: string[] }
+      {
+        writeTarget?: string;
+        flushNodes: string[];
+        skippedFlushNodes?: string[];
+        reason?: string;
+      }
     >();
     const writeTargetSet = new Set<string>();
 
@@ -981,47 +1240,92 @@ export class TechnitiumService {
       // Unknown node: pass through — legacy behavior, will error at request time
       // if truly invalid. Callers can decide what to do with the result.
       if (!summary) {
-        perCandidate.set(nodeId, {
-          writeTarget: nodeId,
-          flushNodes: [nodeId],
-        });
-        writeTargetSet.add(nodeId);
+        if (this.nodeConfigs.length === 0) {
+          perCandidate.set(nodeId, {
+            writeTarget: nodeId,
+            flushNodes: [nodeId],
+          });
+          writeTargetSet.add(nodeId);
+        } else if (hasImplicitNodeGrouping(this.nodeConfigs)) {
+          perCandidate.set(nodeId, {
+            writeTarget: nodeId,
+            flushNodes: admittedFlushNodeIds.has(nodeId) ? [nodeId] : [],
+            ...(!admittedFlushNodeIds.has(nodeId)
+              ? { skippedFlushNodes: [nodeId] }
+              : {}),
+          });
+          writeTargetSet.add(nodeId);
+        } else {
+          perCandidate.set(nodeId, {
+            flushNodes: [],
+            reason:
+              "The requested node is not a validated member of a configured group.",
+          });
+        }
         continue;
       }
 
       const domain = summary.clusterState?.domain;
       const clustered = summary.clusterState?.initialized === true;
+      const groupId = summary.groupId ?? INTERNAL_DEFAULT_GROUP_ID;
 
       if (!clustered || !domain) {
         // Standalone — self-write, self-flush.
-        perCandidate.set(nodeId, {
-          writeTarget: nodeId,
-          flushNodes: [nodeId],
-        });
-        writeTargetSet.add(nodeId);
+        if (admittedWriteNodeIds.has(nodeId)) {
+          perCandidate.set(nodeId, {
+            writeTarget: nodeId,
+            flushNodes: admittedFlushNodeIds.has(nodeId) ? [nodeId] : [],
+            ...(!admittedFlushNodeIds.has(nodeId)
+              ? { skippedFlushNodes: [nodeId] }
+              : {}),
+          });
+          writeTargetSet.add(nodeId);
+        } else {
+          perCandidate.set(nodeId, {
+            flushNodes: [],
+            reason:
+              "The standalone node is not admitted for configuration writes.",
+          });
+        }
         continue;
       }
 
-      const primary = primaryByDomain.get(domain);
+      const primary = primaryByGroup.get(groupId);
       if (!primary) {
         // Clustered but Primary wasn't discoverable (probe failed, or this
         // node's cluster has no node marked Primary in our summaries).
         // Fall back to direct write so we make progress; warn once.
-        this.logger.warn(
-          `Cluster "${domain}" has no discoverable Primary — falling back to direct write on "${nodeId}".`,
-        );
-        perCandidate.set(nodeId, {
-          writeTarget: nodeId,
-          flushNodes: [nodeId],
-        });
-        writeTargetSet.add(nodeId);
+        if (
+          this.nodeConfigs.length === 0 ||
+          hasImplicitNodeGrouping(this.nodeConfigs)
+        ) {
+          this.logger.warn(
+            `Cluster "${domain}" has no discoverable Primary — falling back to direct write on "${nodeId}" in implicit legacy mode.`,
+          );
+          perCandidate.set(nodeId, {
+            writeTarget: nodeId,
+            flushNodes: admittedFlushNodeIds.has(nodeId) ? [nodeId] : [],
+            ...(!admittedFlushNodeIds.has(nodeId)
+              ? { skippedFlushNodes: [nodeId] }
+              : {}),
+          });
+          writeTargetSet.add(nodeId);
+        } else {
+          perCandidate.set(nodeId, {
+            flushNodes: [],
+            reason: `Group "${groupId}" has no reachable, validated, admitted Primary.`,
+          });
+        }
         continue;
       }
 
-      const flushNodes = clusterMembers.get(domain) ?? [nodeId];
+      const flushNodes = clusterMembers.get(groupId) ?? [];
       perCandidate.set(nodeId, {
         writeTarget: primary.id,
         flushNodes,
+        ...(skippedClusterMembers.get(groupId)?.length
+          ? { skippedFlushNodes: skippedClusterMembers.get(groupId) }
+          : {}),
       });
       writeTargetSet.add(primary.id);
     }
@@ -1030,6 +1334,28 @@ export class TechnitiumService {
       perCandidate,
       writeTargets: [...writeTargetSet],
     };
+  }
+
+  private getAdmittedNodeIds(
+    role: keyof GroupCredentialStatus["admittedNodeIds"],
+  ): Set<string> {
+    const session = AuthRequestContext.getSession();
+    const envelope = session?.groupCredentials ?? this.scheduleGroupCredentials;
+    if (envelope) {
+      return new Set(
+        envelope.groups.flatMap((group) => group.admittedNodeIds[role]),
+      );
+    }
+    if (session) {
+      return new Set(Object.keys(session.tokensByNodeId));
+    }
+    if (this.scheduleCredentials.source === "scalar") {
+      return new Set(this.nodeConfigs.map((node) => node.id));
+    }
+    if (hasImplicitNodeGrouping(this.nodeConfigs)) {
+      return new Set(this.nodeConfigs.map((node) => node.id));
+    }
+    return new Set();
   }
 
   /**
@@ -1053,7 +1379,8 @@ export class TechnitiumService {
             id: number;
             name: string;
             url: string;
-            ipAddress: string;
+            ipAddress?: string;
+            ipAddresses?: string[];
             type: "Primary" | "Secondary";
             state: string;
           }>;
@@ -1562,7 +1889,10 @@ export class TechnitiumService {
             lease.hostName &&
             typeof lease.hostName === "string"
           ) {
-            ipToHostname.set(lease.address, lease.hostName);
+            ipToHostname.set(
+              this.clientNamespaceKey(nodeGroupId(node), lease.address),
+              lease.hostName,
+            );
           }
         }
       }
@@ -1607,29 +1937,32 @@ export class TechnitiumService {
 
   private async getAllDhcpLeasesWithOptions(options?: {
     authMode?: "session" | "background";
+    sourceGroupId?: string;
   }): Promise<Map<string, string>> {
     const authMode = options?.authMode ?? "session";
     const now = Date.now();
+    const cacheKey = options?.sourceGroupId ?? "__all__";
+    const cachedLeases = this.dhcpLeaseCacheForBackground.get(cacheKey);
 
-    if (authMode === "background" && this.dhcpLeaseCacheForBackground) {
-      if (
-        now - this.dhcpLeaseCacheForBackground.fetchedAt <
-        this.DHCP_LEASE_CACHE_TTL_MS
-      ) {
-        return new Map(this.dhcpLeaseCacheForBackground.map);
+    if (authMode === "background" && cachedLeases) {
+      if (now - cachedLeases.fetchedAt < this.DHCP_LEASE_CACHE_TTL_MS) {
+        return new Map(cachedLeases.map);
       }
     }
 
     if (authMode === "background") {
-      await this.refreshDhcpScopeCapabilitiesIfNeeded();
-    } else if (this.backgroundToken) {
+      await this.refreshDhcpScopeCapabilitiesIfNeeded(options?.sourceGroupId);
+    } else if (this.backgroundCredentials.configured) {
       // Interactive requests must not wait for topology discovery. The
       // background refresh populates a shared capability map containing only
       // node IDs and enabled-scope names; it never caches session responses.
       void this.refreshDhcpScopeCapabilitiesIfNeeded();
     }
 
-    const candidateNodes = this.getDhcpLeaseCandidateNodes(authMode);
+    const candidateNodes = this.getDhcpLeaseCandidateNodes(
+      authMode,
+      options?.sourceGroupId,
+    );
 
     const allLeases = await Promise.all(
       candidateNodes.map((node) => {
@@ -1650,7 +1983,10 @@ export class TechnitiumService {
     }
 
     if (authMode === "background") {
-      this.dhcpLeaseCacheForBackground = { map: merged, fetchedAt: now };
+      this.dhcpLeaseCacheForBackground.set(cacheKey, {
+        map: merged,
+        fetchedAt: now,
+      });
     }
 
     return merged;
@@ -1658,8 +1994,26 @@ export class TechnitiumService {
 
   private getDhcpLeaseCandidateNodes(
     authMode: "session" | "background",
+    sourceGroupId?: string,
   ): TechnitiumNodeConfig[] {
+    const session = AuthRequestContext.getSession();
+    const credentialGroups =
+      authMode === "background"
+        ? this.backgroundGroupCredentials
+        : session?.groupCredentials;
     return this.nodeConfigs.filter((node) => {
+      if (sourceGroupId && nodeGroupId(node) !== sourceGroupId) {
+        return false;
+      }
+      const groupAdmission = credentialGroups?.groups.find(
+        (group) => group.groupId === nodeGroupId(node),
+      );
+      if (
+        groupAdmission &&
+        !groupAdmission.admittedNodeIds.dhcpRead.includes(node.id)
+      ) {
+        return false;
+      }
       const capability = this.dhcpScopeCapabilities.get(node.id);
 
       if (!capability?.hasSuccessfulScan) {
@@ -1673,9 +2027,12 @@ export class TechnitiumService {
     });
   }
 
-  private async refreshDhcpScopeCapabilitiesIfNeeded(): Promise<void> {
+  private async refreshDhcpScopeCapabilitiesIfNeeded(
+    sourceGroupId?: string,
+  ): Promise<void> {
     const now = Date.now();
     const nodesToRefresh = this.nodeConfigs.filter((node) => {
+      if (sourceGroupId && nodeGroupId(node) !== sourceGroupId) return false;
       const state = this.dhcpScopeCapabilities.get(node.id);
       if (!state) return true;
       if (now < state.retryAfter) return false;
@@ -1723,7 +2080,7 @@ export class TechnitiumService {
             !previous?.hasSuccessfulScan ||
             !this.haveSameSet(previous.enabledScopeNames, enabledScopeNames)
           ) {
-            this.dhcpLeaseCacheForBackground = undefined;
+            this.dhcpLeaseCacheForBackground.clear();
           }
 
           this.dhcpScopeCapabilities.set(node.id, {
@@ -1793,7 +2150,7 @@ export class TechnitiumService {
 
   private invalidateDhcpScopeCapability(nodeId: string): void {
     this.dhcpScopeCapabilities.delete(nodeId);
-    this.dhcpLeaseCacheForBackground = undefined;
+    this.dhcpLeaseCacheForBackground.clear();
     this.lastDhcpScopeTopologyFingerprint = undefined;
   }
 
@@ -1812,6 +2169,7 @@ export class TechnitiumService {
   private enrichWithHostnames<T extends TechnitiumQueryLogEntry>(
     entries: T[],
     ipToHostname: Map<string, string>,
+    defaultGroupId?: string,
   ): T[] {
     return entries.map((entry) => {
       const clientIp = entry.clientIpAddress;
@@ -1824,6 +2182,9 @@ export class TechnitiumService {
       if (!clientIp) {
         return entry;
       }
+      const groupId =
+        entry.groupId ?? defaultGroupId ?? INTERNAL_DEFAULT_GROUP_ID;
+      const clientKey = this.clientNamespaceKey(groupId, clientIp);
 
       // If the entry already has a non-IP clientName, preserve it.
       // This is important for the SQLite stored logs path where we want to
@@ -1833,24 +2194,24 @@ export class TechnitiumService {
       }
 
       // Track this IP for future PTR lookups (only when hostname is unknown)
-      this.recentClientIps.add(clientIp);
+      this.recentClientIps.add(clientKey);
 
       // Priority 1: Use DHCP hostname if available (most reliable for local devices)
-      if (ipToHostname.has(clientIp)) {
-        return { ...entry, clientName: ipToHostname.get(clientIp) };
+      if (ipToHostname.has(clientKey)) {
+        return { ...entry, groupId, clientName: ipToHostname.get(clientKey) };
       }
 
       // Priority 2: Check hostname cache (from previous PTR lookups)
-      const cached = this.hostnameCache.get(clientIp);
+      const cached = this.hostnameCache.get(clientKey);
       if (
         cached &&
         Date.now() - cached.lastUpdated < this.HOSTNAME_CACHE_TTL_MS
       ) {
-        return { ...entry, clientName: cached.hostname };
+        return { ...entry, groupId, clientName: cached.hostname };
       }
 
       // No hostname available yet - return entry as-is (will show IP only)
-      return entry;
+      return { ...entry, groupId };
     });
   }
 
@@ -1862,14 +2223,21 @@ export class TechnitiumService {
    */
   async enrichQueryLogEntriesWithHostnames<T extends TechnitiumQueryLogEntry>(
     entries: T[],
-    options?: { authMode?: "session" | "background" },
+    options?: {
+      authMode?: "session" | "background";
+      sourceGroupId?: string;
+    },
   ): Promise<T[]> {
     if (entries.length === 0) {
       return entries;
     }
 
     const ipToHostname = await this.getAllDhcpLeasesWithOptions(options);
-    return this.enrichWithHostnames(entries, ipToHostname);
+    return this.enrichWithHostnames(
+      entries,
+      ipToHostname,
+      options?.sourceGroupId,
+    );
   }
 
   /**
@@ -1880,8 +2248,12 @@ export class TechnitiumService {
   enrichQueryLogEntriesWithCachedHostnames<T extends TechnitiumQueryLogEntry>(
     entries: T[],
   ): T[] {
-    const cachedDhcp: Map<string, string> =
-      this.dhcpLeaseCacheForBackground?.map ?? new Map<string, string>();
+    const cachedDhcp = new Map<string, string>();
+    for (const cache of this.dhcpLeaseCacheForBackground.values()) {
+      for (const [clientKey, hostname] of cache.map) {
+        cachedDhcp.set(clientKey, hostname);
+      }
+    }
     return this.enrichWithHostnames(entries, cachedDhcp);
   }
 
@@ -1890,14 +2262,16 @@ export class TechnitiumService {
    * as autocomplete suggestions. Sources: DHCP leases (live) + PTR hostname
    * cache (from recent query log enrichment). DHCP takes priority.
    */
-  async getKnownClients(): Promise<{ ip: string; hostname?: string }[]> {
+  async getKnownClients(): Promise<
+    { groupId: string; ip: string; hostname?: string }[]
+  > {
     const ipToHostname = new Map<string, string>();
 
     // Source 1: live DHCP leases
     try {
       const dhcp = await this.getAllDhcpLeases();
-      for (const [ip, hostname] of dhcp.entries()) {
-        ipToHostname.set(ip, hostname);
+      for (const [clientKey, hostname] of dhcp.entries()) {
+        ipToHostname.set(clientKey, hostname);
       }
     } catch {
       // Best-effort; fall through to PTR cache
@@ -1905,19 +2279,20 @@ export class TechnitiumService {
 
     // Source 2: PTR-resolved hostname cache (IPs seen in query logs)
     const now = Date.now();
-    for (const [ip, entry] of this.hostnameCache.entries()) {
+    for (const [clientKey, entry] of this.hostnameCache.entries()) {
       if (
-        !ipToHostname.has(ip) &&
+        !ipToHostname.has(clientKey) &&
         now - entry.lastUpdated < this.HOSTNAME_CACHE_TTL_MS
       ) {
-        ipToHostname.set(ip, entry.hostname);
+        ipToHostname.set(clientKey, entry.hostname);
       }
     }
 
-    const clients: { ip: string; hostname?: string }[] = [];
+    const clients: { groupId: string; ip: string; hostname?: string }[] = [];
 
-    for (const [ip, hostname] of ipToHostname.entries()) {
-      clients.push({ ip, hostname });
+    for (const [clientKey, hostname] of ipToHostname.entries()) {
+      const parsed = this.parseClientNamespaceKey(clientKey);
+      clients.push({ ...parsed, hostname });
     }
 
     return clients.sort((a, b) => {
@@ -1931,7 +2306,7 @@ export class TechnitiumService {
    * Start periodic background PTR lookups for recently seen client IPs.
    */
   private startPeriodicPtrLookups(): void {
-    if (this.sessionAuthEnabled && !this.backgroundToken) {
+    if (this.sessionAuthEnabled && !this.backgroundCredentials.configured) {
       this.logger.log(
         "Session auth is enabled and TECHNITIUM_BACKGROUND_TOKEN is not set; skipping background PTR hostname resolution.",
       );
@@ -1947,23 +2322,23 @@ export class TechnitiumService {
       }
 
       // Take a snapshot of IPs to look up and clear the set
-      const ipsToLookup = Array.from(this.recentClientIps);
+      const clientsToLookup = Array.from(this.recentClientIps);
       this.recentClientIps.clear();
 
       // Limit to prevent overwhelming DNS
-      const limited = ipsToLookup.slice(0, this.MAX_PTR_LOOKUPS_PER_CYCLE);
+      const limited = clientsToLookup.slice(0, this.MAX_PTR_LOOKUPS_PER_CYCLE);
 
       this.logger.debug(`Running PTR lookup cycle for ${limited.length} IPs`);
 
-      // Use first available node for DNS resolution
-      const node = this.nodeConfigs[0];
-      if (!node) {
-        return;
-      }
-
       // Perform PTR lookups in parallel (but limited)
       await Promise.allSettled(
-        limited.map((ip) => this.performPtrLookup(node, ip)),
+        limited.map((clientKey) => {
+          const { groupId, ip } = this.parseClientNamespaceKey(clientKey);
+          const node = this.nodeConfigs.find(
+            (candidate) => nodeGroupId(candidate) === groupId,
+          );
+          return node ? this.performPtrLookup(node, ip) : Promise.resolve();
+        }),
       );
     };
 
@@ -1987,6 +2362,36 @@ export class TechnitiumService {
     Extract<typeof this.backgroundTokenValidation, { validated: true }>
   > {
     if (this.backgroundTokenValidation.validated) {
+      return this.backgroundTokenValidation;
+    }
+
+    if (
+      this.backgroundCredentials.source === "map" ||
+      this.backgroundCredentials.source === "scalar"
+    ) {
+      this.backgroundGroupCredentials =
+        await this.validateMappedAutomationCredentials("background");
+      const readyGroups = this.backgroundGroupCredentials.groups.filter(
+        (group) =>
+          (group.state === "ready" || group.state === "degraded") &&
+          group.capabilities.ptrRead,
+      );
+      const usernames = [
+        ...new Set(
+          readyGroups.flatMap((group) =>
+            group.verifiedUsername ? [group.verifiedUsername] : [],
+          ),
+        ),
+      ];
+      this.backgroundTokenValidation = {
+        validated: true,
+        okForPtr: readyGroups.length > 0,
+        username: usernames.length === 1 ? usernames[0] : undefined,
+        reason:
+          readyGroups.length > 0
+            ? undefined
+            : "No configured group has an admitted DnsClient: View credential for background PTR lookups.",
+      };
       return this.backgroundTokenValidation;
     }
 
@@ -2170,12 +2575,46 @@ export class TechnitiumService {
 
   private async validateScheduleToken(): Promise<void> {
     if (this.scheduleTokenValidation.validated) return;
+    if (
+      this.scheduleCredentials.source === "map" ||
+      this.scheduleCredentials.source === "scalar"
+    ) {
+      this.scheduleGroupCredentials =
+        await this.validateMappedAutomationCredentials("schedule");
+      const usableGroups = this.scheduleGroupCredentials.groups.filter(
+        (group) =>
+          (group.state === "ready" || group.state === "degraded") &&
+          group.capabilities.primaryConfigWrite,
+      );
+      const usernames = [
+        ...new Set(
+          usableGroups.flatMap((group) =>
+            group.verifiedUsername ? [group.verifiedUsername] : [],
+          ),
+        ),
+      ];
+      this.scheduleTokenValidation = {
+        validated: true,
+        valid: usableGroups.length > 0,
+        hasAppsModify: usableGroups.length > 0,
+        hasCacheDelete: usableGroups.some(
+          (group) => group.capabilities.cacheFlush,
+        ),
+        username: usernames.length === 1 ? usernames[0] : undefined,
+        reason:
+          usableGroups.length > 0
+            ? undefined
+            : "No configured group has an admitted Primary with Apps: Modify permission.",
+      };
+      this.logScheduleTokenValidationOutcome();
+      return;
+    }
     if (!this.scheduleToken) {
       this.scheduleTokenValidation = {
         validated: true,
         valid: false,
         hasAppsModify: false,
-        hasCacheModify: false,
+        hasCacheDelete: false,
         reason: "TECHNITIUM_SCHEDULE_TOKEN is not set.",
       };
       return;
@@ -2187,7 +2626,7 @@ export class TechnitiumService {
         validated: true,
         valid: false,
         hasAppsModify: false,
-        hasCacheModify: false,
+        hasCacheDelete: false,
         reason:
           "No nodes are configured; cannot validate TECHNITIUM_SCHEDULE_TOKEN.",
       };
@@ -2227,7 +2666,7 @@ export class TechnitiumService {
         validated: true,
         valid: false,
         hasAppsModify: false,
-        hasCacheModify: false,
+        hasCacheDelete: false,
         transient: true,
         reason: `Failed to validate TECHNITIUM_SCHEDULE_TOKEN against node "${node.id}": ${message}`,
       };
@@ -2245,7 +2684,7 @@ export class TechnitiumService {
         validated: true,
         valid: false,
         hasAppsModify: false,
-        hasCacheModify: false,
+        hasCacheDelete: false,
         reason: `Failed to validate TECHNITIUM_SCHEDULE_TOKEN: unexpected response from node "${node.id}".`,
       };
       this.logScheduleTokenValidationOutcome();
@@ -2257,7 +2696,7 @@ export class TechnitiumService {
         validated: true,
         valid: false,
         hasAppsModify: false,
-        hasCacheModify: false,
+        hasCacheDelete: false,
         reason:
           envelopeObj.status === "invalid-token"
             ? `TECHNITIUM_SCHEDULE_TOKEN was rejected by node "${node.id}": invalid token.`
@@ -2280,13 +2719,13 @@ export class TechnitiumService {
 
     const permissions = sessionInfo?.info?.permissions ?? {};
     const hasAppsModify = permissions["Apps"]?.canModify === true;
-    const hasCacheModify = permissions["Cache"]?.canModify === true;
+    const hasCacheDelete = permissions["Cache"]?.canDelete === true;
 
     this.scheduleTokenValidation = {
       validated: true,
       valid: true,
       hasAppsModify,
-      hasCacheModify,
+      hasCacheDelete,
       username: sessionInfo?.username,
       reason: hasAppsModify
         ? undefined
@@ -2324,14 +2763,14 @@ export class TechnitiumService {
       );
       return;
     }
-    if (!v.hasCacheModify) {
+    if (!v.hasCacheDelete) {
       this.logger.warn(
-        `TECHNITIUM_SCHEDULE_TOKEN is missing Cache: Modify permission — schedules with flushCacheOnChange=true will log warnings at window transitions, but apply/remove will otherwise work.`,
+        `TECHNITIUM_SCHEDULE_TOKEN is missing Cache: Delete permission — schedules with flushCacheOnChange=true will log warnings at window transitions, but apply/remove will otherwise work.`,
       );
       return;
     }
     this.logger.log(
-      `Validated TECHNITIUM_SCHEDULE_TOKEN (user: ${v.username ?? "unknown"}, Apps:Modify=true, Cache:Modify=true).`,
+      `Validated TECHNITIUM_SCHEDULE_TOKEN (user: ${v.username ?? "unknown"}, Apps:Modify=true, Cache:Delete=true).`,
     );
   }
 
@@ -2397,6 +2836,7 @@ export class TechnitiumService {
               name: "Primary",
               baseUrl: primaryOrigin,
               token: "",
+              groupId: node.groupId,
               queryLoggerAppName: undefined,
               queryLoggerClassPath: undefined,
             } satisfies TechnitiumNodeConfig)
@@ -2586,6 +3026,220 @@ export class TechnitiumService {
     }
   }
 
+  private async validateMappedAutomationCredentials(
+    role: "background" | "schedule",
+  ): Promise<GroupCredentialStatusEnvelope> {
+    const config =
+      role === "background"
+        ? this.backgroundCredentials
+        : this.scheduleCredentials;
+    const statuses: GroupCredentialStatus[] = [];
+    const topologyDomains =
+      role === "background"
+        ? this.backgroundTopologyDomainsByGroup
+        : this.scheduleTopologyDomainsByGroup;
+    topologyDomains.clear();
+
+    for (const groupId of configuredGroupIds(this.nodeConfigs)) {
+      const credential = config.credentialsByGroup.get(groupId);
+      if (!credential) {
+        statuses.push(notAuthorizedGroupStatus(groupId));
+        continue;
+      }
+      const nodes = this.nodeConfigs.filter(
+        (node) => nodeGroupId(node) === groupId,
+      );
+      const results = await Promise.all(
+        nodes.map(async (node) => {
+          try {
+            const probe = await this.validateExplicitSessionToken(
+              node.id,
+              credential.token,
+            );
+            if (
+              config.source === "map" &&
+              probe.username !== credential.username
+            ) {
+              throw new UnauthorizedException("Mapped token owner mismatch");
+            }
+            return { node, probe };
+          } catch (error) {
+            const unreachable =
+              error instanceof HttpException &&
+              [
+                HttpStatus.SERVICE_UNAVAILABLE,
+                HttpStatus.GATEWAY_TIMEOUT,
+              ].includes(error.getStatus());
+            return {
+              node,
+              error: unreachable
+                ? ("unreachable" as const)
+                : ("failed" as const),
+            };
+          }
+        }),
+      );
+      const successful = results.filter(
+        (
+          result,
+        ): result is {
+          node: TechnitiumNodeConfig;
+          probe: TechnitiumCredentialProbe;
+        } => "probe" in result,
+      );
+      const unreachableNodeIds = results.flatMap((result) =>
+        result.error === "unreachable" ? [result.node.id] : [],
+      );
+      const failedNodeIds = results.flatMap((result) =>
+        result.error === "failed" ? [result.node.id] : [],
+      );
+      const reportedTopologyDomains = new Set(
+        successful
+          .filter(({ probe }) => probe.clusterInitialized)
+          .map(({ probe }) => probe.clusterDomain ?? ""),
+      );
+      const topologyMismatch =
+        !hasImplicitNodeGrouping(this.nodeConfigs) &&
+        (reportedTopologyDomains.size > 1 ||
+          (nodes.length > 1 &&
+            successful.some(({ probe }) => !probe.clusterInitialized)) ||
+          successful.some(
+            ({ node, probe }) =>
+              probe.clusterInitialized &&
+              !this.getCredentialProbeNodeRole(node, probe),
+          ));
+      const verifiedUsernames = new Set(
+        successful.map(({ probe }) => probe.username),
+      );
+      const ownerMismatch = verifiedUsernames.size > 1;
+      const permissionMismatch = successful.some(({ probe }) =>
+        role === "background"
+          ? probe.permissions["DnsClient"]?.canView !== true ||
+            Object.values(probe.permissions).some(
+              (permission) =>
+                permission?.canModify === true ||
+                permission?.canDelete === true,
+            ) ||
+            probe.permissions["Administration"]?.canView === true
+          : probe.permissions["Apps"]?.canModify !== true,
+      );
+      if (
+        failedNodeIds.length > 0 ||
+        topologyMismatch ||
+        ownerMismatch ||
+        permissionMismatch
+      ) {
+        statuses.push({
+          groupId,
+          state: "failed",
+          authenticatedNodeIds: [],
+          unreachableNodeIds,
+          failedNodeIds: [
+            ...new Set([
+              ...failedNodeIds,
+              ...successful.map(({ node }) => node.id),
+            ]),
+          ],
+          admittedNodeIds: emptyAdmissions(),
+          capabilities: {
+            ptrRead: false,
+            dhcpRead: false,
+            primaryConfigWrite: false,
+            cacheFlush: false,
+          },
+          reason: topologyMismatch
+            ? "Configured group topology did not match the declared node group."
+            : ownerMismatch
+              ? "Configured group members reported different token owners."
+              : permissionMismatch
+                ? role === "background"
+                  ? "Background credential permissions do not satisfy the least-privilege DnsClient: View policy."
+                  : "Schedule credential lacks Apps: Modify permission."
+                : "Credential validation failed for this group.",
+        });
+        continue;
+      }
+
+      const topologyDomain = successful.find(
+        ({ probe }) => probe.clusterInitialized && probe.clusterDomain,
+      )?.probe.clusterDomain;
+      if (topologyDomain) {
+        topologyDomains.set(groupId, topologyDomain);
+      }
+
+      const admitted = emptyAdmissions();
+      for (const { node, probe } of successful) {
+        admitted.interactive.push(node.id);
+        if (probe.permissions["DnsClient"]?.canView === true)
+          admitted.ptrRead.push(node.id);
+        if (probe.permissions["DhcpServer"]?.canView === true)
+          admitted.dhcpRead.push(node.id);
+        const roleInTopology = this.getCredentialProbeNodeRole(node, probe);
+        if (
+          probe.permissions["Apps"]?.canModify === true &&
+          (roleInTopology === "Primary" || !probe.clusterInitialized)
+        )
+          admitted.primaryConfigWrite.push(node.id);
+        if (probe.permissions["Cache"]?.canDelete === true)
+          admitted.cacheFlush.push(node.id);
+      }
+      const state: GroupCredentialStatus["state"] =
+        successful.length === 0
+          ? "unreachable"
+          : unreachableNodeIds.length > 0
+            ? "degraded"
+            : "ready";
+      statuses.push({
+        groupId,
+        state,
+        verifiedUsername:
+          successful.length > 0 ? successful[0].probe.username : undefined,
+        authenticatedNodeIds: successful.map(({ node }) => node.id),
+        unreachableNodeIds,
+        failedNodeIds: [],
+        admittedNodeIds: admitted,
+        capabilities: {
+          ptrRead: admitted.ptrRead.length > 0,
+          dhcpRead: admitted.dhcpRead.length > 0,
+          primaryConfigWrite: admitted.primaryConfigWrite.length > 0,
+          cacheFlush: admitted.cacheFlush.length > 0,
+        },
+      });
+    }
+    return buildGroupCredentialEnvelope(statuses);
+  }
+
+  private getCredentialProbeNodeRole(
+    node: TechnitiumNodeConfig,
+    probe: TechnitiumCredentialProbe,
+  ): "Primary" | "Secondary" | undefined {
+    if (!probe.clusterInitialized) return undefined;
+    const configuredNodeId = node.id.toLowerCase();
+    const reportedNodeName = probe.dnsServerDomain?.toLowerCase();
+    let origin: string | undefined;
+    try {
+      origin = new URL(node.baseUrl).origin.toLowerCase();
+    } catch {
+      origin = undefined;
+    }
+    return probe.clusterNodes.find((member) => {
+      const memberName = member.name?.toLowerCase();
+      if (
+        memberName &&
+        (memberName === reportedNodeName ||
+          memberName === configuredNodeId ||
+          memberName.startsWith(`${configuredNodeId}.`))
+      )
+        return true;
+      if (!origin || !member.url) return false;
+      try {
+        return new URL(member.url).origin.toLowerCase() === origin;
+      } catch {
+        return false;
+      }
+    })?.type;
+  }
+
   private logPtrFailureWithThrottling(
     nodeId: string,
     ipAddress: string,
@@ -2652,10 +3306,21 @@ export class TechnitiumService {
   private getPtrLookupCandidateNodes(
     preferredNode: TechnitiumNodeConfig,
   ): TechnitiumNodeConfig[] {
-    const fallbackNodes = this.nodeConfigs.filter(
-      (candidate) => candidate.id !== preferredNode.id,
+    const groupId = nodeGroupId(preferredNode);
+    const admittedNodeIds = new Set(
+      this.backgroundGroupCredentials?.groups.find(
+        (group) => group.groupId === groupId,
+      )?.admittedNodeIds.ptrRead ?? [],
     );
-    return [preferredNode, ...fallbackNodes];
+    return [
+      preferredNode,
+      ...this.nodeConfigs.filter(
+        (candidate) => candidate.id !== preferredNode.id,
+      ),
+    ].filter(
+      (candidate) =>
+        nodeGroupId(candidate) === groupId && admittedNodeIds.has(candidate.id),
+    );
   }
 
   private async performPtrLookup(
@@ -2663,8 +3328,10 @@ export class TechnitiumService {
     ipAddress: string,
   ): Promise<void> {
     try {
+      const groupId = nodeGroupId(node);
+      const clientKey = this.clientNamespaceKey(groupId, ipAddress);
       // Skip if we have a fresh cache entry
-      const cached = this.hostnameCache.get(ipAddress);
+      const cached = this.hostnameCache.get(clientKey);
       if (
         cached &&
         Date.now() - cached.lastUpdated < this.HOSTNAME_CACHE_TTL_MS
@@ -2697,18 +3364,11 @@ export class TechnitiumService {
       for (let index = 0; index < candidateNodes.length; index += 1) {
         const candidate = candidateNodes[index];
         try {
-          const envelope = this.sessionAuthEnabled
-            ? await this.requestWithExplicitToken<TechnitiumApiResponse<any>>(
-                candidate,
-                requestConfig,
-                this.backgroundToken ?? "",
-                { suppressNetworkErrorLog: true },
-              )
-            : await this.request<TechnitiumApiResponse<any>>(
-                candidate,
-                requestConfig,
-                { authMode: "background", suppressNetworkErrorLog: true },
-              );
+          const envelope = await this.request<TechnitiumApiResponse<any>>(
+            candidate,
+            requestConfig,
+            { authMode: "background", suppressNetworkErrorLog: true },
+          );
 
           const data = this.unwrapApiResponse<TechnitiumPtrLookupResult>(
             envelope as unknown as TechnitiumApiResponse<TechnitiumPtrLookupResult>,
@@ -2721,7 +3381,7 @@ export class TechnitiumService {
             return;
           }
 
-          this.hostnameCache.set(ipAddress, {
+          this.hostnameCache.set(clientKey, {
             hostname,
             lastUpdated: Date.now(),
             source: "ptr",
@@ -2762,6 +3422,27 @@ export class TechnitiumService {
       // Keep logs concise by throttling repeated failures per node.
       this.logPtrFailureWithThrottling(node.id, ipAddress, error);
     }
+  }
+
+  private clientNamespaceKey(groupId: string, ipAddress: string): string {
+    const normalizedIp = ipAddress.trim().toLowerCase();
+    return groupId === INTERNAL_DEFAULT_GROUP_ID
+      ? normalizedIp
+      : `${groupId}\u0000${normalizedIp}`;
+  }
+
+  private parseClientNamespaceKey(key: string): {
+    groupId: string;
+    ip: string;
+  } {
+    const separator = key.indexOf("\u0000");
+    if (separator === -1) {
+      return { groupId: INTERNAL_DEFAULT_GROUP_ID, ip: key };
+    }
+    return {
+      groupId: key.slice(0, separator),
+      ip: key.slice(separator + 1),
+    };
   }
 
   /**
@@ -2967,13 +3648,20 @@ export class TechnitiumService {
       entries: fetchedEntries,
     };
 
-    // Fetch DHCP leases from ALL nodes to enrich with hostnames
-    // (Some nodes may not run DHCP, so we aggregate across all nodes)
-    const ipToHostname = await this.getAllDhcpLeases();
+    // Fetch DHCP leases only inside the source node's network namespace.
+    // A peer in the same group may host DHCP even when this node does not.
+    const ipToHostname = await this.getAllDhcpLeasesWithOptions({
+      authMode: "session",
+      sourceGroupId: nodeGroupId(node),
+    });
 
     // Enrich log entries with hostnames from DHCP
     if (data.entries && Array.isArray(data.entries)) {
-      data.entries = this.enrichWithHostnames(data.entries, ipToHostname);
+      data.entries = this.enrichWithHostnames(
+        data.entries,
+        ipToHostname,
+        nodeGroupId(node),
+      );
     }
 
     // Apply client-side filtering for fields not handled by Technitium DNS API
@@ -2995,9 +3683,12 @@ export class TechnitiumService {
           continue;
         }
 
-        const existing = domainMap.get(domain);
+        const dedupKey = filters.deduplicatePerClient
+          ? `${domain.toLowerCase()}\u0000${nodeGroupId(node)}\u0000${(entry.clientIpAddress ?? "").toLowerCase()}`
+          : domain.toLowerCase();
+        const existing = domainMap.get(dedupKey);
         if (!existing) {
-          domainMap.set(domain, entry);
+          domainMap.set(dedupKey, entry);
           continue;
         }
 
@@ -3010,10 +3701,10 @@ export class TechnitiumService {
           existing.responseType === "BlockedEDNS";
 
         if (entryIsBlocked && !existingIsBlocked) {
-          domainMap.set(domain, entry);
+          domainMap.set(dedupKey, entry);
         } else if (entryIsBlocked === existingIsBlocked) {
           if (entry.qtype === "A" && existing.qtype !== "A") {
-            domainMap.set(domain, entry);
+            domainMap.set(dedupKey, entry);
           }
         }
       }
@@ -3337,6 +4028,7 @@ export class TechnitiumService {
             return {
               nodeId: node.id,
               baseUrl: node.baseUrl,
+              groupId: node.groupId,
               fetchedAt,
               data,
               durationMs: performance.now() - nodeStartTime,
@@ -3350,6 +4042,7 @@ export class TechnitiumService {
             return {
               nodeId: node.id,
               baseUrl: node.baseUrl,
+              groupId: node.groupId,
               fetchedAt: new Date().toISOString(),
               error: message,
               durationMs: performance.now() - nodeStartTime,
@@ -3377,6 +4070,7 @@ export class TechnitiumService {
           ...entry,
           nodeId: snapshot.nodeId,
           baseUrl: snapshot.baseUrl,
+          groupId: snapshot.groupId,
         });
       }
     }
@@ -3422,10 +4116,13 @@ export class TechnitiumService {
           continue;
         }
 
-        const existing = domainMap.get(domain);
+        const dedupKey = effectiveFilters.deduplicatePerClient
+          ? `${domain.toLowerCase()}\u0000${entry.groupId}\u0000${(entry.clientIpAddress ?? "").toLowerCase()}`
+          : domain.toLowerCase();
+        const existing = domainMap.get(dedupKey);
         if (!existing) {
           // First entry for this domain
-          domainMap.set(domain, entry);
+          domainMap.set(dedupKey, entry);
           nodeCountMap.set(
             entry.nodeId,
             (nodeCountMap.get(entry.nodeId) ?? 0) + 1,
@@ -3469,7 +4166,7 @@ export class TechnitiumService {
 
         if (shouldReplace) {
           // Update domain map
-          domainMap.set(domain, entry);
+          domainMap.set(dedupKey, entry);
           // Update node counts
           nodeCountMap.set(
             existing.nodeId,
@@ -5570,6 +6267,7 @@ export class TechnitiumService {
       suppressNetworkErrorLog?: boolean;
     },
   ): Promise<T> {
+    const authMode = options?.authMode ?? "session";
     try {
       const axiosConfig: AxiosRequestConfig = {
         baseURL: node.baseUrl,
@@ -5581,41 +6279,61 @@ export class TechnitiumService {
 
       // Add token to request params
       const session = AuthRequestContext.getSession();
-      const sessionToken = session?.tokensByNodeId?.[node.id];
-      const authMode = options?.authMode ?? "session";
 
       let effectiveToken: string | undefined;
       if (this.sessionAuthEnabled) {
         if (authMode === "background") {
           // Background timers have no per-user session context; use a dedicated
           // least-privilege token when configured.
-          effectiveToken = this.backgroundToken;
+          effectiveToken = this.backgroundCredentials.credentialsByGroup.get(
+            nodeGroupId(node),
+          )?.token;
           if (!effectiveToken) {
             throw new UnauthorizedException(
-              `Authentication required for background access to Technitium node "${node.id}". Set TECHNITIUM_BACKGROUND_TOKEN to enable background tasks.`,
+              `Background automation is not authorized for Technitium group "${nodeGroupId(node)}".`,
             );
           }
+          await this.assertAutomationNodeAdmitted(
+            "background",
+            node,
+            this.getAdmissionRole(config),
+          );
         } else if (authMode === "schedule") {
           // DNS Schedule evaluator uses a dedicated token with Apps: Modify permission.
-          effectiveToken = this.scheduleToken;
+          effectiveToken = this.scheduleCredentials.credentialsByGroup.get(
+            nodeGroupId(node),
+          )?.token;
           if (!effectiveToken) {
             throw new UnauthorizedException(
-              `Authentication required for DNS schedule operations on node "${node.id}". Set TECHNITIUM_SCHEDULE_TOKEN to enable DNS schedules.`,
+              `Schedule automation is not authorized for Technitium group "${nodeGroupId(node)}".`,
             );
           }
+          await this.assertAutomationNodeAdmitted(
+            "schedule",
+            node,
+            this.getAdmissionRole(config),
+          );
         } else {
           // Default: interactive calls must use a per-user session token.
-          effectiveToken = sessionToken;
+          if (!session?.tokensByNodeId[node.id]) {
+            await this.tryReadmitSessionNode(session, node);
+          }
+          effectiveToken = session?.tokensByNodeId[node.id];
           if (!effectiveToken) {
             throw new UnauthorizedException(
               `Authentication required for Technitium node "${node.id}".`,
             );
           }
+          this.assertSessionNodeAdmitted(
+            session,
+            node,
+            this.getAdmissionRole(config),
+          );
         }
       } else {
         // Legacy mode: accept either a request-scoped session token (if any)
         // or a configured per-node token.
-        effectiveToken = sessionToken ?? node.token;
+        effectiveToken = session?.tokensByNodeId?.[node.id] ?? node.token;
       }
 
       const params = axiosConfig.params as unknown;
@@ -5649,21 +6367,31 @@ export class TechnitiumService {
         this.sessionAuthEnabled &&
         this.isTechnitiumInvalidTokenEnvelope(response.data)
       ) {
-        const session = AuthRequestContext.getSession();
-        if (session?.tokensByNodeId?.[node.id]) {
-          delete session.tokensByNodeId[node.id];
-          session.nodeAuthStatesByNodeId ??= {};
-          session.nodeAuthStatesByNodeId[node.id] = {
-            status: "failed",
-            error: "invalid-token",
-          };
-          this.logger.warn(
-            `Technitium rejected token for node "${node.id}" (invalid-token envelope). Dropped token from session; re-login required for this node.`,
+        if (authMode === "background" || authMode === "schedule") {
+          this.invalidateAutomationGroupAuthorization(
+            authMode,
+            node,
+            "Technitium rejected the configured automation credential.",
           );
+          this.logger.warn(
+            `Technitium rejected the ${authMode} credential for group "${nodeGroupId(node)}" (invalid-token envelope). Invalidated that group's automation admission.`,
+          );
+        } else {
+          const session = AuthRequestContext.getSession();
+          if (session?.tokensByNodeId?.[node.id]) {
+            this.invalidateSessionNodeAuthorization(
+              session,
+              node,
+              "invalid-token",
+            );
+            this.logger.warn(
+              `Technitium rejected token for node "${node.id}" (invalid-token envelope). Dropped token from session; re-login required for this node.`,
+            );
+          }
         }
 
         throw new UnauthorizedException(
-          `Technitium token is invalid for node "${node.id}". Please sign in again.`,
+          `Technitium token is invalid for node "${node.id}".`,
         );
       }
 
@@ -5677,36 +6405,778 @@ export class TechnitiumService {
         throw error;
       }
 
-      // If Technitium rejects the token, drop it from the current session.
-      // This prevents repeated 401 spam and allows the frontend to stop
-      // issuing per-node requests for nodes that are no longer authenticated.
+      // If Technitium rejects a credential, invalidate only its declared group.
       if (
         this.sessionAuthEnabled &&
         axios.isAxiosError(error) &&
-        error.response?.status === 401 &&
-        this.isLikelyInvalidTokenResponse(error.response.data)
+        (error.response?.status === 401 || error.response?.status === 403)
       ) {
-        const session = AuthRequestContext.getSession();
-        if (session?.tokensByNodeId?.[node.id]) {
-          delete session.tokensByNodeId[node.id];
-          session.nodeAuthStatesByNodeId ??= {};
-          session.nodeAuthStatesByNodeId[node.id] = {
-            status: "failed",
-            error: "invalid token",
-          };
+        const reason =
+          error.response.status === 401 ? "invalid token" : "permission denied";
+        if (authMode === "background" || authMode === "schedule") {
+          this.invalidateAutomationGroupAuthorization(
+            authMode,
+            node,
+            `Technitium rejected the configured automation credential (${reason}).`,
+          );
           this.logger.warn(
-            `Technitium rejected token for node "${node.id}" (invalid token). Dropped token from session; re-login required for this node.`,
+            `Technitium rejected the ${authMode} credential for group "${nodeGroupId(node)}" (HTTP ${error.response.status}). Invalidated that group's automation admission.`,
+          );
+        } else {
+          const session = AuthRequestContext.getSession();
+          if (session?.tokensByNodeId?.[node.id]) {
+            this.invalidateSessionNodeAuthorization(session, node, reason);
+            this.logger.warn(
+              `Technitium rejected authorization for node "${node.id}" (HTTP ${error.response.status}). Invalidated admission for its session group.`,
+            );
+          }
+        }
+        if (error.response.status === 403) {
+          throw new ForbiddenException(
+            `Technitium denied this operation for node "${node.id}".`,
           );
         }
         throw new UnauthorizedException(
-          `Technitium token is invalid for node "${node.id}". Please sign in again.`,
+          `Technitium token is invalid for node "${node.id}".`,
         );
+      }
+
+      if (
+        this.sessionAuthEnabled &&
+        (authMode === "background" || authMode === "schedule") &&
+        axios.isAxiosError(error) &&
+        (!error.response ||
+          [502, 503, 504].includes(error.response.status ?? 0))
+      ) {
+        this.markAutomationNodeUnreachable(authMode, node);
+      }
+
+      if (
+        this.sessionAuthEnabled &&
+        authMode === "session" &&
+        axios.isAxiosError(error) &&
+        (!error.response ||
+          [502, 503, 504].includes(error.response.status ?? 0))
+      ) {
+        const session = AuthRequestContext.getSession();
+        if (
+          session?.authSource === "trusted-sso" &&
+          session.tokensByNodeId[node.id]
+        ) {
+          this.markSessionNodeUnreachable(session, node);
+        }
       }
 
       throw this.normalizeAxiosError(error, node.id, {
         suppressNetworkErrorLog: options?.suppressNetworkErrorLog,
       });
     }
+  }
+
+  private invalidateAutomationGroupAuthorization(
+    authMode: "background" | "schedule",
+    node: TechnitiumNodeConfig,
+    reason: string,
+  ): void {
+    const current =
+      authMode === "background"
+        ? this.backgroundGroupCredentials
+        : this.scheduleGroupCredentials;
+    const groupId = nodeGroupId(node);
+    const group = current?.groups.find((item) => item.groupId === groupId);
+    if (!current || !group) return;
+
+    const groupNodeIds = this.nodeConfigs
+      .filter((candidate) => nodeGroupId(candidate) === groupId)
+      .map((candidate) => candidate.id);
+    group.state = "failed";
+    delete group.verifiedUsername;
+    group.authenticatedNodeIds = [];
+    group.unreachableNodeIds = [];
+    group.failedNodeIds = groupNodeIds;
+    group.admittedNodeIds = emptyAdmissions();
+    group.capabilities = {
+      ptrRead: false,
+      dhcpRead: false,
+      primaryConfigWrite: false,
+      cacheFlush: false,
+    };
+    group.reason = reason;
+    for (const groupNodeId of groupNodeIds) {
+      const key = `${authMode}\u0000${groupNodeId}`;
+      this.automationNodeRetryAfter.delete(key);
+      this.automationNodeRetryAttempts.delete(key);
+    }
+
+    this.updateAutomationCredentialSummary(authMode, current);
+  }
+
+  private updateAutomationCredentialSummary(
+    authMode: "background" | "schedule",
+    current: GroupCredentialStatusEnvelope,
+  ): void {
+    const updated = buildGroupCredentialEnvelope(current.groups);
+    const usable = updated.groups.filter(
+      (item) => item.state === "ready" || item.state === "degraded",
+    );
+    const usernames = [
+      ...new Set(
+        usable.flatMap((item) =>
+          item.verifiedUsername ? [item.verifiedUsername] : [],
+        ),
+      ),
+    ];
+    if (authMode === "background") {
+      this.backgroundGroupCredentials = updated;
+      const ptrReady = usable.filter((item) => item.capabilities.ptrRead);
+      this.backgroundTokenValidation = {
+        validated: true,
+        okForPtr: ptrReady.length > 0,
+        username: usernames.length === 1 ? usernames[0] : undefined,
+        reason:
+          ptrReady.length > 0
+            ? undefined
+            : "No configured group has an admitted DnsClient: View credential for background PTR lookups.",
+      };
+      return;
+    }
+
+    this.scheduleGroupCredentials = updated;
+    const writeReady = usable.filter(
+      (item) => item.capabilities.primaryConfigWrite,
+    );
+    this.scheduleTokenValidation = {
+      validated: true,
+      valid: writeReady.length > 0,
+      hasAppsModify: writeReady.length > 0,
+      hasCacheDelete: writeReady.some((item) => item.capabilities.cacheFlush),
+      username: usernames.length === 1 ? usernames[0] : undefined,
+      reason:
+        writeReady.length > 0
+          ? undefined
+          : "No configured group has an admitted Primary with Apps: Modify permission.",
+    };
+  }
+
+  private markAutomationNodeUnreachable(
+    authMode: "background" | "schedule",
+    node: TechnitiumNodeConfig,
+  ): void {
+    const current =
+      authMode === "background"
+        ? this.backgroundGroupCredentials
+        : this.scheduleGroupCredentials;
+    const group = current?.groups.find(
+      (item) => item.groupId === nodeGroupId(node),
+    );
+    if (!current || !group || group.state === "not-authorized") return;
+
+    group.authenticatedNodeIds = group.authenticatedNodeIds.filter(
+      (id) => id !== node.id,
+    );
+    group.failedNodeIds = group.failedNodeIds.filter((id) => id !== node.id);
+    if (!group.unreachableNodeIds.includes(node.id)) {
+      group.unreachableNodeIds.push(node.id);
+    }
+    for (const nodeIds of Object.values(group.admittedNodeIds)) {
+      const index = nodeIds.indexOf(node.id);
+      if (index >= 0) nodeIds.splice(index, 1);
+    }
+    group.capabilities = {
+      ptrRead: group.admittedNodeIds.ptrRead.length > 0,
+      dhcpRead: group.admittedNodeIds.dhcpRead.length > 0,
+      primaryConfigWrite: group.admittedNodeIds.primaryConfigWrite.length > 0,
+      cacheFlush: group.admittedNodeIds.cacheFlush.length > 0,
+    };
+    group.state =
+      group.authenticatedNodeIds.length > 0 ? "degraded" : "unreachable";
+    group.reason = "One or more group members are awaiting revalidation.";
+    this.updateAutomationCredentialSummary(authMode, current);
+    this.scheduleAutomationNodeRetry(authMode, node);
+  }
+
+  private scheduleAutomationNodeRetry(
+    authMode: "background" | "schedule",
+    node: TechnitiumNodeConfig,
+  ): void {
+    const key = `${authMode}\u0000${node.id}`;
+    const attempt = (this.automationNodeRetryAttempts.get(key) ?? 0) + 1;
+    this.automationNodeRetryAttempts.set(key, attempt);
+    const delay = Math.min(
+      this.SESSION_NODE_RETRY_MAX_MS,
+      this.SESSION_NODE_RETRY_BASE_MS * 2 ** Math.min(attempt - 1, 8),
+    );
+    this.automationNodeRetryAfter.set(key, Date.now() + delay);
+  }
+
+  private getAdmissionRole(
+    config: AxiosRequestConfig,
+  ): keyof GroupCredentialStatus["admittedNodeIds"] {
+    const url = config.url ?? "";
+    if (url === "/api/dnsClient/resolve") return "ptrRead";
+    if (url === "/api/dhcp/leases/list" || url === "/api/dhcp/scopes/list")
+      return "dhcpRead";
+    if (url === "/api/cache/delete") return "cacheFlush";
+    if (url === "/api/apps/config/set") return "primaryConfigWrite";
+    return "interactive";
+  }
+
+  private assertSessionNodeAdmitted(
+    session: ReturnType<typeof AuthRequestContext.getSession>,
+    node: TechnitiumNodeConfig,
+    role: keyof GroupCredentialStatus["admittedNodeIds"],
+  ): void {
+    if (!session?.groupCredentials) return;
+    const group = session.groupCredentials.groups.find(
+      (item) => item.groupId === nodeGroupId(node),
+    );
+    if (!group?.admittedNodeIds[role].includes(node.id)) {
+      throw new ForbiddenException(
+        `Technitium node "${node.id}" is not admitted for ${role} in group "${nodeGroupId(node)}".`,
+      );
+    }
+  }
+
+  private async tryReadmitSessionNode(
+    session: ReturnType<typeof AuthRequestContext.getSession>,
+    node: TechnitiumNodeConfig,
+  ): Promise<void> {
+    if (
+      !session ||
+      session.authSource !== "trusted-sso" ||
+      !session.pendingTokensByNodeId?.[node.id]
+    ) {
+      return;
+    }
+    const retryAfter = session.nodeRetryAfterByNodeId?.[node.id] ?? 0;
+    if (retryAfter > Date.now()) {
+      throw new ServiceUnavailableException(
+        `Technitium node "${node.id}" is awaiting a bounded credential revalidation retry.`,
+      );
+    }
+
+    const flightKey = `${session.id}\0${node.id}`;
+    let flight = this.sessionNodeReadmissionFlights.get(flightKey);
+    if (!flight) {
+      flight = this.revalidatePendingSessionNode(session, node).finally(() => {
+        this.sessionNodeReadmissionFlights.delete(flightKey);
+      });
+      this.sessionNodeReadmissionFlights.set(flightKey, flight);
+    }
+    await flight;
+  }
+
+  private async revalidatePendingSessionNode(
+    session: AuthSession,
+    node: TechnitiumNodeConfig,
+  ): Promise<void> {
+    const token = session.pendingTokensByNodeId?.[node.id];
+    if (!token) return;
+    const groupId = nodeGroupId(node);
+    try {
+      const probe = await this.validateExplicitSessionToken(node.id, token);
+      const expectedUsername = session.credentialUsernamesByGroup?.[groupId];
+      if (!expectedUsername || probe.username !== expectedUsername) {
+        throw new UnauthorizedException("Mapped token owner mismatch");
+      }
+
+      const groupNodes = this.nodeConfigs.filter(
+        (candidate) => nodeGroupId(candidate) === groupId,
+      );
+      const role = this.getCredentialProbeNodeRole(node, probe);
+      if (
+        !hasImplicitNodeGrouping(this.nodeConfigs) &&
+        ((groupNodes.length > 1 && !probe.clusterInitialized) ||
+          (probe.clusterInitialized && !role))
+      ) {
+        throw new UnauthorizedException(
+          "Returning node does not match its declared group topology",
+        );
+      }
+      const expectedDomain = session.topologyDomainsByGroup?.[groupId];
+      if (
+        expectedDomain &&
+        (!probe.clusterInitialized || probe.clusterDomain !== expectedDomain)
+      ) {
+        throw new UnauthorizedException(
+          "Returning node reported a different group topology",
+        );
+      }
+
+      const group = session.groupCredentials?.groups.find(
+        (candidate) => candidate.groupId === groupId,
+      );
+      if (!group || group.state === "not-authorized") {
+        throw new UnauthorizedException(
+          "Returning node belongs to a group not authorized by this session",
+        );
+      }
+
+      session.tokensByNodeId[node.id] = token;
+      delete session.pendingTokensByNodeId?.[node.id];
+      delete session.nodeRetryAfterByNodeId?.[node.id];
+      delete session.nodeRetryAttemptsByNodeId?.[node.id];
+      session.nodeAuthStatesByNodeId ??= {};
+      session.nodeAuthStatesByNodeId[node.id] = { status: "authenticated" };
+      group.failedNodeIds = group.failedNodeIds.filter((id) => id !== node.id);
+      group.unreachableNodeIds = group.unreachableNodeIds.filter(
+        (id) => id !== node.id,
+      );
+      if (!group.authenticatedNodeIds.includes(node.id)) {
+        group.authenticatedNodeIds.push(node.id);
+      }
+      this.addAdmission(group.admittedNodeIds.interactive, node.id);
+      if (probe.permissions["DnsClient"]?.canView === true)
+        this.addAdmission(group.admittedNodeIds.ptrRead, node.id);
+      if (probe.permissions["DhcpServer"]?.canView === true)
+        this.addAdmission(group.admittedNodeIds.dhcpRead, node.id);
+      if (
+        probe.permissions["Apps"]?.canModify === true &&
+        (role === "Primary" || !probe.clusterInitialized)
+      )
+        this.addAdmission(group.admittedNodeIds.primaryConfigWrite, node.id);
+      if (probe.permissions["Cache"]?.canDelete === true)
+        this.addAdmission(group.admittedNodeIds.cacheFlush, node.id);
+      group.capabilities = {
+        ptrRead: group.admittedNodeIds.ptrRead.length > 0,
+        dhcpRead: group.admittedNodeIds.dhcpRead.length > 0,
+        primaryConfigWrite: group.admittedNodeIds.primaryConfigWrite.length > 0,
+        cacheFlush: group.admittedNodeIds.cacheFlush.length > 0,
+      };
+      group.verifiedUsername = probe.username;
+      session.verifiedUsernamesByGroup ??= {};
+      session.verifiedUsernamesByGroup[groupId] = probe.username;
+      session.technitiumUser = singularVerifiedUsername(
+        session.verifiedUsernamesByGroup,
+      );
+      if (probe.clusterInitialized && probe.clusterDomain) {
+        session.topologyDomainsByGroup ??= {};
+        session.topologyDomainsByGroup[groupId] = probe.clusterDomain;
+      }
+      group.state =
+        group.unreachableNodeIds.length === 0 &&
+        group.failedNodeIds.length === 0 &&
+        group.authenticatedNodeIds.length === groupNodes.length
+          ? "ready"
+          : "degraded";
+      delete group.reason;
+      session.groupCredentials = buildGroupCredentialEnvelope(
+        session.groupCredentials?.groups ?? [],
+      );
+    } catch (error) {
+      if (
+        error instanceof HttpException &&
+        [HttpStatus.SERVICE_UNAVAILABLE, HttpStatus.GATEWAY_TIMEOUT].includes(
+          error.getStatus(),
+        )
+      ) {
+        this.scheduleSessionNodeRetry(session, node);
+      } else {
+        this.failSessionGroup(
+          session,
+          groupId,
+          "A returning node failed owner or topology revalidation.",
+        );
+      }
+      throw error;
+    }
+  }
+
+  private addAdmission(nodeIds: string[], nodeId: string): void {
+    if (!nodeIds.includes(nodeId)) nodeIds.push(nodeId);
+  }
+
+  private async assertAutomationNodeAdmitted(
+    authMode: "background" | "schedule",
+    node: TechnitiumNodeConfig,
+    role: keyof GroupCredentialStatus["admittedNodeIds"],
+  ): Promise<void> {
+    if (authMode === "background") {
+      await this.validateBackgroundTokenForPtr();
+    } else {
+      await this.validateScheduleToken();
+    }
+    let envelope =
+      authMode === "background"
+        ? this.backgroundGroupCredentials
+        : this.scheduleGroupCredentials;
+    let group = envelope?.groups.find(
+      (item) => item.groupId === nodeGroupId(node),
+    );
+    if (
+      group?.unreachableNodeIds.includes(node.id) &&
+      !group.admittedNodeIds[role].includes(node.id)
+    ) {
+      await this.tryReadmitAutomationNode(authMode, node);
+      envelope =
+        authMode === "background"
+          ? this.backgroundGroupCredentials
+          : this.scheduleGroupCredentials;
+      group = envelope?.groups.find(
+        (item) => item.groupId === nodeGroupId(node),
+      );
+    }
+    if (!group?.admittedNodeIds[role].includes(node.id)) {
+      throw new ForbiddenException(
+        `${authMode === "background" ? "Background" : "Schedule"} credential is not admitted for ${role} on node "${node.id}".`,
+      );
+    }
+  }
+
+  private async tryReadmitAutomationNode(
+    authMode: "background" | "schedule",
+    node: TechnitiumNodeConfig,
+  ): Promise<void> {
+    const key = `${authMode}\u0000${node.id}`;
+    const retryAfter = this.automationNodeRetryAfter.get(key) ?? 0;
+    if (retryAfter > Date.now()) {
+      throw new ServiceUnavailableException(
+        `${authMode === "background" ? "Background" : "Schedule"} credential for node "${node.id}" is awaiting a bounded revalidation retry.`,
+      );
+    }
+
+    let flight = this.automationNodeReadmissionFlights.get(key);
+    if (!flight) {
+      flight = this.revalidateAutomationNode(authMode, node).finally(() => {
+        this.automationNodeReadmissionFlights.delete(key);
+      });
+      this.automationNodeReadmissionFlights.set(key, flight);
+    }
+    await flight;
+  }
+
+  private async revalidateAutomationNode(
+    authMode: "background" | "schedule",
+    node: TechnitiumNodeConfig,
+  ): Promise<void> {
+    const config =
+      authMode === "background"
+        ? this.backgroundCredentials
+        : this.scheduleCredentials;
+    const credential = config.credentialsByGroup.get(nodeGroupId(node));
+    if (!credential) {
+      throw new UnauthorizedException(
+        `${authMode} automation is not authorized for this node group.`,
+      );
+    }
+
+    const groupId = nodeGroupId(node);
+    const key = `${authMode}\u0000${node.id}`;
+    try {
+      const probe = await this.validateExplicitSessionToken(
+        node.id,
+        credential.token,
+      );
+      const current =
+        authMode === "background"
+          ? this.backgroundGroupCredentials
+          : this.scheduleGroupCredentials;
+      const group = current?.groups.find((item) => item.groupId === groupId);
+      if (!current || !group || group.state === "not-authorized") {
+        throw new UnauthorizedException(
+          "Returning automation node belongs to an unauthorized group.",
+        );
+      }
+
+      const expectedUsername =
+        config.source === "map"
+          ? credential.username
+          : group.verifiedUsername || probe.username;
+      if (probe.username !== expectedUsername) {
+        throw new UnauthorizedException(
+          "Returning automation token owner does not match its group.",
+        );
+      }
+
+      const groupNodes = this.nodeConfigs.filter(
+        (candidate) => nodeGroupId(candidate) === groupId,
+      );
+      const role = this.getCredentialProbeNodeRole(node, probe);
+      if (
+        !hasImplicitNodeGrouping(this.nodeConfigs) &&
+        ((groupNodes.length > 1 && !probe.clusterInitialized) ||
+          (probe.clusterInitialized && !role))
+      ) {
+        throw new UnauthorizedException(
+          "Returning automation node does not match its declared topology.",
+        );
+      }
+      const topologyDomains =
+        authMode === "background"
+          ? this.backgroundTopologyDomainsByGroup
+          : this.scheduleTopologyDomainsByGroup;
+      const expectedDomain = topologyDomains.get(groupId);
+      if (
+        expectedDomain &&
+        (!probe.clusterInitialized || probe.clusterDomain !== expectedDomain)
+      ) {
+        throw new UnauthorizedException(
+          "Returning automation node reported a different group topology.",
+        );
+      }
+
+      if (authMode === "background") {
+        const tooPrivileged =
+          Object.values(probe.permissions).some(
+            (permission) =>
+              permission?.canModify === true || permission?.canDelete === true,
+          ) || probe.permissions["Administration"]?.canView === true;
+        if (probe.permissions["DnsClient"]?.canView !== true || tooPrivileged) {
+          throw new ForbiddenException(
+            "Returning background credential no longer satisfies its least-privilege policy.",
+          );
+        }
+      } else if (probe.permissions["Apps"]?.canModify !== true) {
+        throw new ForbiddenException(
+          "Returning schedule credential no longer has Apps: Modify permission.",
+        );
+      }
+
+      if (probe.clusterInitialized && probe.clusterDomain) {
+        topologyDomains.set(groupId, probe.clusterDomain);
+      }
+      group.unreachableNodeIds = group.unreachableNodeIds.filter(
+        (id) => id !== node.id,
+      );
+      group.failedNodeIds = group.failedNodeIds.filter((id) => id !== node.id);
+      this.addAdmission(group.authenticatedNodeIds, node.id);
+      this.addAdmission(group.admittedNodeIds.interactive, node.id);
+      if (probe.permissions["DnsClient"]?.canView === true)
+        this.addAdmission(group.admittedNodeIds.ptrRead, node.id);
+      if (probe.permissions["DhcpServer"]?.canView === true)
+        this.addAdmission(group.admittedNodeIds.dhcpRead, node.id);
+      if (
+        probe.permissions["Apps"]?.canModify === true &&
+        (role === "Primary" || !probe.clusterInitialized)
+      )
+        this.addAdmission(group.admittedNodeIds.primaryConfigWrite, node.id);
+      if (probe.permissions["Cache"]?.canDelete === true)
+        this.addAdmission(group.admittedNodeIds.cacheFlush, node.id);
+      group.capabilities = {
+        ptrRead: group.admittedNodeIds.ptrRead.length > 0,
+        dhcpRead: group.admittedNodeIds.dhcpRead.length > 0,
+        primaryConfigWrite: group.admittedNodeIds.primaryConfigWrite.length > 0,
+        cacheFlush: group.admittedNodeIds.cacheFlush.length > 0,
+      };
+      group.verifiedUsername = probe.username;
+      group.state =
+        group.authenticatedNodeIds.length === groupNodes.length
+          ? "ready"
+          : "degraded";
+      delete group.reason;
+      this.updateAutomationCredentialSummary(authMode, current);
+      this.automationNodeRetryAfter.delete(key);
+      this.automationNodeRetryAttempts.delete(key);
+    } catch (error) {
+      if (
+        error instanceof HttpException &&
+        [HttpStatus.SERVICE_UNAVAILABLE, HttpStatus.GATEWAY_TIMEOUT].includes(
+          error.getStatus(),
+        )
+      ) {
+        this.scheduleAutomationNodeRetry(authMode, node);
+      } else {
+        this.invalidateAutomationGroupAuthorization(
+          authMode,
+          node,
+          "A returning automation node failed owner, permission, or topology revalidation.",
+        );
+      }
+      throw error;
+    }
+  }
+
+  private getAutomationGroupEnvelope(
+    config: AutomationCredentialConfig,
+    validated: GroupCredentialStatusEnvelope | undefined,
+  ): GroupCredentialStatusEnvelope {
+    if (validated) return validated;
+    return buildGroupCredentialEnvelope(
+      configuredGroupIds(this.nodeConfigs).map((groupId) => {
+        if (config.reason) {
+          return {
+            groupId,
+            state: "failed" as const,
+            authenticatedNodeIds: [],
+            unreachableNodeIds: [],
+            failedNodeIds: this.nodeConfigs
+              .filter((node) => nodeGroupId(node) === groupId)
+              .map((node) => node.id),
+            admittedNodeIds: emptyAdmissions(),
+            capabilities: {
+              ptrRead: false,
+              dhcpRead: false,
+              primaryConfigWrite: false,
+              cacheFlush: false,
+            },
+            reason: config.reason,
+          };
+        }
+        if (!config.credentialsByGroup.has(groupId)) {
+          return notAuthorizedGroupStatus(groupId);
+        }
+        return {
+          groupId,
+          state: "unreachable" as const,
+          authenticatedNodeIds: [],
+          unreachableNodeIds: this.nodeConfigs
+            .filter((node) => nodeGroupId(node) === groupId)
+            .map((node) => node.id),
+          failedNodeIds: [],
+          admittedNodeIds: emptyAdmissions(),
+          capabilities: {
+            ptrRead: false,
+            dhcpRead: false,
+            primaryConfigWrite: false,
+            cacheFlush: false,
+          },
+          reason: "Credential validation is pending.",
+        };
+      }),
+    );
+  }
+
+  private invalidateSessionNodeAdmission(
+    session: NonNullable<ReturnType<typeof AuthRequestContext.getSession>>,
+    nodeId: string,
+  ): void {
+    const group = session.groupCredentials?.groups.find((item) =>
+      Object.values(item.admittedNodeIds).some((nodeIds) =>
+        nodeIds.includes(nodeId),
+      ),
+    );
+    if (!group) return;
+    for (const nodeIds of Object.values(group.admittedNodeIds)) {
+      const index = nodeIds.indexOf(nodeId);
+      if (index >= 0) nodeIds.splice(index, 1);
+    }
+    group.authenticatedNodeIds = group.authenticatedNodeIds.filter(
+      (id) => id !== nodeId,
+    );
+    if (!group.failedNodeIds.includes(nodeId)) group.failedNodeIds.push(nodeId);
+    group.state = group.authenticatedNodeIds.length > 0 ? "degraded" : "failed";
+    group.reason =
+      "A node credential was invalidated after an authorization failure.";
+    session.groupCredentials = buildGroupCredentialEnvelope(
+      session.groupCredentials?.groups ?? [],
+    );
+  }
+
+  private invalidateSessionNodeAuthorization(
+    session: AuthSession,
+    node: TechnitiumNodeConfig,
+    reason: string,
+  ): void {
+    delete session.tokensByNodeId[node.id];
+    delete session.pendingTokensByNodeId?.[node.id];
+    if (session.authSource === "trusted-sso" && session.groupCredentials) {
+      this.failSessionGroup(
+        session,
+        nodeGroupId(node),
+        `Technitium rejected this group's credential (${reason}).`,
+      );
+      return;
+    }
+    this.invalidateSessionNodeAdmission(session, node.id);
+    session.nodeAuthStatesByNodeId ??= {};
+    session.nodeAuthStatesByNodeId[node.id] = {
+      status: "failed",
+      error: reason,
+    };
+  }
+
+  private markSessionNodeUnreachable(
+    session: AuthSession,
+    node: TechnitiumNodeConfig,
+  ): void {
+    const token = session.tokensByNodeId[node.id];
+    if (!token) return;
+    session.pendingTokensByNodeId ??= {};
+    session.pendingTokensByNodeId[node.id] = token;
+    delete session.tokensByNodeId[node.id];
+    this.invalidateSessionNodeAdmission(session, node.id);
+    const group = session.groupCredentials?.groups.find(
+      (candidate) => candidate.groupId === nodeGroupId(node),
+    );
+    if (group) {
+      group.failedNodeIds = group.failedNodeIds.filter((id) => id !== node.id);
+      if (!group.unreachableNodeIds.includes(node.id)) {
+        group.unreachableNodeIds.push(node.id);
+      }
+      group.state =
+        group.authenticatedNodeIds.length > 0 ? "degraded" : "unreachable";
+      group.reason = "One or more group members are awaiting revalidation.";
+      session.groupCredentials = buildGroupCredentialEnvelope(
+        session.groupCredentials?.groups ?? [],
+      );
+    }
+    session.nodeAuthStatesByNodeId ??= {};
+    session.nodeAuthStatesByNodeId[node.id] = {
+      status: "unreachable",
+      error: "Technitium node is unreachable",
+    };
+    this.scheduleSessionNodeRetry(session, node);
+  }
+
+  private scheduleSessionNodeRetry(
+    session: AuthSession,
+    node: TechnitiumNodeConfig,
+  ): void {
+    session.nodeRetryAttemptsByNodeId ??= {};
+    session.nodeRetryAfterByNodeId ??= {};
+    const attempt = (session.nodeRetryAttemptsByNodeId[node.id] ?? 0) + 1;
+    session.nodeRetryAttemptsByNodeId[node.id] = attempt;
+    const delay = Math.min(
+      this.SESSION_NODE_RETRY_MAX_MS,
+      this.SESSION_NODE_RETRY_BASE_MS * 2 ** Math.min(attempt - 1, 8),
+    );
+    session.nodeRetryAfterByNodeId[node.id] = Date.now() + delay;
+  }
+
+  private failSessionGroup(
+    session: AuthSession,
+    groupId: string,
+    reason: string,
+  ): void {
+    const group = session.groupCredentials?.groups.find(
+      (candidate) => candidate.groupId === groupId,
+    );
+    if (!group) return;
+    const groupNodeIds = this.nodeConfigs
+      .filter((node) => nodeGroupId(node) === groupId)
+      .map((node) => node.id);
+    for (const nodeId of groupNodeIds) {
+      delete session.tokensByNodeId[nodeId];
+      delete session.pendingTokensByNodeId?.[nodeId];
+      delete session.nodeRetryAfterByNodeId?.[nodeId];
+      delete session.nodeRetryAttemptsByNodeId?.[nodeId];
+      session.nodeAuthStatesByNodeId ??= {};
+      session.nodeAuthStatesByNodeId[nodeId] = {
+        status: "failed",
+        error: reason,
+      };
+    }
+    group.state = "failed";
+    group.authenticatedNodeIds = [];
+    group.unreachableNodeIds = [];
+    group.failedNodeIds = groupNodeIds;
+    group.admittedNodeIds = emptyAdmissions();
+    group.capabilities = {
+      ptrRead: false,
+      dhcpRead: false,
+      primaryConfigWrite: false,
+      cacheFlush: false,
+    };
+    group.reason = reason;
+    delete session.verifiedUsernamesByGroup?.[groupId];
+    if (session.verifiedUsernamesByGroup) {
+      session.technitiumUser = singularVerifiedUsername(
+        session.verifiedUsernamesByGroup,
+      );
+    }
+    session.groupCredentials = buildGroupCredentialEnvelope(
+      session.groupCredentials?.groups ?? [],
+    );
   }
 
   private isTechnitiumInvalidTokenEnvelope(data: unknown): boolean {

--- a/apps/backend/src/technitium/technitium.types.ts
+++ b/apps/backend/src/technitium/technitium.types.ts
@@ -6,8 +6,30 @@ export interface TechnitiumNodeConfig {
   name?: string;
   baseUrl: string;
   token: string;
+  groupId: string;
   queryLoggerAppName?: string;
   queryLoggerClassPath?: string;
+}
+
+export interface TechnitiumSessionPermission {
+  canView?: boolean;
+  canModify?: boolean;
+  canDelete?: boolean;
+}
+
+export interface TechnitiumCredentialProbe {
+  username: string;
+  permissions: Record<string, TechnitiumSessionPermission | undefined>;
+  clusterInitialized: boolean;
+  clusterDomain?: string;
+  dnsServerDomain?: string;
+  clusterNodes: Array<{
+    name?: string;
+    url?: string;
+    ipAddress?: string;
+    ipAddresses?: string[];
+    type?: "Primary" | "Secondary";
+  }>;
 }
 
 export interface TechnitiumClusterState {
@@ -29,6 +51,7 @@ export interface TechnitiumNodeSummary {
   id: string;
   name?: string;
   baseUrl: string;
+  groupId: string;
   hasAdvancedBlocking?: boolean;
   clusterState?: TechnitiumClusterState;
   isPrimary?: boolean; // True if this node is the Primary in the cluster
@@ -198,6 +221,7 @@ export interface TechnitiumQueryLogEntry {
   qclass?: string;
   answer?: string;
   responseRtt?: number;
+  groupId?: string;
 }
 
 export interface TechnitiumQueryLogPage {
@@ -239,6 +263,7 @@ export interface TechnitiumDashboardStatsData {
 export interface TechnitiumCombinedQueryLogEntry extends TechnitiumQueryLogEntry {
   nodeId: string;
   baseUrl: string;
+  groupId: string;
 }
 
 export interface TechnitiumCombinedNodeLogSnapshot {

--- a/apps/frontend/src/components/common/BackgroundTokenSecurityBanner.tsx
+++ b/apps/frontend/src/components/common/BackgroundTokenSecurityBanner.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import type { GroupCredentialStatusEnvelope } from "../../types/auth";
 import "./BackgroundTokenSecurityBanner.css";
 
 export type BackgroundPtrTokenValidationSummary = {
@@ -11,6 +12,7 @@ export type BackgroundPtrTokenValidationSummary = {
   tooPrivilegedSections?: string[];
   /** True when the failure was a transient connectivity error rather than a permission/security issue. */
   transient?: boolean;
+  groups?: GroupCredentialStatusEnvelope;
 };
 
 export function BackgroundTokenSecurityBanner({

--- a/apps/frontend/src/components/common/GroupCredentialStatusBanner.tsx
+++ b/apps/frontend/src/components/common/GroupCredentialStatusBanner.tsx
@@ -1,0 +1,40 @@
+import type { GroupCredentialStatusEnvelope } from "../../types/auth";
+import "./BackgroundTokenSecurityBanner.css";
+
+export function GroupCredentialStatusBanner({
+  credentials,
+  title = "Technitium group access needs attention",
+}: {
+  credentials: GroupCredentialStatusEnvelope | undefined;
+  title?: string;
+}) {
+  const actionable =
+    credentials?.groups.filter(
+      (group) =>
+        group.state === "degraded" ||
+        group.state === "unreachable" ||
+        group.state === "failed",
+    ) ?? [];
+  if (actionable.length === 0) return null;
+
+  return (
+    <div
+      className="background-token-security-banner background-token-security-banner--warning"
+      role="alert"
+    >
+      <div className="background-token-security-banner__content">
+        <p className="background-token-security-banner__title">
+          {title}
+        </p>
+        <p className="background-token-security-banner__message">
+          {actionable
+            .map(
+              (group) =>
+                `${group.groupId}: ${group.state}${group.reason ? ` (${group.reason})` : ""}`,
+            )
+            .join("; ")}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/common/NodeSessionExpiredBanner.tsx
+++ b/apps/frontend/src/components/common/NodeSessionExpiredBanner.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import "./BackgroundTokenSecurityBanner.css";
+import type { GroupCredentialStatusEnvelope } from "../../types/auth";
 
 export function NodeSessionExpiredBanner({
   sessionAuthEnabled,
@@ -8,12 +9,14 @@ export function NodeSessionExpiredBanner({
   configuredNodeIds,
   nodeIds,
   unreachableNodeIds,
+  groupCredentials,
 }: {
   sessionAuthEnabled: boolean | undefined;
   authenticated: boolean;
   configuredNodeIds: string[] | undefined;
   nodeIds: string[] | undefined;
   unreachableNodeIds: string[] | undefined;
+  groupCredentials?: GroupCredentialStatusEnvelope;
 }) {
   const location = useLocation();
   const navigate = useNavigate();
@@ -36,6 +39,7 @@ export function NodeSessionExpiredBanner({
   const show =
     sessionAuthEnabled === true &&
     authenticated &&
+    !groupCredentials &&
     configured.length > 0 &&
     missingNodeIds.length > 0 &&
     !location.pathname.startsWith("/login");

--- a/apps/frontend/src/components/layout/AppLayout.tsx
+++ b/apps/frontend/src/components/layout/AppLayout.tsx
@@ -3,6 +3,7 @@ import { useLocation } from "react-router-dom";
 import { useAuth } from "../../context/useAuth";
 import { BackgroundTokenSecurityBanner } from "../common/BackgroundTokenSecurityBanner";
 import { NodeSessionExpiredBanner } from "../common/NodeSessionExpiredBanner";
+import { GroupCredentialStatusBanner } from "../common/GroupCredentialStatusBanner";
 import { TransportSecurityBanner } from "../common/TransportSecurityBanner";
 import { Header } from "./Header";
 
@@ -25,6 +26,12 @@ export function AppLayout({ children }: { children: ReactNode }) {
         configuredNodeIds={status?.configuredNodeIds}
         nodeIds={status?.nodeIds}
         unreachableNodeIds={status?.unreachableNodeIds}
+        groupCredentials={status?.groupCredentials}
+      />
+      <GroupCredentialStatusBanner credentials={status?.groupCredentials} />
+      <GroupCredentialStatusBanner
+        credentials={status?.backgroundPtrToken?.groups}
+        title="Background credential groups need attention"
       />
       <TransportSecurityBanner
         sessionAuthEnabled={status?.sessionAuthEnabled}

--- a/apps/frontend/src/context/AuthContext.tsx
+++ b/apps/frontend/src/context/AuthContext.tsx
@@ -9,6 +9,7 @@ import {
 } from "../config";
 import { AuthContext } from "./authContextInstance";
 import { redirectToTrustedSsoLogout } from "../utils/trustedSso";
+import type { GroupCredentialStatusEnvelope } from "../types/auth";
 
 export type AuthStatus = {
   sessionAuthEnabled?: boolean;
@@ -16,6 +17,8 @@ export type AuthStatus = {
   user?: string;
   authSource?: "password" | "trusted-sso";
   technitiumUser?: string;
+  verifiedUsernamesByGroup?: Record<string, string>;
+  groupCredentials?: GroupCredentialStatusEnvelope;
   nodeIds?: string[];
   unreachableNodeIds?: string[];
   failedNodeIds?: string[];

--- a/apps/frontend/src/context/TechnitiumContext.tsx
+++ b/apps/frontend/src/context/TechnitiumContext.tsx
@@ -105,6 +105,7 @@ export interface TechnitiumNode {
   id: string;
   name: string;
   baseUrl: string;
+  groupId: string;
   status: NodeStatus;
   lastSync: string;
   issues?: string[];
@@ -484,6 +485,7 @@ const fetchConfiguredNodes = async (): Promise<TechnitiumNode[]> => {
         id: string;
         name: string;
         baseUrl: string;
+        groupId: string;
         clusterState?: TechnitiumClusterState;
         isPrimary?: boolean;
       }> = await response.json();
@@ -493,6 +495,7 @@ const fetchConfiguredNodes = async (): Promise<TechnitiumNode[]> => {
         id: node.id,
         name: node.name || node.id,
         baseUrl: node.baseUrl,
+        groupId: node.groupId,
         status: "unknown" as NodeStatus,
         lastSync: new Date().toISOString(),
         clusterState: node.clusterState,
@@ -905,6 +908,7 @@ export function TechnitiumProvider({ children }: { children: ReactNode }) {
         id: string;
         name: string;
         baseUrl: string;
+        groupId: string;
         clusterState?: TechnitiumClusterState;
         isPrimary?: boolean;
       }> = await response.json();
@@ -943,6 +947,7 @@ export function TechnitiumProvider({ children }: { children: ReactNode }) {
                 ...node,
                 clusterState: updated.clusterState,
                 isPrimary: updated.isPrimary,
+                groupId: updated.groupId,
               };
             }
             return node;

--- a/apps/frontend/src/pages/AutomationPage.tsx
+++ b/apps/frontend/src/pages/AutomationPage.tsx
@@ -18,6 +18,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useCallback, useEffect, useRef, useState, type DragEvent } from "react";
 import { AppInput, AppTextarea } from "../components/common/AppInput";
 import { ConfirmModal } from "../components/common/ConfirmModal";
+import { GroupCredentialStatusBanner } from "../components/common/GroupCredentialStatusBanner";
 import { apiFetch, apiFetchStatus } from "../config";
 import { useTechnitiumState } from "../context/useTechnitiumState";
 import { useToast } from "../context/useToast";
@@ -1306,17 +1307,17 @@ function ScheduleForm({
             />
             <span>Flush DNS cache when schedule activates or deactivates</span>
           </label>
-          {draft.flushCacheOnChange && tokenStatus?.hasCacheModify !== true && (
+          {draft.flushCacheOnChange && tokenStatus?.hasCacheDelete !== true && (
             <p className="log-alerts__form-hint">
-              Requires <strong>Cache: Modify</strong> permission on the
+              Requires <strong>Cache: Delete</strong> permission on the
               companion-scheduler user (Administration → Permissions → Cache →
               Edit Permissions). Flush is best-effort — schedule evaluation
               succeeds even if the flush fails.
             </p>
           )}
-          {draft.flushCacheOnChange && tokenStatus?.hasCacheModify === false && (
+          {draft.flushCacheOnChange && tokenStatus?.hasCacheDelete === false && (
             <p className="log-alerts__form-hint log-alerts__form-hint--warn">
-              The companion-scheduler token does not have Cache: Modify
+              The companion-scheduler token does not have Cache: Delete
               permission. Cache flush will be skipped.
             </p>
           )}
@@ -1910,9 +1911,9 @@ function TemporaryOverrideForm({
             />
             <span>Flush DNS cache when the override applies or ends</span>
           </label>
-          {draft.flushCacheOnChange && tokenStatus?.hasCacheModify === false && (
+          {draft.flushCacheOnChange && tokenStatus?.hasCacheDelete === false && (
             <p className="log-alerts__form-hint log-alerts__form-hint--warn">
-              The companion-scheduler token does not have Cache: Modify
+              The companion-scheduler token does not have Cache: Delete
               permission. Cache flush will be skipped.
             </p>
           )}
@@ -3038,6 +3039,10 @@ export function AutomationPage() {
         storageStatus={storageStatus}
         onRevalidate={() => void handleRevalidateToken()}
         revalidating={revalidatingToken}
+      />
+      <GroupCredentialStatusBanner
+        credentials={tokenStatus?.groups}
+        title="Schedule credential groups need attention"
       />
 
       <div className="dns-overrides__tabs" role="tablist" aria-label="DNS Overrides">

--- a/apps/frontend/src/pages/LogsPage.tsx
+++ b/apps/frontend/src/pages/LogsPage.tsx
@@ -1859,7 +1859,7 @@ export function LogsPage() {
   const [activeTab, setActiveTab] = useState<"logs" | "alerts">("logs");
   const [availableAbGroups, setAvailableAbGroups] = useState<string[]>([]);
   const [knownClients, setKnownClients] = useState<
-    { ip: string; hostname?: string }[]
+    { groupId: string; ip: string; hostname?: string }[]
   >([]);
 
   const isAdvancedBlockingActive =
@@ -4697,12 +4697,12 @@ export function LogsPage() {
   const blockWriteNodeLabel = blockWriteNodeId
     ? (nodeMap.get(blockWriteNodeId)?.name ?? blockWriteNodeId)
     : "";
-  const advancedBlockingPrimaryNode = nodes.find(
+  const advancedBlockingPrimaryNodes = nodes.filter(
     (node) => node.isPrimary === true,
   );
-  const advancedBlockingPrimaryLabel = advancedBlockingPrimaryNode
-    ? advancedBlockingPrimaryNode.name || advancedBlockingPrimaryNode.id
-    : "";
+  const advancedBlockingPrimaryLabel = advancedBlockingPrimaryNodes
+    .map((node) => node.name || node.id)
+    .join(", ");
   const isBlockedEntry = blockDialog
     ? isEntryBlocked(blockDialog.entry)
     : false;
@@ -5839,6 +5839,7 @@ export function LogsPage() {
               ...entry,
               nodeId: selectedNodeId,
               baseUrl: nodeInfo?.baseUrl ?? "",
+              groupId: entry.groupId ?? nodeInfo?.groupId ?? "__default__",
             }));
 
           if (displayMode === "tail") {
@@ -5977,6 +5978,7 @@ export function LogsPage() {
         ...entry,
         nodeId: selectedNodeId,
         baseUrl: nodeInfo?.baseUrl ?? "",
+        groupId: entry.groupId ?? nodeInfo?.groupId ?? "__default__",
       }));
     }
 
@@ -6411,6 +6413,7 @@ export function LogsPage() {
         const response = await apiFetch("/nodes/known-clients");
         if (response.ok) {
           const data = (await response.json()) as {
+            groupId: string;
             ip: string;
             hostname?: string;
           }[];
@@ -7203,18 +7206,20 @@ export function LogsPage() {
                       }
                     />
                     <datalist id="log-alert-rule-client-datalist">
-                      {knownClients.map(({ ip, hostname }) =>
+                      {knownClients.map(({ groupId, ip, hostname }) =>
                         hostname ? (
-                          <>
-                            <option key={`${ip}-name`} value={hostname}>
-                              {hostname} ({ip})
+                          <React.Fragment key={`${groupId}-${ip}`}>
+                            <option value={hostname}>
+                              {hostname} ({ip}, {groupId})
                             </option>
-                            <option key={`${ip}-ip`} value={ip}>
-                              {ip} ({hostname})
+                            <option value={ip}>
+                              {ip} ({hostname}, {groupId})
                             </option>
-                          </>
+                          </React.Fragment>
                         ) : (
-                          <option key={ip} value={ip} />
+                          <option key={`${groupId}-${ip}`} value={ip}>
+                            {ip} ({groupId})
+                          </option>
                         ),
                       )}
                     </datalist>
@@ -8948,7 +8953,7 @@ export function LogsPage() {
                             {selectedDomains.size !== 1 ? "s" : ""}
                           </strong>{" "}
                           in Advanced Blocking groups
-                          {advancedBlockingPrimaryNode
+                          {advancedBlockingPrimaryNodes.length > 0
                             ? ` through ${advancedBlockingPrimaryLabel}.`
                             : " across all nodes."}
                         </p>

--- a/apps/frontend/src/test/advanced-blocking-routing.test.ts
+++ b/apps/frontend/src/test/advanced-blocking-routing.test.ts
@@ -14,6 +14,28 @@ describe("Advanced Blocking write routing", () => {
     expect(resolveAdvancedBlockingWriteNodeId(nodes, "eq14")).toBe("eq10");
   });
 
+  it("routes a secondary only to the primary in its group", () => {
+    const nodes = [
+      { id: "site-a-primary", groupId: "site-a", isPrimary: true },
+      { id: "site-a-secondary", groupId: "site-a", isPrimary: false },
+      { id: "site-b-primary", groupId: "site-b", isPrimary: true },
+      { id: "site-b-secondary", groupId: "site-b", isPrimary: false },
+    ];
+
+    expect(
+      resolveAdvancedBlockingWriteNodeId(nodes, "site-b-secondary"),
+    ).toBe("site-b-primary");
+  });
+
+  it("keeps an unknown source instead of guessing a group", () => {
+    expect(
+      resolveAdvancedBlockingWriteNodeId(
+        [{ id: "site-a-primary", groupId: "site-a", isPrimary: true }],
+        "unknown-node",
+      ),
+    ).toBe("unknown-node");
+  });
+
   it("keeps the source node as the target outside a cluster", () => {
     expect(
       resolveAdvancedBlockingWriteNodeId(
@@ -46,5 +68,32 @@ describe("Advanced Blocking write routing", () => {
         snapshots,
       ),
     ).toEqual(snapshots);
+  });
+
+  it("keeps one primary target per group for bulk writes", () => {
+    const snapshots = [
+      { nodeId: "site-a-primary" },
+      { nodeId: "site-a-secondary" },
+      { nodeId: "site-b-primary" },
+      { nodeId: "site-b-secondary" },
+      { nodeId: "standalone" },
+    ];
+
+    expect(
+      selectAdvancedBlockingWriteSnapshots(
+        [
+          { id: "site-a-primary", groupId: "site-a", isPrimary: true },
+          { id: "site-a-secondary", groupId: "site-a", isPrimary: false },
+          { id: "site-b-primary", groupId: "site-b", isPrimary: true },
+          { id: "site-b-secondary", groupId: "site-b", isPrimary: false },
+          { id: "standalone", groupId: "standalone" },
+        ],
+        snapshots,
+      ),
+    ).toEqual([
+      { nodeId: "site-a-primary" },
+      { nodeId: "site-b-primary" },
+      { nodeId: "standalone" },
+    ]);
   });
 });

--- a/apps/frontend/src/test/auth-session-expiry-routing.test.tsx
+++ b/apps/frontend/src/test/auth-session-expiry-routing.test.tsx
@@ -20,6 +20,9 @@ let mockedAuthStatus: {
   configuredNodeIds: string[];
   nodeIds: string[];
   unreachableNodeIds?: string[];
+  groupCredentials?: {
+    groups: Array<{ state: string }>;
+  };
   trustedSso?: {
     enabled: boolean;
     available: boolean;
@@ -43,6 +46,7 @@ vi.mock("../context/useAuth", async () => {
         configuredNodeIds: mockedAuthStatus?.configuredNodeIds ?? ["node1"],
         nodeIds: mockedAuthStatus?.nodeIds ?? [],
         unreachableNodeIds: mockedAuthStatus?.unreachableNodeIds ?? [],
+        groupCredentials: mockedAuthStatus?.groupCredentials,
         trustedSso: mockedAuthStatus?.trustedSso,
       },
       loading: false,
@@ -194,6 +198,20 @@ describe("Auth routing when node session expires", () => {
         unreachableNodeIds: [],
       }),
     ).toBe(true);
+  });
+
+  it("does not treat intentionally unauthorized groups as an expired session", () => {
+    expect(
+      isNodeSessionRequiredButMissing({
+        sessionAuthEnabled: true,
+        authenticated: true,
+        configuredNodeIds: ["site-a-primary", "site-b-primary"],
+        nodeIds: ["site-a-primary"],
+        groupCredentials: {
+          groups: [{ state: "ready" }, { state: "not-authorized" }],
+        },
+      }),
+    ).toBe(false);
   });
 
   it.each([

--- a/apps/frontend/src/test/group-credential-status-banner.test.tsx
+++ b/apps/frontend/src/test/group-credential-status-banner.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { GroupCredentialStatusBanner } from "../components/common/GroupCredentialStatusBanner";
+import type { GroupCredentialStatus } from "../types/auth";
+
+const status = (
+  groupId: string,
+  state: GroupCredentialStatus["state"],
+  reason?: string,
+): GroupCredentialStatus => ({
+  groupId,
+  state,
+  authenticatedNodeIds: [],
+  unreachableNodeIds: [],
+  failedNodeIds: [],
+  admittedNodeIds: {
+    interactive: [],
+    ptrRead: [],
+    dhcpRead: [],
+    primaryConfigWrite: [],
+    cacheFlush: [],
+  },
+  capabilities: {
+    ptrRead: false,
+    dhcpRead: false,
+    primaryConfigWrite: false,
+    cacheFlush: false,
+  },
+  reason,
+});
+
+describe("GroupCredentialStatusBanner", () => {
+  it("surfaces degraded and failed groups with their sanitized reasons", () => {
+    render(
+      <GroupCredentialStatusBanner
+        credentials={{
+          anyReady: true,
+          allReady: false,
+          groups: [
+            status("site-a", "degraded", "Primary is unreachable."),
+            status("site-b", "failed", "Token owner mismatch."),
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "site-a: degraded (Primary is unreachable.)",
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "site-b: failed (Token owner mismatch.)",
+    );
+  });
+
+  it("does not present an intentionally unauthorized group as an error", () => {
+    const { container } = render(
+      <GroupCredentialStatusBanner
+        credentials={{
+          anyReady: true,
+          allReady: true,
+          groups: [
+            status("site-a", "ready"),
+            status("site-b", "not-authorized"),
+          ],
+        }}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/frontend/src/types/auth.ts
+++ b/apps/frontend/src/types/auth.ts
@@ -1,0 +1,35 @@
+export type GroupCredentialState =
+  | "ready"
+  | "degraded"
+  | "unreachable"
+  | "failed"
+  | "not-authorized";
+
+export interface GroupCredentialStatus {
+  groupId: string;
+  state: GroupCredentialState;
+  verifiedUsername?: string;
+  authenticatedNodeIds: string[];
+  unreachableNodeIds: string[];
+  failedNodeIds: string[];
+  admittedNodeIds: {
+    interactive: string[];
+    ptrRead: string[];
+    dhcpRead: string[];
+    primaryConfigWrite: string[];
+    cacheFlush: string[];
+  };
+  capabilities: {
+    ptrRead: boolean;
+    dhcpRead: boolean;
+    primaryConfigWrite: boolean;
+    cacheFlush: boolean;
+  };
+  reason?: string;
+}
+
+export interface GroupCredentialStatusEnvelope {
+  anyReady: boolean;
+  allReady: boolean;
+  groups: GroupCredentialStatus[];
+}

--- a/apps/frontend/src/types/dnsSchedules.ts
+++ b/apps/frontend/src/types/dnsSchedules.ts
@@ -1,3 +1,5 @@
+import type { GroupCredentialStatusEnvelope } from "./auth";
+
 export type DnsScheduleAction = "block" | "allow";
 export type DnsScheduleTargetType = "advanced-blocking" | "built-in";
 
@@ -77,7 +79,8 @@ export interface DnsScheduleTokenStatus {
   username?: string;
   reason?: string;
   hasAppsModify: boolean | null;
-  hasCacheModify: boolean | null;
+  hasCacheDelete: boolean | null;
+  groups?: GroupCredentialStatusEnvelope;
 }
 
 export interface DnsScheduleEvaluatorStatus {
@@ -101,6 +104,10 @@ export interface DnsScheduleApplicationResult {
   action: "applied" | "removed" | "skipped" | "error";
   reason?: string;
   error?: string;
+  cacheFlush?: {
+    flushedNodeIds: string[];
+    skippedNodeIds: string[];
+  };
 }
 
 export interface RunDnsScheduleEvaluatorResponse {

--- a/apps/frontend/src/types/technitiumLogs.ts
+++ b/apps/frontend/src/types/technitiumLogs.ts
@@ -34,6 +34,7 @@ export interface TechnitiumQueryLogEntry {
   qtype?: string;
   qclass?: string;
   answer?: string;
+  groupId?: string;
 }
 
 export interface TechnitiumQueryLogPage {
@@ -48,6 +49,7 @@ export interface TechnitiumQueryLogPage {
 export interface TechnitiumCombinedQueryLogEntry extends TechnitiumQueryLogEntry {
   nodeId: string;
   baseUrl: string;
+  groupId: string;
 }
 
 export interface TechnitiumNodeQueryLogEnvelope {

--- a/apps/frontend/src/utils/advanced-blocking-routing.ts
+++ b/apps/frontend/src/utils/advanced-blocking-routing.ts
@@ -1,5 +1,6 @@
 interface AdvancedBlockingRouteNode {
   id: string;
+  groupId?: string;
   isPrimary?: boolean;
 }
 
@@ -7,20 +8,48 @@ interface AdvancedBlockingRouteSnapshot {
   nodeId: string;
 }
 
+const DEFAULT_GROUP_ID = "__default__";
+
+function getNodeGroupId(node: AdvancedBlockingRouteNode): string {
+  return node.groupId ?? DEFAULT_GROUP_ID;
+}
+
 export function resolveAdvancedBlockingWriteNodeId(
   nodes: AdvancedBlockingRouteNode[],
   sourceNodeId: string,
 ): string {
-  return nodes.find((node) => node.isPrimary === true)?.id ?? sourceNodeId;
+  const sourceNode = nodes.find((node) => node.id === sourceNodeId);
+  if (!sourceNode) {
+    return sourceNodeId;
+  }
+
+  const sourceGroupId = getNodeGroupId(sourceNode);
+  return (
+    nodes.find(
+      (node) =>
+        node.isPrimary === true && getNodeGroupId(node) === sourceGroupId,
+    )?.id ?? sourceNodeId
+  );
 }
 
 export function selectAdvancedBlockingWriteSnapshots<
   T extends AdvancedBlockingRouteSnapshot,
 >(nodes: AdvancedBlockingRouteNode[], snapshots: T[]): T[] {
-  const primaryNodeId = nodes.find((node) => node.isPrimary === true)?.id;
-  if (!primaryNodeId) {
-    return snapshots;
-  }
+  const nodesById = new Map(nodes.map((node) => [node.id, node]));
+  const primaryNodeIdsByGroup = new Map<string, string>();
+  nodes.forEach((node) => {
+    if (node.isPrimary === true) {
+      primaryNodeIdsByGroup.set(getNodeGroupId(node), node.id);
+    }
+  });
 
-  return snapshots.filter((snapshot) => snapshot.nodeId === primaryNodeId);
+  return snapshots.filter((snapshot) => {
+    const node = nodesById.get(snapshot.nodeId);
+    if (!node) {
+      return false;
+    }
+
+    const primaryNodeId = primaryNodeIdsByGroup.get(getNodeGroupId(node));
+    return !primaryNodeId || snapshot.nodeId === primaryNodeId;
+  });
 }

--- a/apps/frontend/src/utils/authSession.ts
+++ b/apps/frontend/src/utils/authSession.ts
@@ -4,12 +4,14 @@ export type AuthStatusLike = {
   configuredNodeIds?: string[];
   nodeIds?: string[];
   unreachableNodeIds?: string[];
+  groupCredentials?: { groups: Array<{ state: string }> };
 };
 
 export function isNodeSessionRequiredButMissing(
   status: AuthStatusLike | null,
 ): boolean {
   if (!status?.authenticated) return false;
+  if (status.groupCredentials) return false;
 
   const configuredNodeCount = status.configuredNodeIds?.length ?? 0;
   const sessionNodeIds = new Set(status.nodeIds ?? []);

--- a/docker-compose.multi-cluster-sso-test.yml
+++ b/docker-compose.multi-cluster-sso-test.yml
@@ -1,0 +1,192 @@
+name: technitium-companion-multi-cluster-sso-test
+
+x-technitium-common: &technitium-common
+  image: technitium/dns-server:${TECHNITIUM_MULTI_CLUSTER_TEST_TAG:-15.3.0}
+  restart: "no"
+  env_file:
+    - ./.multi-cluster-sso-test/technitium.env
+
+services:
+  site-a-primary:
+    <<: *technitium-common
+    hostname: site-a-primary
+    environment:
+      DNS_SERVER_DOMAIN: a-primary.site-a.test
+    ports:
+      - "127.0.0.1:${SITE_A_PRIMARY_HTTP_PORT:-15380}:5380"
+      - "127.0.0.1:${SITE_A_PRIMARY_HTTPS_PORT:-15480}:53443"
+    volumes:
+      - site-a-primary-config:/etc/dns
+    networks:
+      site-a:
+        ipv4_address: 172.30.111.10
+
+  site-a-secondary:
+    <<: *technitium-common
+    hostname: site-a-secondary
+    environment:
+      DNS_SERVER_DOMAIN: a-secondary.site-a.test
+    ports:
+      - "127.0.0.1:${SITE_A_SECONDARY_HTTP_PORT:-15381}:5380"
+    volumes:
+      - site-a-secondary-config:/etc/dns
+    networks:
+      site-a:
+        ipv4_address: 172.30.111.11
+
+  site-b-primary:
+    <<: *technitium-common
+    hostname: site-b-primary
+    environment:
+      DNS_SERVER_DOMAIN: b-primary.site-b.test
+    ports:
+      - "127.0.0.1:${SITE_B_PRIMARY_HTTP_PORT:-15382}:5380"
+      - "127.0.0.1:${SITE_B_PRIMARY_HTTPS_PORT:-15482}:53443"
+    volumes:
+      - site-b-primary-config:/etc/dns
+    networks:
+      site-b:
+        ipv4_address: 172.30.112.10
+
+  site-b-secondary:
+    <<: *technitium-common
+    hostname: site-b-secondary
+    environment:
+      DNS_SERVER_DOMAIN: b-secondary.site-b.test
+    ports:
+      - "127.0.0.1:${SITE_B_SECONDARY_HTTP_PORT:-15383}:5380"
+    volumes:
+      - site-b-secondary-config:/etc/dns
+    networks:
+      site-b:
+        ipv4_address: 172.30.112.11
+
+  technitium-dns-companion-test:
+    image: technitium-dns-companion:multi-cluster-sso-test
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: "no"
+    depends_on:
+      - site-a-primary
+      - site-a-secondary
+      - site-b-primary
+      - site-b-secondary
+    environment:
+      NODE_ENV: production
+      HTTPS_ENABLED: "false"
+      TRUST_PROXY: "true"
+      TRUST_PROXY_HOPS: "1"
+      TRUSTED_SSO_ENABLED: "true"
+      TRUSTED_SSO_IDENTITY_HEADER: X-Forwarded-User
+      TRUSTED_SSO_PROXY_SECRET_HEADER: X-Trusted-Proxy-Secret
+      TRUSTED_SSO_PROXY_SECRET_FILE: /run/secrets/trusted-sso-proxy-secret
+      TRUSTED_SSO_TOKEN_MAP_FILE: /run/secrets/trusted-sso-token-map.json
+      TRUSTED_SSO_PROXY_CIDRS: 172.30.113.0/24
+      TECHNITIUM_BACKGROUND_TOKEN_MAP_FILE: /run/secrets/background-token-map.json
+      TECHNITIUM_SCHEDULE_TOKEN_MAP_FILE: /run/secrets/schedule-token-map.json
+      TECHNITIUM_NODES: site-a-primary,site-a-secondary,site-b-primary,site-b-secondary
+      TECHNITIUM_SITEAPRIMARY_NAME: Site A Primary
+      TECHNITIUM_SITEAPRIMARY_BASE_URL: http://site-a-primary:5380
+      TECHNITIUM_SITEAPRIMARY_GROUP: site-a
+      TECHNITIUM_SITEASECONDARY_NAME: Site A Secondary
+      TECHNITIUM_SITEASECONDARY_BASE_URL: http://site-a-secondary:5380
+      TECHNITIUM_SITEASECONDARY_GROUP: site-a
+      TECHNITIUM_SITEBPRIMARY_NAME: Site B Primary
+      TECHNITIUM_SITEBPRIMARY_BASE_URL: http://site-b-primary:5380
+      TECHNITIUM_SITEBPRIMARY_GROUP: site-b
+      TECHNITIUM_SITEBSECONDARY_NAME: Site B Secondary
+      TECHNITIUM_SITEBSECONDARY_BASE_URL: http://site-b-secondary:5380
+      TECHNITIUM_SITEBSECONDARY_GROUP: site-b
+      COMPANION_DB_PATH: /data/companion.sqlite
+    ports:
+      - "127.0.0.1:${MULTI_CLUSTER_COMPANION_HTTP_PORT:-15300}:3000"
+    volumes:
+      - companion-data:/data
+      - type: bind
+        source: ./.multi-cluster-sso-test/proxy-secret
+        target: /run/secrets/trusted-sso-proxy-secret
+        read_only: true
+      - type: bind
+        source: ./.multi-cluster-sso-test/trusted-sso-token-map.json
+        target: /run/secrets/trusted-sso-token-map.json
+        read_only: true
+      - type: bind
+        source: ./.multi-cluster-sso-test/background-token-map.json
+        target: /run/secrets/background-token-map.json
+        read_only: true
+      - type: bind
+        source: ./.multi-cluster-sso-test/schedule-token-map.json
+        target: /run/secrets/schedule-token-map.json
+        read_only: true
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    networks:
+      - site-a
+      - site-b
+      - sso-front
+
+  trusted-sso-test-proxy:
+    image: nginx:1.29-alpine
+    restart: "no"
+    depends_on:
+      - technitium-dns-companion-test
+    entrypoint:
+      - /bin/sh
+      - -ec
+      - |
+        export TRUSTED_SSO_PROXY_SECRET="$$(cat /run/secrets/trusted-sso-proxy-secret)"
+        envsubst '$$TRUSTED_SSO_PROXY_SECRET' < /etc/nginx/templates/trusted-sso.conf.template > /tmp/nginx.conf
+        exec nginx -c /tmp/nginx.conf -g 'daemon off;'
+    ports:
+      - "127.0.0.1:${MULTI_CLUSTER_PROXY_HTTPS_PORT:-15443}:8443"
+    volumes:
+      - type: bind
+        source: ./deploy/sso-test/nginx.conf.template
+        target: /etc/nginx/templates/trusted-sso.conf.template
+        read_only: true
+      - type: bind
+        source: ./.multi-cluster-sso-test/proxy-secret
+        target: /run/secrets/trusted-sso-proxy-secret
+        read_only: true
+      - type: bind
+        source: ./.multi-cluster-sso-test/htpasswd
+        target: /etc/nginx/auth/htpasswd
+        read_only: true
+      - type: bind
+        source: ./.multi-cluster-sso-test/tls
+        target: /etc/nginx/tls
+        read_only: true
+    read_only: true
+    tmpfs:
+      - /var/cache/nginx
+      - /var/run
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      sso-front:
+        ipv4_address: 172.30.113.10
+
+volumes:
+  site-a-primary-config:
+  site-a-secondary-config:
+  site-b-primary-config:
+  site-b-secondary-config:
+  companion-data:
+
+networks:
+  site-a:
+    ipam:
+      config:
+        - subnet: 172.30.111.0/24
+  site-b:
+    ipam:
+      config:
+        - subnet: 172.30.112.0/24
+  sso-front:
+    ipam:
+      config:
+        - subnet: 172.30.113.0/24

--- a/docs/BETA_TESTING.md
+++ b/docs/BETA_TESTING.md
@@ -1,9 +1,10 @@
 # Beta Testing
 
-The beta channel is an opt-in preview of the current `next` branch. It is for
-operators who can tolerate regressions, retain a rollback path, and report the
-exact build they tested. Stable installations continue to use `:latest` unless
-their image is explicitly changed.
+The beta channel is an opt-in, approval-gated release candidate promoted from
+a selected `next` or `release/*` commit. It is for operators who can tolerate
+regressions, retain a rollback path, and report the exact build they tested.
+Stable installations continue to use `:latest` unless their image is
+explicitly changed.
 
 ## Before you start
 
@@ -29,9 +30,36 @@ docker compose up -d
 docker compose ps
 ```
 
-The `beta` and `next` tags are rolling aliases. For a longer test or a reliable
-reproduction, replace `:beta` with the immutable `sha-<commit>` tag associated
-with the build.
+The `beta` tag advances only after an explicit promotion and can remain fixed
+while the rolling `next` integration tag receives more changes. For a longer
+test or reliable reproduction, replace `:beta` with the immutable
+`sha-<commit>` tag associated with the promoted build.
+
+## Promote a candidate
+
+Maintainers promote a candidate by manually running **Build and Push Docker
+Image** from `next` or a `release/*` branch with `push_image=true` and
+`channel=beta`. The workflow runs the release quality gates, validates the
+source branch, waits for approval through the protected `beta` environment,
+and publishes `:beta`, `<version>-beta`, and `sha-<commit>` to the same image
+digest.
+
+```bash
+gh workflow run docker-publish.yml \
+  --ref next \
+  -f push_image=true \
+  -f channel=beta
+```
+
+Ordinary pushes to `next` publish only `:next` and `sha-<commit>`. Merging a
+stable release back into `next` therefore cannot silently replace a beta that
+is already being soaked.
+
+The repository's `beta` environment must require a maintainer approval and
+limit deployment branches to `next` and `release/*`. These protection rules
+live in **Settings → Environments → beta** rather than in the workflow file;
+without them, referencing the environment records a deployment but does not
+create an approval gate.
 
 ## Record the exact build
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,6 +17,8 @@ A mobile-friendly web interface for managing multiple Technitium DNS servers. Vi
 - Proxies requests to multiple Technitium DNS nodes (no state storage)
 - Caches query logs for 30 seconds to improve performance
 - Aggregates data from multiple nodes (combined logs, zone comparison, DHCP scopes)
+- Treats each declared node group as an independent credential, topology, and
+  private-address namespace
 - Loads node credentials from environment variables at startup
 
 ### Modules
@@ -68,6 +70,10 @@ TECHNITIUM_NODES=node1,node2
 # Required - Base URL per node
 TECHNITIUM_NODE1_BASE_URL=http://192.168.1.10:5380
 TECHNITIUM_NODE2_BASE_URL=http://192.168.1.11:5380
+
+# Required on every node when one Companion manages independent clusters
+TECHNITIUM_NODE1_GROUP=site-a
+TECHNITIUM_NODE2_GROUP=site-b
 
 # Preferred (interactive UI): Session auth (v1.4+: required)
 # - Users log in with their Technitium credentials.

--- a/docs/features/CONFIG_SYNC_SCHEDULING.md
+++ b/docs/features/CONFIG_SYNC_SCHEDULING.md
@@ -18,6 +18,12 @@ CONFIG_SYNC_INTERVAL_MINUTES=60
 CONFIG_SYNC_NOTIFY_EMAILS=admin@example.com,ops@example.com
 ```
 
+The scalar token is supported only in implicit single-group deployments. For
+explicit node groups, configure `TECHNITIUM_SCHEDULE_TOKEN_MAP_FILE` using the
+strict group-map schema in
+[Session Auth and Background Token Guide](./SESSION_AUTH_AND_TOKEN_MIGRATION.md).
+Only mapped groups are eligible for reads or writes.
+
 The schedule token requires `Apps: Modify`. Use a dedicated automation user and
 do not reuse an administrator token.
 

--- a/docs/features/SESSION_AUTH_AND_TOKEN_MIGRATION.md
+++ b/docs/features/SESSION_AUTH_AND_TOKEN_MIGRATION.md
@@ -47,6 +47,30 @@ Used only for backend background work (example: background PTR lookups). It shou
 
 The backend validates this token and disables background PTR work if the token is unsafe.
 
+### Grouped automation maps
+
+The scalar background and schedule tokens remain valid only when all nodes use
+the implicit single group. Explicit grouped deployments use
+`TECHNITIUM_BACKGROUND_TOKEN_MAP_FILE` and
+`TECHNITIUM_SCHEDULE_TOKEN_MAP_FILE`. Both files use this strict schema:
+
+```json
+{
+  "version": 1,
+  "groups": {
+    "site-a": {
+      "username": "automation-user",
+      "token": "server-side-token"
+    }
+  }
+}
+```
+
+A role map may cover only the groups where that automation is enabled. Omitted
+groups are `not-authorized`. Scalar-plus-map conflicts, malformed maps, and a
+scalar used with explicit groups disable that automation role and expose a
+sanitized group status without preventing Companion startup.
+
 ## Set up `TECHNITIUM_BACKGROUND_TOKEN` (manual)
 
 In v1.4+, `TECHNITIUM_CLUSTER_TOKEN` is removed and there is no guided “migration banner” flow.
@@ -145,11 +169,12 @@ Permission names below are based on the permission sections returned by Techniti
 | Dashboard/Overview totals                                      | `/api/dashboard/stats/get`                                                                                                                                                                 | Dashboard: View (or equivalent)                         | Used for “last day” totals shown in node overview cards.                                                                      |
 | Query Logs (read)                                              | `/api/logs/query`                                                                                                                                                                          | Logs: View (or equivalent)                              | Read-only, but can be high-volume.                                                                                            |
 | DNS Lookup tools                                               | `/api/dnsClient/resolve`                                                                                                                                                                   | `DnsClient`: View                                       | This aligns with the background token validator, which requires `DnsClient: View` for PTR work.                               |
-| DHCP (read)                                                    | `/api/dhcp/scopes/list`, `/api/dhcp/scopes/get`, `/api/dhcp/leases/list`                                                                                                                   | DHCP: View (or equivalent)                              | Exact permission section name depends on Technitium.                                                                          |
+| DHCP (read)                                                    | `/api/dhcp/scopes/list`, `/api/dhcp/scopes/get`, `/api/dhcp/leases/list`                                                                                                                   | `DhcpServer`: View                                      | Admission is per validated node and group.                                                                                     |
 | DHCP (write / sync / clone)                                    | `/api/dhcp/scopes/set`, `/api/dhcp/scopes/delete`                                                                                                                                          | DHCP: Modify/Delete (or equivalent)                     | In cluster mode, writes should target the Primary node.                                                                       |
 | Zones (read / compare)                                         | `/api/zones/list`, `/api/zones/options/get`                                                                                                                                                | Zones: View (or equivalent)                             | Comparison is read-only but touches many endpoints.                                                                           |
 | Advanced Blocking App (read)                                   | `/api/apps/list`, `/api/apps/config/get`                                                                                                                                                   | Apps: View (or equivalent)                              | Depends on Technitium “Apps” permissions.                                                                                     |
 | Advanced Blocking App (write)                                  | `/api/apps/config/set`                                                                                                                                                                     | Apps: Modify (or equivalent)                            | Writes should target the Primary node in cluster mode.                                                                        |
+| Full resolver cache flush                                      | `/api/cache/delete`                                                                                                                                                                        | `Cache`: Delete                                         | Cache flush is node-local; partial/skipped members are reported and never receive a fallback credential.                       |
 | Built-in allow/block lists (read)                              | `/api/settings/get`, `/api/allowed/list`, `/api/blocked/list`, `/api/allowed/export`, `/api/blocked/export`                                                                                | Settings: View + (Allow/Block list view permission)     | Technitium may gate allow/block list endpoints under Zones/DNS/Settings depending on version.                                 |
 | Built-in allow/block lists (write)                             | `/api/settings/set`, `/api/settings/forceUpdateBlockLists`, `/api/settings/temporaryDisableBlocking`, `/api/allowed/add`, `/api/allowed/delete`, `/api/blocked/add`, `/api/blocked/delete` | Settings: Modify + (Allow/Block list modify permission) | If users see “permission denied,” the simplest fix is granting the smallest additional privilege needed for that page/action. |
 | Background PTR hostname resolution                             | `/api/dnsClient/resolve` (PTR lookups)                                                                                                                                                     | `DnsClient`: View                                       | Companion explicitly rejects background tokens that are too privileged, and also rejects tokens lacking `DnsClient: View`.    |

--- a/docs/features/TRUSTED_HEADER_SSO.md
+++ b/docs/features/TRUSTED_HEADER_SSO.md
@@ -17,23 +17,30 @@ successful authentication.
 
 ## Authorization model
 
-Every SSO identity maps exactly to one Technitium username and one cluster-wide
-API token. Technitium replicates users, permissions, and API tokens created on
-the Primary to every node in its cluster. Companion validates the same token
-against every configured node with
-`/api/user/session/get` and requires the returned owner to equal the configured
-username before creating a session. Unreachable nodes may produce the existing
-degraded partial session; an invalid token or owner mismatch fails the complete
-login.
+Every SSO identity maps to a non-empty subset of configured Technitium groups.
+Each authorized group has its own Technitium username and cluster-wide API
+token. Companion validates that token against members of that group with
+`/api/user/session/get`; token owner, permissions, and reported topology are
+never borrowed from another group. An owner, token, permission, or topology
+mismatch fails only that group. The login succeeds when at least one authorized
+group has usable nodes.
+
+Admission is recorded per node and operation. `DnsClient: View` admits PTR
+reads, `DhcpServer: View` admits DHCP reads, `Apps: Modify` admits configuration
+writes only on a validated Primary in the same group, and `Cache: Delete`
+admits cache flushes. An unreachable member can make a group degraded without
+granting that member access. When it returns, Companion retries with bounded
+backoff and revalidates owner, permissions, group membership, and topology role
+before first use.
 
 Companion retains at most eight active trusted-SSO sessions for one mapped
 identity. Creating a ninth evicts that identity's oldest SSO session without
 affecting password sessions or another identity. This supports normal
 multi-device use while bounding server-side session state.
 
-Trusted SSO therefore expects all configured Companion nodes to belong to the
-same Technitium cluster. Independent clusters or standalone nodes require
-separate Companion deployments for this authentication mode.
+Independent clusters and standalone sites can share one Companion deployment
+when every node declares an explicit group. A group is the routing, credential,
+DHCP/PTR hostname, and private-address namespace boundary.
 
 Shared-account mode and fallback for unmapped identities are intentionally not
 supported. Both would make multiple people operate as one Technitium principal,
@@ -52,6 +59,21 @@ TRUSTED_SSO_LOGOUT_URL=https://idp.example.com/application/o/companion/end-sessi
 TRUST_PROXY=true
 TRUST_PROXY_HOPS=1
 ```
+
+Declare groups on nodes before using a version-2 token map:
+
+```dotenv
+TECHNITIUM_NODES=site-a-primary,site-a-secondary,site-b-primary
+TECHNITIUM_SITEAPRIMARY_GROUP=site-a
+TECHNITIUM_SITEASECONDARY_GROUP=site-a
+TECHNITIUM_SITEBPRIMARY_GROUP=site-b
+```
+
+Node IDs are normalized to uppercase alphanumeric environment keys. Group IDs
+are case-sensitive lowercase slugs matching
+`[a-z0-9][a-z0-9._-]{0,62}`; names beginning with `__` are reserved. If any
+node declares a group, every configured node must declare one. Omitting all
+group variables retains the implicit single-cluster `__default__` mode.
 
 `TRUSTED_SSO_PROXY_SECRET` may be set directly, but the `_FILE` form is
 recommended. The value must be at least 32 characters. Generate it with a
@@ -74,15 +96,16 @@ The application validates all enabled SSO configuration once during startup.
 Invalid headers, CIDRs, secrets, URLs, or token-map schemas stop the backend
 instead of silently weakening authentication.
 
-## Token map
+## Token maps
 
 Create a separate Technitium user for each person on the cluster Primary, grant
 only the permissions that person needs, and create one API token owned by that
 user on the Primary through **Administration → Sessions → Create Token** or
 `/api/admin/sessions/createToken`. Save the returned token immediately.
 Technitium synchronizes the user, permissions, and API token to its Secondary
-nodes. Store the mapping in a root-readable file mounted read-only into the
-container:
+nodes. Store mappings in a root-readable file mounted read-only into the
+container. Version 1 remains supported only when all nodes use the implicit
+`__default__` group:
 
 ```json
 {
@@ -104,6 +127,35 @@ Identity matching is exact and case-sensitive. Companion expands the replicated
 cluster token into its server-side per-node session state only for nodes that
 successfully validate it. Tokens never enter the browser or API response.
 
+Use version 2 for explicit groups. Omitted groups are intentionally
+`not-authorized` for that identity:
+
+```json
+{
+  "version": 2,
+  "identities": {
+    "operator@example.com": {
+      "groups": {
+        "site-a": {
+          "username": "operator-a",
+          "token": "cluster-a-token"
+        },
+        "site-b": {
+          "username": "operator-b",
+          "token": "cluster-b-token"
+        }
+      }
+    }
+  }
+}
+```
+
+Every identity must authorize at least one known group. Unknown groups,
+duplicate JSON keys, extra fields, malformed credentials, and empty mappings
+make enabled SSO startup-fatal. Status responses contain every configured group
+with `anyReady` and `allReady`; intentionally unauthorized groups do not count
+against `allReady` and are not presented as expired sessions.
+
 Technitium documents that API tokens created on the cluster Primary are
 synchronized to every node, while ordinary interactive login sessions remain
 node-local. See [Understanding Clustering And How To Configure It](https://blog.technitium.com/2025/11/understanding-clustering-and-how-to.html).
@@ -112,7 +164,7 @@ node-local. See [Understanding Clustering And How To Configure It](https://blog.
 
 1. Create a replacement token under the same Technitium principal on the
    cluster Primary and allow it to synchronize to the Secondary nodes.
-2. Write a complete version-1 map to a new file, set restrictive file
+2. Write a complete map to a new file, set restrictive file
    permissions, and atomically replace the mounted map.
 3. Restart Companion so it loads and validates the new configuration.
 4. Sign in through SSO and verify the expected username and node access.
@@ -182,6 +234,57 @@ docker compose \
 
 Basic Auth is only a stand-in for local validation. Do not deploy this overlay
 as the production identity provider.
+
+### Test two independent clusters
+
+The repository also includes an opt-in acceptance harness for the explicit
+multi-group boundary. It starts four real Technitium DNS v15.3 containers as
+two genuinely independent Primary/Secondary clusters, provisions separate
+operator and least-privilege automation principals in each cluster, builds
+Companion from the current worktree, and places the existing test nginx proxy
+in front of it.
+
+Run the complete scenario from the repository root:
+
+```bash
+npm run test:multicluster:sso -- --reset
+```
+
+The harness verifies:
+
+- a token replicated inside one cluster is rejected by the other cluster;
+- one SSO identity can use both groups while a subset identity sees the
+  omitted group as `not-authorized`;
+- interactive, Primary-write, background PTR, schedule-write, and cache-flush
+  admissions stay group-local;
+- a hard credential failure in one group does not invalidate the other;
+- loss and recovery of one Primary removes its write admission until the
+  returning node has been revalidated; and
+- loss of every node in one group leaves an independently healthy group usable.
+
+The image tag defaults to `technitium/dns-server:15.3.0`; set
+`TECHNITIUM_MULTI_CLUSTER_TEST_TAG` to exercise another v15 release. The proxy
+is available at `https://127.0.0.1:15443`, and every directly exposed test port
+is loopback-only. Generated credentials are written with restrictive
+permissions beneath ignored `.multi-cluster-sso-test/`; their values are not
+printed. Docker named volumes preserve the two clusters between runs.
+
+Use `--cleanup` to remove the harness containers and named volumes after a
+successful run:
+
+```bash
+npm run test:multicluster:sso -- --cleanup
+```
+
+`--reset` and `--cleanup` affect only the Compose project named
+`technitium-companion-multi-cluster-sso-test`. The generated credential files
+remain for reproducible reruns. The backend unit suite separately covers the
+same private client IP appearing in different groups for DHCP/PTR enrichment,
+known-client suggestions, SQLite backfill, and per-client deduplication.
+
+Basic Auth deliberately substitutes only for Authentik's authenticated header
+delivery. A beta rollout should still be validated behind the deployment's
+actual Authentik provider and network policy before stable promotion.
 
 ## Reverse-proxy requirements
 

--- a/docs/features/clustering/CLUSTER_PRIMARY_WRITE_RESTRICTION.md
+++ b/docs/features/clustering/CLUSTER_PRIMARY_WRITE_RESTRICTION.md
@@ -10,6 +10,12 @@
 
 With Technitium DNS v14's clustering enabled, **only the Primary node can be modified**. Secondary nodes are read-only replicas that receive updates via zone transfers from the Primary.
 
+Current multi-cluster deployments declare a `TECHNITIUM_<NODE>_GROUP` for every
+node. Primary discovery and write routing are scoped to that group. An explicit
+group with an unknown, unreachable, unmatched, or unvalidated Primary has no
+write target; direct-write fallback exists only for the implicit legacy
+`__default__` group.
+
 This implementation ensures the UI respects this restriction by:
 1. Auto-selecting the Primary node for write operations
 2. Displaying an informational banner explaining cluster restrictions

--- a/docs/features/query-logs/SQLITE_ROLLING_QUERY_LOG_STORE.md
+++ b/docs/features/query-logs/SQLITE_ROLLING_QUERY_LOG_STORE.md
@@ -59,13 +59,22 @@ The stored endpoints accept the same query filter shape used elsewhere in the Lo
 - On a timer (`QUERY_LOG_SQLITE_POLL_INTERVAL_MS`), it polls each configured node for recent query logs.
 - It deduplicates inserts (so overlap polling is safe) and keeps only a rolling window (`QUERY_LOG_SQLITE_RETENTION_HOURS`).
 - A small overlap (`QUERY_LOG_SQLITE_OVERLAP_SECONDS`) is used to reduce the risk of missing entries between polls.
+- Each row stores the source node's `groupId`. Existing databases add this
+  column idempotently and synchronize it from the current node configuration.
+- DHCP/PTR enrichment and hostname backfill use `(groupId, normalized IP)`, so
+  the same private address in independent sites cannot acquire another site's
+  hostname.
 
 ## Query performance and maintenance
 
 - SQLite runs in WAL mode with a 64 MiB page cache and up to 256 MiB of memory-mapped I/O.
 - Planner statistics are refreshed when the long-lived connection opens and during daily maintenance.
 - Status counts use a `(blockedRank, ts)` covering index.
-- Unfiltered domain and per-client deduplication share a priority index. Requests with entry filters retain their filter-aware window-function path.
+- Unfiltered domain and per-client deduplication share a priority index.
+  Per-client mode partitions by `(domain, groupId, client IP)`: replicated
+  rows inside one cluster collapse, while identical private IPs in different
+  groups remain distinct. Requests with entry filters retain their
+  filter-aware window-function path.
 - Stored-page hostname enrichment uses persisted names and local caches only; browsing SQLite never waits for live DHCP nodes.
 - Background hostname collection discovers enabled DHCP scopes every five minutes and requests leases only from active DHCP nodes.
 - Daily maintenance truncates the WAL and incrementally reclaims free pages created by rolling retention.
@@ -78,7 +87,10 @@ See [Query Log SQLite Performance Iterations](../../performance/QUERY_LOG_SQLITE
 
 Background timers do **not** have an interactive user session token. The SQLite ingester therefore runs using **background auth mode**, which requires a configured background token:
 
-- Set `TECHNITIUM_BACKGROUND_TOKEN` to a **least-privilege** Technitium token that can read query logs.
+- In implicit single-group mode, set `TECHNITIUM_BACKGROUND_TOKEN` to a
+  **least-privilege** Technitium token that can read query logs.
+- In explicit grouped mode, use `TECHNITIUM_BACKGROUND_TOKEN_MAP_FILE` and
+  include only groups whose logs should be ingested.
 - Without `TECHNITIUM_BACKGROUND_TOKEN`, the SQLite DB can still open (status may show `ready: true`), but ingestion will fail with auth errors and the store will not stay up to date.
 
 ## Configuration (env vars)

--- a/docs/performance/QUERY_LOG_SQLITE_BENCHMARKS.md
+++ b/docs/performance/QUERY_LOG_SQLITE_BENCHMARKS.md
@@ -53,12 +53,39 @@ The shared index supports both dedup keys:
 ```sql
 CREATE INDEX idx_query_log_dedup_rank ON query_log_entries (
   qnameLc,
+  groupId,
   clientIpLc,
   blockedRank DESC,
   aRank DESC,
   ts DESC
 );
 ```
+
+## Group-ID migration validation
+
+Issue #112 extended the synthetic million-row dataset to two independent
+network namespaces and rebuilt the production priority index around
+`(qnameLc, groupId, clientIpLc, ranking fields)`. The same adaptive stage,
+PRAGMAs, FTS routing, and three warm samples produced:
+
+| Operation | Previous final | Group-aware final | Change |
+| --- | ---: | ---: | ---: |
+| Ordinary page one, dedup off | 0.03 ms | 0.03 ms | No change |
+| Domain dedup | 136 ms | 147 ms | +11 ms |
+| Deep domain-dedup page | 145 ms | 139 ms | -6 ms |
+| Per-client dedup | 196 ms | 226 ms | +30 ms |
+| One-hour domain dedup | 36 ms | 53 ms | +17 ms |
+| Google plus A-record filter | 271 ms | 231 ms | -40 ms |
+| Phone client filter | 728 ms | 630 ms | -98 ms |
+| Unique-domain count | 5 ms | 4 ms | -1 ms |
+| Blocked count | 2 ms | 2 ms | No change |
+
+The group-aware key adds a bounded 30 ms to the operation whose result
+cardinality intentionally increases. Ordinary browsing is unchanged; the
+short-window increase remains 17 ms, and the other representative
+deduplicated/filter paths remain within or improve on the existing benchmark.
+This is not a material regression for the common DNS Logs queries. The
+generated database was 764.4 MiB including FTS and the production indexes.
 
 ## Why the final path is adaptive
 

--- a/docs/performance/query-log-sqlite-benchmark-results.csv
+++ b/docs/performance/query-log-sqlite-benchmark-results.csv
@@ -1,21 +1,21 @@
-id,query,baseline_ms,planner_stats_ms,distinct_count_ms,status_index_ms,dedup_rewrite_ms,dedup_adaptive_ms
-1,"Recent unfiltered page 1, dedup off",0.03,0.03,0.03,0.03,0.03,0.03
-2,"Recent unfiltered page 1, dedup on",2980,2930,3170,3130,142,136
-3,"Domain substring youtube, dedup off",0.06,0.06,0.06,0.06,0.05,0.06
-4,"Domain substring youtube, dedup on",739,749,799,757,415,798
-5,"Client substring phone, dedup off",0.08,0.08,0.07,0.08,0.06,0.06
-6,"Qtype AAAA equality, dedup off",0.03,0.03,0.03,0.03,0.03,0.03
-7,"Blocked page 1, dedup off",0.12,0.13,0.18,0.03,0.03,0.03
-8,"Domain google plus qtype A, dedup on",458,256,259,261,562,271
-9,"Deep pagination offset 2500, dedup on",2920,3020,3120,3100,148,145
-10,"Window-scoped total count",14,14,15,14,15,14
-11,"Rare domain substring iphone, dedup off",15,12,15,13,13,15
-12,"No-match substring, dedup off",1340,1330,1350,1400,1390,1500
-13,"Per-node window-scoped count",6,6,6,7,6,6
-14,"Dotted domain google.com, dedup on",164,160,174,169,206,171
-15,"Client substring phone, dedup on",709,700,754,763,439,728
-16,"Client substring guest, dedup on",244,259,267,260,261,264
-17,"Unique-domain count",1680,54,5,5,5,5
-18,"Blocked window-scoped count",1300,1340,1370,2,2,2
-19,"Recent one-hour page 1, dedup on",37,34,35,33,36,36
-20,"Recent page 1, dedup per client",3250,3190,3420,3350,198,196
+id,query,baseline_ms,planner_stats_ms,distinct_count_ms,status_index_ms,dedup_rewrite_ms,dedup_adaptive_ms,group_id_migration_ms
+1,"Recent unfiltered page 1, dedup off",0.03,0.03,0.03,0.03,0.03,0.03,0.03
+2,"Recent unfiltered page 1, dedup on",2980,2930,3170,3130,142,136,147
+3,"Domain substring youtube, dedup off",0.06,0.06,0.06,0.06,0.05,0.06,0.07
+4,"Domain substring youtube, dedup on",739,749,799,757,415,798,736
+5,"Client substring phone, dedup off",0.08,0.08,0.07,0.08,0.06,0.06,0.06
+6,"Qtype AAAA equality, dedup off",0.03,0.03,0.03,0.03,0.03,0.03,0.03
+7,"Blocked page 1, dedup off",0.12,0.13,0.18,0.03,0.03,0.03,0.03
+8,"Domain google plus qtype A, dedup on",458,256,259,261,562,271,231
+9,"Deep pagination offset 2500, dedup on",2920,3020,3120,3100,148,145,139
+10,"Window-scoped total count",14,14,15,14,15,14,13
+11,"Rare domain substring iphone, dedup off",15,12,15,13,13,15,10
+12,"No-match substring, dedup off",1340,1330,1350,1400,1390,1500,1250
+13,"Per-node window-scoped count",6,6,6,7,6,6,5
+14,"Dotted domain google.com, dedup on",164,160,174,169,206,171,152
+15,"Client substring phone, dedup on",709,700,754,763,439,728,630
+16,"Client substring guest, dedup on",244,259,267,260,261,264,228
+17,"Unique-domain count",1680,54,5,5,5,5,4
+18,"Blocked window-scoped count",1300,1340,1370,2,2,2,2
+19,"Recent one-hour page 1, dedup on",37,34,35,33,36,36,53
+20,"Recent page 1, dedup per client",3250,3190,3420,3350,198,196,226

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "technitium-dns-companion",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "technitium-dns-companion",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "license": "MIT",
       "workspaces": [
         "apps/backend",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "technitium-dns-companion",
   "private": true,
-  "version": "1.11.0",
+  "version": "1.12.0",
   "license": "MIT",
   "workspaces": [
     "apps/backend",
@@ -12,6 +12,7 @@
     "build": "npm run build --workspaces --if-present",
     "test": "npm run test --workspaces --if-present",
     "test:technitium:v15": "npm run test:technitium:v15 --workspace apps/backend",
+    "test:multicluster:sso": "./scripts/run-multi-cluster-sso-test.sh",
     "prepare": "git config core.hooksPath .githooks 2>/dev/null || true"
   },
   "overrides": {

--- a/scripts/run-multi-cluster-sso-test.sh
+++ b/scripts/run-multi-cluster-sso-test.sh
@@ -1,0 +1,596 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+COMPOSE_FILE="$PROJECT_ROOT/docker-compose.multi-cluster-sso-test.yml"
+ASSET_DIR="$PROJECT_ROOT/.multi-cluster-sso-test"
+VERIFY_SCRIPT="$SCRIPT_DIR/verify-multi-cluster-sso-test.sh"
+COMPOSE_PROJECT="technitium-companion-multi-cluster-sso-test"
+
+SITE_A_PRIMARY_URL="http://127.0.0.1:${SITE_A_PRIMARY_HTTP_PORT:-15380}"
+SITE_A_PRIMARY_HTTPS_URL="https://127.0.0.1:${SITE_A_PRIMARY_HTTPS_PORT:-15480}"
+SITE_A_SECONDARY_URL="http://127.0.0.1:${SITE_A_SECONDARY_HTTP_PORT:-15381}"
+SITE_B_PRIMARY_URL="http://127.0.0.1:${SITE_B_PRIMARY_HTTP_PORT:-15382}"
+SITE_B_PRIMARY_HTTPS_URL="https://127.0.0.1:${SITE_B_PRIMARY_HTTPS_PORT:-15482}"
+SITE_B_SECONDARY_URL="http://127.0.0.1:${SITE_B_SECONDARY_HTTP_PORT:-15383}"
+
+RESET=false
+CLEANUP=false
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/run-multi-cluster-sso-test.sh [--reset] [--cleanup]
+
+  --reset    Remove only this harness's containers and named volumes first.
+  --cleanup  Remove the harness containers and named volumes after a pass.
+
+Generated credentials remain under the ignored .multi-cluster-sso-test/
+directory. Their values are never printed by this script.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --reset)
+      RESET=true
+      ;;
+    --cleanup)
+      CLEANUP=true
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+for command_name in curl docker htpasswd jq node openssl; do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "Required command not found: $command_name" >&2
+    exit 1
+  fi
+done
+
+compose() {
+  docker compose --project-name "$COMPOSE_PROJECT" -f "$COMPOSE_FILE" "$@"
+}
+
+log() {
+  printf '[multi-cluster-sso] %s\n' "$*" >&2
+}
+
+fail() {
+  log "ERROR: $*"
+  exit 1
+}
+
+on_error() {
+  log "Harness failed. Container state follows; secret values are not included."
+  compose ps >&2 || true
+}
+trap on_error ERR
+
+write_secret() {
+  local path="$1"
+  local bytes="$2"
+  if [ ! -s "$path" ]; then
+    openssl rand -hex "$bytes" >"$path"
+    chmod 600 "$path"
+  fi
+}
+
+prepare_assets() {
+  umask 077
+  mkdir -p "$ASSET_DIR/tls"
+  chmod 700 "$ASSET_DIR" "$ASSET_DIR/tls"
+
+  write_secret "$ASSET_DIR/node-admin-password" 24
+  write_secret "$ASSET_DIR/account-password" 24
+  write_secret "$ASSET_DIR/browser-password" 24
+  write_secret "$ASSET_DIR/proxy-secret" 32
+
+  local admin_password
+  IFS= read -r admin_password <"$ASSET_DIR/node-admin-password"
+  printf 'DNS_SERVER_ADMIN_PASSWORD=%s\n' "$admin_password" \
+    >"$ASSET_DIR/technitium.env"
+  chmod 600 "$ASSET_DIR/technitium.env"
+
+  local browser_password
+  IFS= read -r browser_password <"$ASSET_DIR/browser-password"
+  if [ ! -s "$ASSET_DIR/htpasswd" ]; then
+    printf '%s\n' "$browser_password" |
+      htpasswd -ciB "$ASSET_DIR/htpasswd" 'operator@example.test' >/dev/null 2>&1
+    printf '%s\n' "$browser_password" |
+      htpasswd -iB "$ASSET_DIR/htpasswd" 'site-a-only@example.test' >/dev/null 2>&1
+    printf '%s\n' "$browser_password" |
+      htpasswd -iB "$ASSET_DIR/htpasswd" 'partial-failure@example.test' >/dev/null 2>&1
+  fi
+  chmod 600 "$ASSET_DIR/htpasswd"
+
+  if [ ! -s "$ASSET_DIR/tls/key.pem" ] || [ ! -s "$ASSET_DIR/tls/cert.pem" ]; then
+    openssl req \
+      -x509 \
+      -newkey rsa:2048 \
+      -sha256 \
+      -nodes \
+      -days 7 \
+      -subj '/CN=localhost' \
+      -addext 'subjectAltName=DNS:localhost,IP:127.0.0.1' \
+      -keyout "$ASSET_DIR/tls/key.pem" \
+      -out "$ASSET_DIR/tls/cert.pem" \
+      >/dev/null 2>&1
+  fi
+  chmod 600 "$ASSET_DIR/tls/key.pem"
+  chmod 644 "$ASSET_DIR/tls/cert.pem"
+}
+
+raw_request() {
+  local method="$1"
+  local base_url="$2"
+  local path="$3"
+  local bearer_token="$4"
+  shift 4
+
+  if [ -n "$bearer_token" ]; then
+    printf 'header = "Authorization: Bearer %s"\n' "$bearer_token" |
+      curl \
+        --config - \
+        --silent \
+        --show-error \
+        --max-time 180 \
+        --request "$method" \
+        --get \
+        "$@" \
+        "$base_url$path"
+  else
+    curl \
+      --silent \
+      --show-error \
+      --max-time 180 \
+      --request "$method" \
+      --get \
+      "$@" \
+      "$base_url$path"
+  fi
+}
+
+require_ok() {
+  local label="$1"
+  local response="$2"
+  if ! jq -e '.status == "ok"' >/dev/null 2>&1 <<<"$response"; then
+    local reason
+    reason="$(jq -r '.errorMessage // .status // "unexpected response"' <<<"$response" 2>/dev/null || printf 'unexpected response')"
+    fail "$label failed: $reason"
+  fi
+}
+
+login_admin() {
+  local base_url="$1"
+  local admin_password="$2"
+  local response
+  response="$(raw_request GET "$base_url" '/api/user/login' '' \
+    --data-urlencode 'user=admin' \
+    --data-urlencode "pass=$admin_password" \
+    --data-urlencode 'includeInfo=true')"
+  require_ok "Administrator login at $base_url" "$response"
+  jq -er '.token // .response.token' <<<"$response"
+}
+
+session_info() {
+  local base_url="$1"
+  local token="$2"
+  raw_request GET "$base_url" '/api/user/session/get' "$token"
+}
+
+wait_for_api() {
+  local label="$1"
+  local base_url="$2"
+  local attempt
+  for attempt in $(seq 1 90); do
+    if raw_request GET "$base_url" '/api/status' '' 2>/dev/null |
+      jq -e '.status == "ok"' >/dev/null 2>&1; then
+      return
+    fi
+    sleep 2
+  done
+  fail "$label did not become ready at $base_url"
+}
+
+wait_for_https_api() {
+  local label="$1"
+  local base_url="$2"
+  local attempt
+  for attempt in $(seq 1 90); do
+    if curl \
+      --insecure \
+      --silent \
+      --show-error \
+      --max-time 5 \
+      "$base_url/api/status" \
+      2>/dev/null |
+      jq -e '.status == "ok"' >/dev/null 2>&1; then
+      return
+    fi
+    sleep 2
+  done
+  fail "$label HTTPS API did not become ready at $base_url"
+}
+
+wait_for_cluster() {
+  local label="$1"
+  local base_url="$2"
+  local admin_password="$3"
+  local cluster_domain="$4"
+  local attempt token response
+
+  for attempt in $(seq 1 90); do
+    token="$(login_admin "$base_url" "$admin_password")"
+    response="$(session_info "$base_url" "$token")"
+    if jq -e \
+      --arg domain "$cluster_domain" \
+      '(.response // .) | .info.clusterInitialized == true and .info.clusterDomain == $domain and ([.info.clusterNodes[]?.type] | index("Primary") != null) and ([.info.clusterNodes[]?.type] | index("Secondary") != null)' \
+      >/dev/null 2>&1 <<<"$response"; then
+      return
+    fi
+    sleep 2
+  done
+  fail "$label did not report a complete Primary/Secondary topology"
+}
+
+ensure_cluster() {
+  local site_label="$1"
+  local cluster_domain="$2"
+  local primary_url="$3"
+  local primary_https_url="$4"
+  local primary_internal_url="$5"
+  local primary_ip="$6"
+  local secondary_url="$7"
+  local secondary_ip="$8"
+  local admin_password="$9"
+
+  local primary_token primary_info response
+  primary_token="$(login_admin "$primary_url" "$admin_password")"
+  primary_info="$(session_info "$primary_url" "$primary_token")"
+  require_ok "$site_label Primary session inspection" "$primary_info"
+
+  if jq -e '(.response // .) | .info.clusterInitialized != true' \
+    >/dev/null 2>&1 <<<"$primary_info"; then
+    log "Initializing $site_label Primary"
+    response="$(raw_request POST "$primary_url" '/api/admin/cluster/init' "$primary_token" \
+      --data-urlencode "clusterDomain=$cluster_domain" \
+      --data-urlencode "primaryNodeIpAddresses=$primary_ip")"
+    require_ok "$site_label cluster initialization" "$response"
+    wait_for_api "$site_label Primary" "$primary_url"
+  elif ! jq -e --arg domain "$cluster_domain" \
+    '(.response // .) | .info.clusterDomain == $domain' \
+    >/dev/null 2>&1 <<<"$primary_info"; then
+    fail "$site_label Primary belongs to an unexpected existing cluster"
+  fi
+  wait_for_https_api "$site_label Primary" "$primary_https_url"
+
+  local secondary_token secondary_info
+  secondary_token="$(login_admin "$secondary_url" "$admin_password")"
+  secondary_info="$(session_info "$secondary_url" "$secondary_token")"
+  require_ok "$site_label Secondary session inspection" "$secondary_info"
+
+  if jq -e '(.response // .) | .info.clusterInitialized != true' \
+    >/dev/null 2>&1 <<<"$secondary_info"; then
+    log "Joining $site_label Secondary"
+    response="$(raw_request POST "$secondary_url" '/api/admin/cluster/initJoin' "$secondary_token" \
+      --data-urlencode "secondaryNodeIpAddresses=$secondary_ip" \
+      --data-urlencode "primaryNodeUrl=$primary_internal_url" \
+      --data-urlencode "primaryNodeIpAddress=$primary_ip" \
+      --data-urlencode 'ignoreCertificateErrors=true' \
+      --data-urlencode 'primaryNodeUsername=admin' \
+      --data-urlencode "primaryNodePassword=$admin_password")"
+    require_ok "$site_label Secondary join" "$response"
+    wait_for_api "$site_label Secondary" "$secondary_url"
+  elif ! jq -e --arg domain "$cluster_domain" \
+    '(.response // .) | .info.clusterDomain == $domain' \
+    >/dev/null 2>&1 <<<"$secondary_info"; then
+    fail "$site_label Secondary belongs to an unexpected existing cluster"
+  fi
+
+  wait_for_cluster "$site_label Primary" "$primary_url" "$admin_password" "$cluster_domain"
+  wait_for_cluster "$site_label Secondary" "$secondary_url" "$admin_password" "$cluster_domain"
+  log "$site_label reports an isolated two-node cluster"
+}
+
+ensure_user() {
+  local base_url="$1"
+  local admin_token="$2"
+  local username="$3"
+  local password="$4"
+  local groups="$5"
+  local response
+
+  response="$(raw_request GET "$base_url" '/api/admin/users/get' "$admin_token" \
+    --data-urlencode "user=$username" \
+    --data-urlencode 'includeGroups=true')"
+  if ! jq -e '.status == "ok"' >/dev/null 2>&1 <<<"$response"; then
+    response="$(raw_request POST "$base_url" '/api/admin/users/create' "$admin_token" \
+      --data-urlencode "user=$username" \
+      --data-urlencode "pass=$password" \
+      --data-urlencode "displayName=$username")"
+    require_ok "Create user $username" "$response"
+  fi
+
+  if [ -n "$groups" ]; then
+    response="$(raw_request POST "$base_url" '/api/admin/users/set' "$admin_token" \
+      --data-urlencode "user=$username" \
+      --data-urlencode "memberOfGroups=$groups")"
+    require_ok "Assign groups for $username" "$response"
+  fi
+}
+
+set_section_permissions() {
+  local base_url="$1"
+  local admin_token="$2"
+  local section="$3"
+  local user_permissions="$4"
+  local response
+  response="$(raw_request POST "$base_url" '/api/admin/permissions/set' "$admin_token" \
+    --data-urlencode "section=$section" \
+    --data-urlencode "userPermissions=$user_permissions")"
+  require_ok "Set $section test permissions" "$response"
+}
+
+create_api_token() {
+  local base_url="$1"
+  local username="$2"
+  local password="$3"
+  local token_name="$4"
+  local response
+  response="$(raw_request GET "$base_url" '/api/user/createToken' '' \
+    --data-urlencode "user=$username" \
+    --data-urlencode "pass=$password" \
+    --data-urlencode "tokenName=$token_name")"
+  require_ok "Create API token for $username" "$response"
+  jq -er '.token // .response.token' <<<"$response"
+}
+
+wait_for_owned_token() {
+  local label="$1"
+  local base_url="$2"
+  local token="$3"
+  local expected_user="$4"
+  local expected_domain="$5"
+  local attempt response
+
+  attempt=0
+  while [ "$attempt" -lt 90 ]; do
+    attempt=$((attempt + 1))
+    response="$(session_info "$base_url" "$token" 2>/dev/null || true)"
+    if jq -e \
+      --arg user "$expected_user" \
+      --arg domain "$expected_domain" \
+      '(.response // .) | .status == "ok" and .username == $user and .info.clusterDomain == $domain' \
+      >/dev/null 2>&1 <<<"$response"; then
+      return
+    fi
+    sleep 2
+  done
+  fail "$label did not validate the expected replicated token owner"
+}
+
+provision_site_credentials() {
+  local site_suffix="$1"
+  local cluster_domain="$2"
+  local primary_url="$3"
+  local secondary_url="$4"
+  local admin_password="$5"
+  local account_password="$6"
+
+  local operator_user="operator-$site_suffix"
+  local background_user="background-$site_suffix"
+  local schedule_user="schedule-$site_suffix"
+  local admin_token
+  admin_token="$(login_admin "$primary_url" "$admin_password")"
+
+  ensure_user "$primary_url" "$admin_token" "$operator_user" "$account_password" 'DNS Administrators'
+  ensure_user "$primary_url" "$admin_token" "$background_user" "$account_password" ''
+  ensure_user "$primary_url" "$admin_token" "$schedule_user" "$account_password" ''
+
+  set_section_permissions "$primary_url" "$admin_token" DnsClient \
+    "$operator_user|true|false|false|$background_user|true|false|false"
+  set_section_permissions "$primary_url" "$admin_token" DhcpServer \
+    "$operator_user|true|false|false|$background_user|true|false|false"
+  set_section_permissions "$primary_url" "$admin_token" Apps \
+    "$operator_user|true|true|false|$schedule_user|true|true|false"
+  set_section_permissions "$primary_url" "$admin_token" Cache \
+    "$operator_user|true|false|true|$schedule_user|true|false|true"
+
+  local token_suffix
+  token_suffix="$(date +%s)"
+  provisioned_operator_token="$(create_api_token "$primary_url" "$operator_user" "$account_password" "companion-operator-$token_suffix")"
+  provisioned_background_token="$(create_api_token "$primary_url" "$background_user" "$account_password" "companion-background-$token_suffix")"
+  provisioned_schedule_token="$(create_api_token "$primary_url" "$schedule_user" "$account_password" "companion-schedule-$token_suffix")"
+
+  wait_for_owned_token "$operator_user on Primary" "$primary_url" "$provisioned_operator_token" "$operator_user" "$cluster_domain"
+  wait_for_owned_token "$operator_user on Secondary" "$secondary_url" "$provisioned_operator_token" "$operator_user" "$cluster_domain"
+  wait_for_owned_token "$background_user on Secondary" "$secondary_url" "$provisioned_background_token" "$background_user" "$cluster_domain"
+  wait_for_owned_token "$schedule_user on Secondary" "$secondary_url" "$provisioned_schedule_token" "$schedule_user" "$cluster_domain"
+  log "Provisioned identity-bound operator and automation credentials for $cluster_domain"
+}
+
+write_credential_maps() {
+  local site_a_operator_token="$1"
+  local site_b_operator_token="$2"
+  local site_a_background_token="$3"
+  local site_b_background_token="$4"
+  local site_a_schedule_token="$5"
+  local site_b_schedule_token="$6"
+
+  # The single-quoted JavaScript intentionally owns its template expression.
+  # shellcheck disable=SC2016
+  printf '%s\0%s\0%s\0%s\0%s\0%s\0' \
+    "$site_a_operator_token" \
+    "$site_b_operator_token" \
+    "$site_a_background_token" \
+    "$site_b_background_token" \
+    "$site_a_schedule_token" \
+    "$site_b_schedule_token" |
+    node -e '
+const fs = require("node:fs");
+const values = fs.readFileSync(0, "utf8").split("\0");
+const [operatorA, operatorB, backgroundA, backgroundB, scheduleA, scheduleB] = values;
+const [ssoPath, backgroundPath, schedulePath] = process.argv.slice(1);
+const write = (path, value) => {
+  const temporaryPath = `${path}.tmp`;
+  fs.writeFileSync(temporaryPath, `${JSON.stringify(value, null, 2)}\n`, {
+    mode: 0o600,
+  });
+  fs.renameSync(temporaryPath, path);
+};
+write(ssoPath, {
+  version: 2,
+  identities: {
+    "operator@example.test": {
+      groups: {
+        "site-a": { username: "operator-a", token: operatorA },
+        "site-b": { username: "operator-b", token: operatorB },
+      },
+    },
+    "site-a-only@example.test": {
+      groups: {
+        "site-a": { username: "operator-a", token: operatorA },
+      },
+    },
+    "partial-failure@example.test": {
+      groups: {
+        "site-a": { username: "operator-a", token: operatorA },
+        "site-b": { username: "operator-b", token: operatorA },
+      },
+    },
+  },
+});
+write(backgroundPath, {
+  version: 1,
+  groups: {
+    "site-a": { username: "background-a", token: backgroundA },
+    "site-b": { username: "background-b", token: backgroundB },
+  },
+});
+write(schedulePath, {
+  version: 1,
+  groups: {
+    "site-a": { username: "schedule-a", token: scheduleA },
+    "site-b": { username: "schedule-b", token: scheduleB },
+  },
+});
+' \
+      "$ASSET_DIR/trusted-sso-token-map.json" \
+      "$ASSET_DIR/background-token-map.json" \
+      "$ASSET_DIR/schedule-token-map.json"
+  chmod 600 \
+    "$ASSET_DIR/trusted-sso-token-map.json" \
+    "$ASSET_DIR/background-token-map.json" \
+    "$ASSET_DIR/schedule-token-map.json"
+}
+
+if [ "$RESET" = true ]; then
+  log "Resetting only the multi-cluster test project"
+  compose down --volumes --remove-orphans >/dev/null 2>&1 || true
+fi
+
+prepare_assets
+
+log "Validating the isolated Compose model"
+compose config --quiet
+
+log "Starting four Technitium DNS nodes"
+compose up -d site-a-primary site-a-secondary site-b-primary site-b-secondary
+wait_for_api 'Site A Primary' "$SITE_A_PRIMARY_URL"
+wait_for_api 'Site A Secondary' "$SITE_A_SECONDARY_URL"
+wait_for_api 'Site B Primary' "$SITE_B_PRIMARY_URL"
+wait_for_api 'Site B Secondary' "$SITE_B_SECONDARY_URL"
+
+IFS= read -r admin_password <"$ASSET_DIR/node-admin-password"
+IFS= read -r account_password <"$ASSET_DIR/account-password"
+
+ensure_cluster \
+  'Site A' \
+  'site-a.test' \
+  "$SITE_A_PRIMARY_URL" \
+  "$SITE_A_PRIMARY_HTTPS_URL" \
+  'https://site-a-primary:53443/' \
+  '172.30.111.10' \
+  "$SITE_A_SECONDARY_URL" \
+  '172.30.111.11' \
+  "$admin_password"
+ensure_cluster \
+  'Site B' \
+  'site-b.test' \
+  "$SITE_B_PRIMARY_URL" \
+  "$SITE_B_PRIMARY_HTTPS_URL" \
+  'https://site-b-primary:53443/' \
+  '172.30.112.10' \
+  "$SITE_B_SECONDARY_URL" \
+  '172.30.112.11' \
+  "$admin_password"
+
+provision_site_credentials \
+  a site-a.test "$SITE_A_PRIMARY_URL" "$SITE_A_SECONDARY_URL" \
+  "$admin_password" "$account_password"
+site_a_operator_token="$provisioned_operator_token"
+site_a_background_token="$provisioned_background_token"
+site_a_schedule_token="$provisioned_schedule_token"
+
+provision_site_credentials \
+  b site-b.test "$SITE_B_PRIMARY_URL" "$SITE_B_SECONDARY_URL" \
+  "$admin_password" "$account_password"
+site_b_operator_token="$provisioned_operator_token"
+site_b_background_token="$provisioned_background_token"
+site_b_schedule_token="$provisioned_schedule_token"
+
+write_credential_maps \
+  "$site_a_operator_token" \
+  "$site_b_operator_token" \
+  "$site_a_background_token" \
+  "$site_b_background_token" \
+  "$site_a_schedule_token" \
+  "$site_b_schedule_token"
+
+unset \
+  account_password \
+  admin_password \
+  provisioned_background_token \
+  provisioned_operator_token \
+  provisioned_schedule_token \
+  site_a_background_token \
+  site_a_operator_token \
+  site_a_schedule_token \
+  site_b_background_token \
+  site_b_operator_token \
+  site_b_schedule_token
+
+log "Building Companion from the current worktree"
+compose build technitium-dns-companion-test
+log "Starting Companion and the trusted SSO proxy"
+compose up -d technitium-dns-companion-test trusted-sso-test-proxy
+
+MULTI_CLUSTER_TEST_ASSET_DIR="$ASSET_DIR" \
+MULTI_CLUSTER_TEST_COMPOSE_FILE="$COMPOSE_FILE" \
+MULTI_CLUSTER_TEST_COMPOSE_PROJECT="$COMPOSE_PROJECT" \
+  "$VERIFY_SCRIPT"
+
+trap - ERR
+
+if [ "$CLEANUP" = true ]; then
+  log "Acceptance passed; removing this harness's containers and named volumes"
+  compose down --volumes --remove-orphans
+else
+  log "Acceptance passed. The isolated stack remains available for inspection."
+  log "Proxy URL: https://127.0.0.1:${MULTI_CLUSTER_PROXY_HTTPS_PORT:-15443}"
+  log "Browser identity: operator@example.test"
+  log "The generated browser password is stored in .multi-cluster-sso-test/browser-password."
+  log "Teardown: docker compose --project-name $COMPOSE_PROJECT -f docker-compose.multi-cluster-sso-test.yml down --volumes --remove-orphans"
+fi

--- a/scripts/verify-multi-cluster-sso-test.sh
+++ b/scripts/verify-multi-cluster-sso-test.sh
@@ -1,0 +1,334 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+ASSET_DIR="${MULTI_CLUSTER_TEST_ASSET_DIR:-$PROJECT_ROOT/.multi-cluster-sso-test}"
+COMPOSE_FILE="${MULTI_CLUSTER_TEST_COMPOSE_FILE:-$PROJECT_ROOT/docker-compose.multi-cluster-sso-test.yml}"
+COMPOSE_PROJECT="${MULTI_CLUSTER_TEST_COMPOSE_PROJECT:-technitium-companion-multi-cluster-sso-test}"
+COMPANION_URL="http://127.0.0.1:${MULTI_CLUSTER_COMPANION_HTTP_PORT:-15300}"
+PROXY_URL="https://127.0.0.1:${MULTI_CLUSTER_PROXY_HTTPS_PORT:-15443}"
+SITE_A_PRIMARY_URL="http://127.0.0.1:${SITE_A_PRIMARY_HTTP_PORT:-15380}"
+SITE_A_SECONDARY_URL="http://127.0.0.1:${SITE_A_SECONDARY_HTTP_PORT:-15381}"
+SITE_B_PRIMARY_URL="http://127.0.0.1:${SITE_B_PRIMARY_HTTP_PORT:-15382}"
+SITE_B_SECONDARY_URL="http://127.0.0.1:${SITE_B_SECONDARY_HTTP_PORT:-15383}"
+
+for command_name in curl docker jq mktemp; do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "Required command not found: $command_name" >&2
+    exit 1
+  fi
+done
+
+for required_file in \
+  "$ASSET_DIR/browser-password" \
+  "$ASSET_DIR/trusted-sso-token-map.json"; do
+  if [ ! -s "$required_file" ]; then
+    echo "Required generated test asset is missing: $required_file" >&2
+    exit 1
+  fi
+done
+
+compose() {
+  docker compose --project-name "$COMPOSE_PROJECT" -f "$COMPOSE_FILE" "$@"
+}
+
+log() {
+  printf '[multi-cluster-sso:verify] %s\n' "$*" >&2
+}
+
+fail() {
+  log "ERROR: $*"
+  exit 1
+}
+
+REQUEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/tdc-multi-cluster-sso.XXXXXX")"
+chmod 700 "$REQUEST_DIR"
+fault_injection_active=false
+
+cleanup() {
+  if [ "$fault_injection_active" = true ]; then
+    compose start site-b-primary site-b-secondary >/dev/null 2>&1 || true
+  fi
+  rm -rf "$REQUEST_DIR"
+}
+trap cleanup EXIT INT TERM
+
+IFS= read -r browser_password <"$ASSET_DIR/browser-password"
+
+write_basic_auth_config() {
+  local identity="$1"
+  local path="$2"
+  printf 'user = "%s:%s"\n' "$identity" "$browser_password" >"$path"
+  chmod 600 "$path"
+}
+
+write_basic_auth_config 'operator@example.test' "$REQUEST_DIR/operator.curl"
+write_basic_auth_config 'site-a-only@example.test' "$REQUEST_DIR/site-a-only.curl"
+write_basic_auth_config 'partial-failure@example.test' "$REQUEST_DIR/partial-failure.curl"
+unset browser_password
+
+proxy_request() {
+  local config_path="$1"
+  local cookie_path="$2"
+  local method="$3"
+  local path="$4"
+  curl \
+    --config "$config_path" \
+    --cookie "$cookie_path" \
+    --cookie-jar "$cookie_path" \
+    --fail \
+    --insecure \
+    --silent \
+    --show-error \
+    --max-time 90 \
+    --request "$method" \
+    "$PROXY_URL$path"
+}
+
+assert_filter() {
+  local label="$1"
+  local filter="$2"
+  local document="$3"
+  if ! jq -e "$filter" >/dev/null 2>&1 <<<"$document"; then
+    fail "$label"
+  fi
+}
+
+wait_for_http_json() {
+  local label="$1"
+  local url="$2"
+  local filter="$3"
+  local attempt response
+  for attempt in $(seq 1 90); do
+    response="$(curl --silent --show-error --max-time 5 "$url" 2>/dev/null || true)"
+    if jq -e "$filter" >/dev/null 2>&1 <<<"$response"; then
+      return
+    fi
+    sleep 2
+  done
+  fail "$label did not become ready"
+}
+
+wait_for_proxy() {
+  local attempt
+  for attempt in $(seq 1 90); do
+    if proxy_request \
+      "$REQUEST_DIR/operator.curl" \
+      "$REQUEST_DIR/proxy-ready.cookie" \
+      GET \
+      '/api/auth/me' \
+      >/dev/null 2>&1; then
+      return
+    fi
+    sleep 2
+  done
+  fail "Trusted SSO proxy did not become ready"
+}
+
+login_and_get_session() {
+  local config_path="$1"
+  local cookie_path="$2"
+  local login_response
+  rm -f "$cookie_path"
+  login_response="$(proxy_request "$config_path" "$cookie_path" POST '/api/auth/sso/login')"
+  assert_filter 'Trusted SSO login did not authenticate' '.authenticated == true' "$login_response"
+  proxy_request "$config_path" "$cookie_path" GET '/api/auth/me'
+}
+
+wait_for_automation_ready() {
+  local cookie_path="$1"
+  local attempt auth_me schedule_status
+  for attempt in $(seq 1 60); do
+    auth_me="$(proxy_request "$REQUEST_DIR/operator.curl" "$cookie_path" GET '/api/auth/me')"
+    schedule_status="$(proxy_request "$REQUEST_DIR/operator.curl" "$cookie_path" GET '/api/nodes/dns-schedules/token/status')"
+    if jq -e \
+      '.backgroundPtrToken.groups.anyReady == true and .backgroundPtrToken.groups.allReady == true and ([.backgroundPtrToken.groups.groups[].state] | all(. == "ready"))' \
+      >/dev/null 2>&1 <<<"$auth_me" &&
+      jq -e \
+        '.groups.anyReady == true and .groups.allReady == true and ([.groups.groups[].state] | all(. == "ready"))' \
+        >/dev/null 2>&1 <<<"$schedule_status"; then
+      return
+    fi
+    sleep 2
+  done
+  fail "Per-group background and schedule credentials did not become ready"
+}
+
+write_bearer_config() {
+  local token="$1"
+  local path="$2"
+  printf 'header = "Authorization: Bearer %s"\n' "$token" >"$path"
+  chmod 600 "$path"
+}
+
+technitium_session_info() {
+  local config_path="$1"
+  local base_url="$2"
+  curl \
+    --config "$config_path" \
+    --fail \
+    --silent \
+    --show-error \
+    --max-time 30 \
+    "$base_url/api/user/session/get"
+}
+
+verify_real_cluster_token() {
+  local label="$1"
+  local config_path="$2"
+  local base_url="$3"
+  local expected_user="$4"
+  local expected_domain="$5"
+  local response
+  response="$(technitium_session_info "$config_path" "$base_url")"
+  if ! jq -e \
+    --arg user "$expected_user" \
+    --arg domain "$expected_domain" \
+    '(.response // .) | .status == "ok" and .username == $user and .info.clusterInitialized == true and .info.clusterDomain == $domain and ([.info.clusterNodes[]?.type] | index("Primary") != null) and ([.info.clusterNodes[]?.type] | index("Secondary") != null)' \
+    >/dev/null 2>&1 <<<"$response"; then
+    fail "$label did not report the expected owner and two-node cluster"
+  fi
+}
+
+wait_for_http_json 'Companion' "$COMPANION_URL/api/health" '.status == "ok"'
+wait_for_proxy
+
+log 'Verifying that direct forged headers cannot establish SSO'
+direct_response="$(curl \
+  --fail \
+  --silent \
+  --show-error \
+  --header 'X-Forwarded-Proto: https' \
+  --header 'X-Forwarded-User: operator@example.test' \
+  "$COMPANION_URL/api/auth/me")"
+assert_filter \
+  'Direct assertion spoof unexpectedly authenticated' \
+  '.authenticated == false' \
+  "$direct_response"
+
+site_a_token="$(jq -er '.identities["operator@example.test"].groups["site-a"].token' "$ASSET_DIR/trusted-sso-token-map.json")"
+site_b_token="$(jq -er '.identities["operator@example.test"].groups["site-b"].token' "$ASSET_DIR/trusted-sso-token-map.json")"
+write_bearer_config "$site_a_token" "$REQUEST_DIR/site-a-token.curl"
+write_bearer_config "$site_b_token" "$REQUEST_DIR/site-b-token.curl"
+unset site_a_token site_b_token
+
+log 'Verifying two genuine, independent Primary/Secondary clusters'
+verify_real_cluster_token 'Site A Primary' "$REQUEST_DIR/site-a-token.curl" "$SITE_A_PRIMARY_URL" operator-a site-a.test
+verify_real_cluster_token 'Site A Secondary' "$REQUEST_DIR/site-a-token.curl" "$SITE_A_SECONDARY_URL" operator-a site-a.test
+verify_real_cluster_token 'Site B Primary' "$REQUEST_DIR/site-b-token.curl" "$SITE_B_PRIMARY_URL" operator-b site-b.test
+verify_real_cluster_token 'Site B Secondary' "$REQUEST_DIR/site-b-token.curl" "$SITE_B_SECONDARY_URL" operator-b site-b.test
+
+cross_group_response="$(technitium_session_info "$REQUEST_DIR/site-a-token.curl" "$SITE_B_PRIMARY_URL")"
+assert_filter \
+  'Site A token was unexpectedly accepted by Site B' \
+  '.status == "invalid-token"' \
+  "$cross_group_response"
+cross_group_response="$(technitium_session_info "$REQUEST_DIR/site-b-token.curl" "$SITE_A_PRIMARY_URL")"
+assert_filter \
+  'Site B token was unexpectedly accepted by Site A' \
+  '.status == "invalid-token"' \
+  "$cross_group_response"
+
+log 'Verifying the fully authorized identity and group-local admissions'
+operator_cookie="$REQUEST_DIR/operator.cookie"
+operator_me="$(login_and_get_session "$REQUEST_DIR/operator.curl" "$operator_cookie")"
+assert_filter \
+  'Fully authorized identity did not report both verified usernames' \
+  '.authenticated == true and .authSource == "trusted-sso" and .verifiedUsernamesByGroup == {"site-a":"operator-a","site-b":"operator-b"}' \
+  "$operator_me"
+assert_filter \
+  'Fully authorized identity did not report every group ready' \
+  '.groupCredentials.anyReady == true and .groupCredentials.allReady == true and ([.groupCredentials.groups[].state] | all(. == "ready"))' \
+  "$operator_me"
+assert_filter \
+  'Interactive admission crossed or omitted a group boundary' \
+  '(.groupCredentials.groups[] | select(.groupId == "site-a") | .admittedNodeIds.interactive | sort) == ["site-a-primary","site-a-secondary"] and (.groupCredentials.groups[] | select(.groupId == "site-b") | .admittedNodeIds.interactive | sort) == ["site-b-primary","site-b-secondary"]' \
+  "$operator_me"
+assert_filter \
+  'Primary write admission was not limited to one Primary per group' \
+  '(.groupCredentials.groups[] | select(.groupId == "site-a") | .admittedNodeIds.primaryConfigWrite) == ["site-a-primary"] and (.groupCredentials.groups[] | select(.groupId == "site-b") | .admittedNodeIds.primaryConfigWrite) == ["site-b-primary"]' \
+  "$operator_me"
+
+nodes_response="$(proxy_request "$REQUEST_DIR/operator.curl" "$operator_cookie" GET '/api/nodes')"
+assert_filter \
+  'Companion did not expose four correctly grouped nodes' \
+  'length == 4 and (map(select(.groupId == "site-a")) | length) == 2 and (map(select(.groupId == "site-b")) | length) == 2' \
+  "$nodes_response"
+assert_filter \
+  'Companion did not resolve one Primary in each independent group' \
+  '([.[] | select(.groupId == "site-a" and .isPrimary == true)] | length) == 1 and ([.[] | select(.groupId == "site-b" and .isPrimary == true)] | length) == 1' \
+  "$nodes_response"
+wait_for_automation_ready "$operator_cookie"
+
+log 'Verifying an identity authorized for only one group'
+subset_me="$(login_and_get_session "$REQUEST_DIR/site-a-only.curl" "$REQUEST_DIR/site-a-only.cookie")"
+assert_filter \
+  'Not-authorized group incorrectly invalidated the session' \
+  '.authenticated == true and .groupCredentials.anyReady == true and .groupCredentials.allReady == true and (.groupCredentials.groups[] | select(.groupId == "site-b") | .state) == "not-authorized"' \
+  "$subset_me"
+
+log 'Verifying that a hard credential failure remains isolated to its group'
+partial_me="$(login_and_get_session "$REQUEST_DIR/partial-failure.curl" "$REQUEST_DIR/partial-failure.cookie")"
+assert_filter \
+  'Site B credential failure leaked into Site A or killed the session' \
+  '.authenticated == true and .groupCredentials.anyReady == true and .groupCredentials.allReady == false and (.groupCredentials.groups[] | select(.groupId == "site-a") | .state) == "ready" and (.groupCredentials.groups[] | select(.groupId == "site-b") | .state) == "failed"' \
+  "$partial_me"
+
+fault_injection_active=true
+log 'Stopping the Site B Primary and verifying degraded read-only survival'
+compose stop site-b-primary >/dev/null
+degraded_cookie="$REQUEST_DIR/degraded.cookie"
+degraded_me="$(login_and_get_session "$REQUEST_DIR/operator.curl" "$degraded_cookie")"
+assert_filter \
+  'Offline Site B Primary did not produce an isolated degraded group' \
+  '.authenticated == true and (.groupCredentials.groups[] | select(.groupId == "site-a") | .state) == "ready" and (.groupCredentials.groups[] | select(.groupId == "site-b") | .state) == "degraded"' \
+  "$degraded_me"
+assert_filter \
+  'Offline Site B Primary remained admitted for writes or cache flushes' \
+  '(.groupCredentials.groups[] | select(.groupId == "site-b") | .admittedNodeIds.primaryConfigWrite) == [] and (.groupCredentials.groups[] | select(.groupId == "site-b") | .admittedNodeIds.cacheFlush) == ["site-b-secondary"]' \
+  "$degraded_me"
+
+log 'Restarting the Site B Primary and verifying admission only after revalidation'
+compose start site-b-primary >/dev/null
+wait_for_http_json 'Site B Primary' "$SITE_B_PRIMARY_URL/api/status" '.status == "ok"'
+recovered=false
+attempt=0
+while [ "$attempt" -lt 45 ]; do
+  attempt=$((attempt + 1))
+  proxy_request "$REQUEST_DIR/operator.curl" "$degraded_cookie" GET '/api/nodes' >/dev/null 2>&1 || true
+  recovered_me="$(proxy_request "$REQUEST_DIR/operator.curl" "$degraded_cookie" GET '/api/auth/me')"
+  if jq -e \
+    '(.groupCredentials.groups[] | select(.groupId == "site-b") | .state) == "ready" and (.groupCredentials.groups[] | select(.groupId == "site-b") | .admittedNodeIds.primaryConfigWrite) == ["site-b-primary"]' \
+    >/dev/null 2>&1 <<<"$recovered_me"; then
+    recovered=true
+    break
+  fi
+  sleep 2
+done
+if [ "$recovered" != true ]; then
+  fail 'Returning Site B Primary was not safely readmitted'
+fi
+
+log 'Stopping all Site B nodes and verifying Site A keeps the session usable'
+compose stop site-b-primary site-b-secondary >/dev/null
+isolated_me="$(login_and_get_session "$REQUEST_DIR/operator.curl" "$REQUEST_DIR/site-b-down.cookie")"
+assert_filter \
+  'Complete Site B failure leaked into Site A or killed the session' \
+  '.authenticated == true and .groupCredentials.anyReady == true and .groupCredentials.allReady == false and (.groupCredentials.groups[] | select(.groupId == "site-a") | .state) == "ready" and (.groupCredentials.groups[] | select(.groupId == "site-b") | .state) == "unreachable"' \
+  "$isolated_me"
+
+compose start site-b-primary site-b-secondary >/dev/null
+wait_for_http_json 'Site B Primary' "$SITE_B_PRIMARY_URL/api/status" '.status == "ok"'
+wait_for_http_json 'Site B Secondary' "$SITE_B_SECONDARY_URL/api/status" '.status == "ok"'
+fault_injection_active=false
+
+log 'Rechecking the fully healthy two-group session after fault recovery'
+recovered_me="$(login_and_get_session "$REQUEST_DIR/operator.curl" "$REQUEST_DIR/final.cookie")"
+assert_filter \
+  'Both groups did not return to ready after recovery' \
+  '.groupCredentials.anyReady == true and .groupCredentials.allReady == true and ([.groupCredentials.groups[].state] | all(. == "ready"))' \
+  "$recovered_me"
+
+log 'PASS: real two-cluster trusted SSO, group isolation, and recovery checks succeeded'


### PR DESCRIPTION
## Summary

- add strict node-group configuration plus per-group trusted SSO and automation credential maps
- isolate topology, admission, Primary writes, cache flushes, PTR/DHCP enrichment, known clients, and SQLite deduplication by group
- add group-aware status UI, documentation, and a real two-cluster Technitium v15 acceptance harness
- decouple the rolling next image from approval-gated beta promotion and prepare version 1.12.0

## Validation

- npm run lint
- npm test (479 backend passed; 806 frontend passed)
- npm run test:e2e --workspace=apps/backend (12 passed)
- npm run build
- npm audit --omit=dev --audit-level=high (0 vulnerabilities)
- ShellCheck and Docker Compose validation for the acceptance harness
- live two-cluster Technitium 15.3 SSO/isolation acceptance run
- 1,000,000-row SQLite deduplication benchmark

Closes #112