### PR TITLE
fix(ci): preserve immutable channel provenance

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -168,10 +168,44 @@ jobs:
             # beta channel: explicitly promoted, approval-gated candidate
             type=raw,value=beta,enable=${{ github.event_name == 'workflow_dispatch' && inputs.push_image && inputs.channel == 'beta' }}
             type=raw,value=${{ steps.package-version.outputs.version }}-beta,enable=${{ github.event_name == 'workflow_dispatch' && inputs.push_image && inputs.channel == 'beta' }}
-            # Every published branch/tag image also gets an immutable source-revision tag.
-            type=sha,enable=${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
+            # Channel-qualified immutable source tags prevent a beta/stable rebuild
+            # from replacing a different artifact produced from the same commit.
+            type=sha,enable=${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next') }}
+            type=sha,suffix=-beta,enable=${{ github.event_name == 'workflow_dispatch' && inputs.push_image && inputs.channel == 'beta' }}
+            type=sha,suffix=-stable,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             # Manual runs from non-channel refs retain a discoverable rolling alias.
             type=raw,value=manual,enable=${{ github.event_name == 'workflow_dispatch' && inputs.channel != 'beta' && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/next' }}
+
+      - name: Protect immutable source tag
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push_image && inputs.channel == 'beta')
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BUILD_REF: ${{ github.ref }}
+          REQUESTED_CHANNEL: ${{ inputs.channel || 'preview' }}
+        run: |
+          set -euo pipefail
+          short_sha="${GITHUB_SHA::7}"
+          if [[ "$EVENT_NAME" == "workflow_dispatch" && "$REQUESTED_CHANNEL" == "beta" ]]; then
+            immutable_tag="sha-$short_sha-beta"
+          elif [[ "$BUILD_REF" == refs/tags/v* ]]; then
+            immutable_tag="sha-$short_sha-stable"
+          elif [[ "$BUILD_REF" == "refs/heads/main" || "$BUILD_REF" == "refs/heads/next" ]]; then
+            immutable_tag="sha-$short_sha"
+          else
+            exit 0
+          fi
+
+          immutable_ref="$REGISTRY/$IMAGE_NAME:$immutable_tag"
+          if inspect_output="$(docker buildx imagetools inspect "$immutable_ref" 2>&1)"; then
+            echo "::error::Immutable source tag $immutable_ref already exists; refusing to replace it."
+            exit 1
+          fi
+          if [[ "$inspect_output" != *": not found"* ]]; then
+            echo "::error::Unable to verify immutable source tag availability for $immutable_ref."
+            exit 1
+          fi
+          echo "Immutable source tag $immutable_ref is available."
 
       - name: Build and push Docker image
         id: publish-image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ All notable changes to this project will be documented in this file.
 - Beta container publication is now an explicit, environment-gated promotion
   from `next` or `release/*`. The rolling `:next` integration image can advance
   without replacing a beta candidate under active soak testing.
+- Source-revision container tags are channel-qualified for beta and stable
+  rebuilds, and publication fails closed if an immutable source tag already
+  exists instead of silently replacing it with a different digest.
 - DNS Logs SQLite rows, hostname backfill, known clients, and per-client
   deduplication now include the source group, preventing identical private IPs
   in different sites from being combined.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ Docs: [docs/features/SESSION_AUTH_AND_TOKEN_MIGRATION.md](docs/features/SESSION_
 | `1.6`, `1.6.9` | Pinned version tags |
 | `beta` | Approval-gated release candidate promoted from `next` or `release/*` |
 | `next` | Rolling integration build; may advance independently of `beta` |
-| `sha-<commit>` | Immutable build for reproducing a beta result or rollback |
+| `sha-<commit>` | Immutable rolling-channel build from `main` or `next` |
+| `sha-<commit>-beta` | Immutable artifact for reproducing an approved beta |
+| `sha-<commit>-stable` | Immutable artifact produced by a stable release tag |
 
 Want to help soak-test upcoming changes? See the opt-in [Beta Testing
 Guide](docs/BETA_TESTING.md) for install, verification, reporting, and rollback

--- a/docs/BETA_TESTING.md
+++ b/docs/BETA_TESTING.md
@@ -33,7 +33,7 @@ docker compose ps
 The `beta` tag advances only after an explicit promotion and can remain fixed
 while the rolling `next` integration tag receives more changes. For a longer
 test or reliable reproduction, replace `:beta` with the immutable
-`sha-<commit>` tag associated with the promoted build.
+`sha-<commit>-beta` tag associated with the promoted build.
 
 ## Promote a candidate
 
@@ -41,8 +41,10 @@ Maintainers promote a candidate by manually running **Build and Push Docker
 Image** from `next` or a `release/*` branch with `push_image=true` and
 `channel=beta`. The workflow runs the release quality gates, validates the
 source branch, waits for approval through the protected `beta` environment,
-and publishes `:beta`, `<version>-beta`, and `sha-<commit>` to the same image
-digest.
+and publishes `:beta`, `<version>-beta`, and `sha-<commit>-beta` to the same
+image digest. The beta suffix keeps this rebuilt, channel-labelled artifact
+distinct from the `sha-<commit>` preview artifact produced by an ordinary
+`next` push.
 
 ```bash
 gh workflow run docker-publish.yml \
@@ -98,7 +100,7 @@ docker compose pull
 docker compose up -d
 ```
 
-If stable moved during the test, pin the previous known-good `sha-<commit>` tag
+If stable moved during the test, pin the previous known-good source tag
 instead. Restore persistent data only when the beta changed durable state and
 the relevant feature documentation calls for it; a normal image-only rollback
 should not replace data unnecessarily.


### PR DESCRIPTION
## Summary

- give beta and stable rebuilds channel-qualified source tags instead of replacing the preview artifact for the same commit
- fail closed when a source tag already exists or GHCR availability cannot be verified
- stop manual preview rebuilds from minting or replacing immutable source tags
- document sha-commit, sha-commit-beta, and sha-commit-stable semantics

## Evidence

The first protected beta promotion was cancelled before publication after detecting that it would replace sha-8f7ceef with a different channel-labelled digest. Registry verification confirmed beta remained on the prior 1.11 digest, sha-8f7ceef remained on the 1.12 preview digest, and 1.12.0-beta was not created.

## Validation

- workflow YAML parse
- Prettier workflow check
- git diff --check
- GHCR existing-tag and missing-tag behavior
- pre-push backend tests: 479 passed
- pre-push frontend tests: 806 passed