### PR TITLE
fix(ci): normalize GHCR image references

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -196,7 +196,8 @@ jobs:
             exit 0
           fi
 
-          immutable_ref="$REGISTRY/$IMAGE_NAME:$immutable_tag"
+          image_name_lc="$(printf '%s' "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')"
+          immutable_ref="$REGISTRY/$image_name_lc:$immutable_tag"
           if inspect_output="$(docker buildx imagetools inspect "$immutable_ref" 2>&1)"; then
             echo "::error::Immutable source tag $immutable_ref already exists; refusing to replace it."
             exit 1


### PR DESCRIPTION
## Summary

- lowercase github.repository before immutable-tag inspection
- use a POSIX tr transformation so the guard is reproducible with macOS Bash as well as Ubuntu runners

## Root cause

The guard failed closed because github.repository preserved mixed case while Docker image references require lowercase. Metadata-action already normalizes its generated tags.

## Validation

- fresh sha-96cb2f0 reports available against GHCR
- existing sha-8f7ceef reports a collision
- workflow YAML parse and Prettier check
- pre-push backend tests: 479 passed
- pre-push frontend tests: 806 passed