### PR TITLE
docs: surface DNS Logs performance results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Documentation
+
+- Published a user-facing DNS Logs performance overview connecting the
+  reproducible million-row SQLite results, stored-page hostname isolation, and
+  browser request-control measurements. The README, public documentation
+  navigation, beta guide, and About dialog now link operators to the results,
+  methodology, trade-offs, raw data, and reproduction commands.
+
 ## [1.11.0] - 2026-08-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -41,6 +41,32 @@ Docs: [docs/features/SESSION_AUTH_AND_TOKEN_MIGRATION.md](docs/features/SESSION_
 - **Advanced Blocking** - Easy management of domain lists
 - **DHCP Overview** - Compare and sync DHCP scopes across nodes
 
+## DNS Logs at scale
+
+Companion's stored DNS Logs path is tested against a deterministic database of
+1,000,000 query-log rows. The final adaptive SQLite path preserves ordinary
+page-one performance while removing the largest deduplication and count
+hotspots:
+
+| Stored DNS Logs operation | Before | After | Reduction |
+| --- | ---: | ---: | ---: |
+| Domain deduplication | 2,980 ms | 136 ms | 95.4% |
+| Per-client deduplication | 3,250 ms | 196 ms | 94.0% |
+| Blocked-entry count | 1,300 ms | 2 ms | 99.8% |
+
+![Four line charts showing the measured improvements for domain and per-client deduplication, unique-domain counts, and blocked-entry counts.](https://fail-safe.github.io/Technitium-DNS-Companion/performance/images/query-log-benchmark-iterations.svg)
+
+Stored browsing also makes zero live Technitium calls for DHCP hostname
+enrichment, so an unavailable non-DHCP node no longer holds historical pages
+until the network timeout. Production-derived browser validation recorded 69.5%
+fewer completed backend requests and lower tail latency after request
+amplification was removed; the matched median was approximately unchanged.
+
+Absolute timings vary with hardware, storage, retention, and workload. Read the
+[DNS Logs performance overview](https://fail-safe.github.io/Technitium-DNS-Companion/performance/)
+for the methodology, raw results, trade-offs, remaining hotspot, and
+reproduction commands.
+
 ## Web-based User Interface
 
 [Features Light & Dark Mode](https://fail-safe.github.io/Technitium-DNS-Companion/#screenshots)

--- a/apps/frontend/src/components/common/AboutModal.css
+++ b/apps/frontend/src/components/common/AboutModal.css
@@ -29,9 +29,11 @@
   border-radius: 1rem;
   box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
   max-width: 480px;
+  max-height: calc(100dvh - 2rem);
   width: 100%;
   padding: 2rem;
   position: relative;
+  overflow-y: auto;
   animation: slideUp 0.3s ease-out;
 }
 

--- a/apps/frontend/src/components/common/AboutModal.tsx
+++ b/apps/frontend/src/components/common/AboutModal.tsx
@@ -2,6 +2,7 @@ import { faGithub } from "@fortawesome/free-brands-svg-icons";
 import {
   faBalanceScale,
   faBook,
+  faChartLine,
   faExternalLinkAlt,
   faTimes,
 } from "@fortawesome/free-solid-svg-icons";
@@ -142,6 +143,19 @@ export function AboutModal({ isOpen, onClose }: AboutModalProps) {
           >
             <FontAwesomeIcon icon={faGithub} />
             <span>GitHub Repository</span>
+            <FontAwesomeIcon
+              icon={faExternalLinkAlt}
+              className="about-modal__link-external"
+            />
+          </a>
+          <a
+            href="https://fail-safe.github.io/Technitium-DNS-Companion/performance/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="about-modal__link"
+          >
+            <FontAwesomeIcon icon={faChartLine} />
+            <span>DNS Logs Performance</span>
             <FontAwesomeIcon
               icon={faExternalLinkAlt}
               className="about-modal__link-external"

--- a/apps/frontend/src/test/about-modal-performance-link.test.tsx
+++ b/apps/frontend/src/test/about-modal-performance-link.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AboutModal } from "../components/common/AboutModal";
+
+vi.mock("../hooks/useLatestRelease", () => ({
+  useLatestRelease: () => ({
+    latestVersion: null,
+    latestReleaseUrl: null,
+    isChecking: false,
+    isUpdateAvailable: false,
+    error: null,
+  }),
+}));
+
+describe("AboutModal performance documentation", () => {
+  it("links to the public DNS Logs performance overview", () => {
+    render(<AboutModal isOpen onClose={vi.fn()} />);
+
+    const link = screen.getByRole("link", {
+      name: /DNS Logs Performance/i,
+    });
+
+    expect(link).toHaveAttribute(
+      "href",
+      "https://fail-safe.github.io/Technitium-DNS-Companion/performance/",
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+});

--- a/docs/BETA_TESTING.md
+++ b/docs/BETA_TESTING.md
@@ -12,6 +12,9 @@ their image is explicitly changed.
 - Do not test first on the only path you have to administer DNS.
 - Review the current [Unreleased changelog](../CHANGELOG.md#unreleased), with
   particular attention to upgrade notes and security-sensitive features.
+- Review the public [DNS Logs performance overview](performance/index.md) for
+  the measured database, hostname-enrichment, and browser-request improvements
+  you can compare with your own workload.
 
 ## Install with Docker Compose
 
@@ -54,6 +57,10 @@ tokens, proxy secrets, cookies, private hostnames, and private DNS data.
 - Sign in and out, then confirm the expected Technitium identity and RBAC.
 - Check node overview, query logs, zones, filtering, DHCP, and any scheduled
   automation you normally use.
+- In stored DNS Logs, exercise page one, a deep page, deduplication, and the
+  filters you use most often. Performance reports are most useful when they
+  include approximate row count, retention, storage type, page size, and
+  deduplication mode without including private query data.
 - Exercise the deployment behind its real TLS reverse proxy and from a mobile
   viewport if those are part of your environment.
 - Watch container health, restarts, memory, and logs over at least 24 hours.

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ Welcome to the documentation for Technitium DNS Companion. This guide will help 
 
 ### Performance
 
+- **[DNS Logs performance overview](./performance/index.md)** - User-facing results, operational impact, measurement boundaries, and beta feedback guidance
 - **[performance/](./performance/)** - Performance benchmarking and optimization guides
 - **[Query Log SQLite benchmarks](./performance/QUERY_LOG_SQLITE_BENCHMARKS.md)** - Cumulative DNS Logs query benchmarks, charts, and tradeoffs
 - **[DHCP hostname enrichment benchmarks](./performance/DHCP_HOSTNAME_ENRICHMENT_BENCHMARKS.md)** - DHCP capability routing, stored-log isolation, and before/after metrics

--- a/docs/performance/index.md
+++ b/docs/performance/index.md
@@ -1,0 +1,97 @@
+# DNS Logs performance
+
+Technitium DNS Companion is designed to keep stored DNS Logs useful as the
+database grows and as individual DNS nodes become slow or unavailable. The
+project includes deterministic benchmarks, anonymized deployment measurements,
+and reproducible test commands for the database, hostname-enrichment, and
+browser request paths.
+
+## Results at a glance
+
+On a deterministic database containing 1,000,000 query-log rows, the final
+adaptive SQLite path produced these warm median results:
+
+| Stored DNS Logs operation | Before | After | Reduction |
+| --- | ---: | ---: | ---: |
+| Unfiltered domain deduplication | 2,980 ms | 136 ms | 95.4% |
+| Unfiltered per-client deduplication | 3,250 ms | 196 ms | 94.0% |
+| Unique-domain count | 1,680 ms | 5 ms | 99.7% |
+| Blocked-entry count | 1,300 ms | 2 ms | 99.8% |
+| Ordinary page one, deduplication off | 0.03 ms | 0.03 ms | No change |
+
+![Four line charts showing the measured improvements for domain and per-client deduplication, unique-domain counts, and blocked-entry counts.](./images/query-log-benchmark-iterations.svg)
+
+The benchmark reuses an identical deterministic snapshot at every stage. The
+dataset spans 36 hours, 5,000 domains, 8 clients, and 3 generic DNS nodes. See
+the [SQLite benchmark report](./QUERY_LOG_SQLITE_BENCHMARKS.md) for the complete
+method, filtered-query results, raw CSV, and reproduction commands.
+
+## What changes for operators
+
+### Stored pages do not wait on live DHCP nodes
+
+Stored browsing enriches client names from data persisted during ingestion and
+from in-memory DHCP/PTR caches. It makes **zero live Technitium node calls** for
+hostname enrichment. Previously, an unavailable node without active DHCP scopes
+could hold a stored page until the 30-second backend timeout while the browser
+gave up after 25 seconds.
+
+In the controlled capability benchmark, lease-refresh latency fell from
+80.91 ms to 11.18 ms and lease calls fell from three to one. The important
+reliability boundary is stronger than that timing result: stored pages no longer
+depend on current node reachability for hostname enrichment.
+
+![Three paired bar charts showing reduced DHCP refresh latency and lease calls, plus the removal of live-node calls from stored pages.](./images/dhcp-capability-benchmark.svg)
+
+Read the [DHCP capability and stored-log isolation report](./DHCP_HOSTNAME_ENRICHMENT_BENCHMARKS.md)
+for the controlled method, anonymized deployment observations, and raw results.
+
+### Rapid interactions create less abandoned work
+
+DNS Logs requests bypass the PWA runtime cache so browser cancellation reaches
+the network path. Paginated navigation is serialized while a request is active,
+and automatic refresh pauses when entering Paginated mode.
+
+Controlled tests removed all ten modeled cancelled requests that previously
+continued through the service worker, admitted one request instead of five
+rapid page selections, and produced no automatic refreshes during a 30-second
+paginated dwell.
+
+In a production-derived before/after capture, completed backend requests fell
+from 25.5 to 7.8 per minute, a 69.5% reduction. Ten exact query URLs shared by
+both captures had a nearly flat median, while p90 and maximum latency fell by
+31.0% and 36.5%. This supports a reduction in request pile-up and tail latency;
+it is not presented as a median SQL speedup.
+
+![Paired charts showing fewer completed backend requests and lower p90 and maximum latency, with a nearly unchanged matched median.](./images/dns-logs-browser-live-results.svg)
+
+Read the [browser request-control report](./DNS_LOGS_BROWSER_REQUEST_BENCHMARKS.md)
+for the controlled interaction tests, secret-safe HAR analysis, raw aggregates,
+and validation boundary.
+
+## Measurement boundaries and trade-offs
+
+- Absolute timings depend on CPU, storage, cache warmth, retention, traffic
+  distribution, filters, and page size. Relative changes on the same snapshot
+  are the useful comparison.
+- The SQLite benchmark excludes hostname enrichment, JSON handling, HTTP
+  serialization, browser rendering, and the stored-response cache.
+- A rare no-match substring search with deduplication disabled still takes
+  approximately 1.3–1.5 seconds at one million rows.
+- The two new SQLite indexes added approximately 59.5 MiB per million rows in
+  the benchmark. Existing databases build them synchronously during
+  startup; that one-time duration varies with database size and storage.
+- The production browser captures differed in duration and request population.
+  Request rates are normalized, and only matching exact query URLs are used for
+  the closer latency comparison.
+
+## Help validate the results
+
+Beta feedback is most useful when it includes the Companion version and build
+revision, Technitium version, approximate stored-row count, retention window,
+storage type, page size, deduplication mode, filters used, and the operation that
+felt slow. Do not include query contents, private addresses, credentials,
+cookies, or private hostnames.
+
+See the [Beta Testing Guide](../BETA_TESTING.md) for installation, rollback, and
+reporting guidance.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ extra_css:
 nav:
   - Home: index.md
   - Docker: DOCKER.md
+  - Performance: performance/index.md
 markdown_extensions:
   - toc:
       permalink: true
@@ -33,7 +34,6 @@ plugins:
       glob:
         - "features/**"
         - "implementation/**"
-        - "performance/**"
         - "ui/**"
         - "zone-comparison/**"
         - "apps/**"


### PR DESCRIPTION
## Summary

- publish a user-facing DNS Logs performance overview and add it to the public MkDocs navigation
- place measured one-million-row results and operational impact in the repository/docs homepage
- link the overview from the About dialog and keep the enlarged dialog scrollable on short mobile viewports
- add beta feedback guidance and changelog copy for the next release notes

## Measurement boundaries

The overview keeps the existing benchmark caveats: absolute timings vary by deployment, the SQLite benchmark excludes network and rendering work, the browser captures do not establish a median SQL speedup, index storage/startup costs remain visible, and the known no-match substring hotspot is documented.

## Validation

- `npm run lint`
- `npm run test --workspace apps/frontend` — 801 passed, 2 skipped
- `npm run build`
- pre-push backend suite — 452 passed, 10 skipped
- pre-push frontend suite — 801 passed, 2 skipped
- static MkDocs navigation, exclusion-policy, and linked-file checks
- `git diff --check`