### PR TITLE
docs: clarify performance comparison versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,11 @@ Companion's stored DNS Logs path is tested against a deterministic database of
 page-one performance while removing the largest deduplication and count
 hotspots:
 
-| Stored DNS Logs operation | Before | After | Reduction |
+Here, the prior behavior is the path shipped in **v1.10.1** (and earlier
+releases using the same implementation); the optimized behavior was released
+in **v1.11.0**.
+
+| Stored DNS Logs operation | v1.10.1 baseline | v1.11.0 | Reduction |
 | --- | ---: | ---: | ---: |
 | Domain deduplication | 2,980 ms | 136 ms | 95.4% |
 | Per-client deduplication | 3,250 ms | 196 ms | 94.0% |

--- a/docs/performance/DHCP_HOSTNAME_ENRICHMENT_BENCHMARKS.md
+++ b/docs/performance/DHCP_HOSTNAME_ENRICHMENT_BENCHMARKS.md
@@ -4,9 +4,13 @@
 
 DNS Logs stored browsing no longer contacts live Technitium nodes for DHCP hostname enrichment. Background hostname collection discovers which nodes have enabled DHCP scopes and requests leases only from those nodes.
 
+In this report, **Before** means the behavior shipped in Companion v1.10.1 and
+earlier. Capability routing and stored isolation are successive optimization
+stages released together in Companion v1.11.0.
+
 ![Three paired bar charts showing controlled lease-refresh latency falling from 80.91 to 11.18 milliseconds, lease calls per refresh falling from three to one, and live-node calls per stored page falling from three to zero.](./images/dhcp-capability-benchmark.svg)
 
-| Measurement | Before | Capability routing | Stored isolation |
+| Measurement | v1.10.1 baseline | v1.11.0 capability routing | v1.11.0 stored isolation |
 | --- | ---: | ---: | ---: |
 | Controlled slow-node median | 80.91 ms | 11.18 ms | — |
 | Lease calls per refresh | 3 | 1 | — |
@@ -101,7 +105,7 @@ The next iteration reduces abandoned synchronous SQL without changing the query 
 
 ![Two paired bar charts showing typing three client-filter prefixes falling from three automatic requests to one, while pausing on a one-character filter falls from one automatic request to zero.](./images/logs-filter-request-coalescing.svg)
 
-| Controlled interaction | Before | After | Change |
+| Controlled interaction | v1.10.1 behavior | v1.11.0 behavior | Change |
 | --- | ---: | ---: | ---: |
 | Type `a` → `ab` → `abc`, 100 ms apart | 3 requests | 1 request (`abc`) | 66.7% fewer |
 | Pause on `a` | 1 automatic request | 0 automatic requests | 100% fewer |

--- a/docs/performance/DNS_LOGS_BROWSER_REQUEST_BENCHMARKS.md
+++ b/docs/performance/DNS_LOGS_BROWSER_REQUEST_BENCHMARKS.md
@@ -4,11 +4,15 @@
 
 Production-derived browser evidence showed that request cancellation, pagination, and refresh behavior amplified the remaining SQLite query cost. This iteration makes query-log fetches bypass the PWA runtime cache, blocks page navigation while a request is active, and pauses automatic refresh when entering Paginated mode.
 
+In this report, **Before** means the browser behavior shipped in Companion
+v1.10.1 and earlier. **After** means the request-control behavior released in
+Companion v1.11.0.
+
 ![Three paired bar charts showing cancelled work continuing through the service worker falling from ten requests to zero, five rapid page selections admitting one request instead of five, and a thirty-second paginated dwell producing zero automatic refreshes instead of ten.](./images/dns-logs-browser-request-admission.svg)
 
 ![Two before-and-after bar charts showing completed backend request rate falling by 69.5 percent while exact-query median latency remains nearly flat and p90 and maximum latency fall by 31.0 and 36.5 percent.](./images/dns-logs-browser-live-results.svg)
 
-| Controlled interaction | Before | After | Change |
+| Controlled interaction | v1.10.1 behavior | v1.11.0 behavior | Change |
 | --- | ---: | ---: | ---: |
 | Cancelled stored-log requests routed through Workbox | 10 | 0 | 100% removed |
 | Five rapid page selections admitted | 5 | 1 | 80% fewer |
@@ -18,11 +22,11 @@ These measurements quantify request admission, not SQLite execution speed. They 
 
 Raw measurements are available in [dns-logs-browser-request-results.csv](./dns-logs-browser-request-results.csv).
 
-## Production HAR baseline
+## Production HAR baseline (v1.10.1 behavior)
 
-The before capture came from a production-test build backed by an anonymized deployment database. The capture observed 101 seconds of Combined Stored browsing with 200 rows per page and domain-plus-client deduplication enabled. It included filter changes, automatic refreshes, and navigation through deep pages.
+The v1.10.1-behavior capture came from a production-test build backed by an anonymized deployment database. The capture observed 101 seconds of Combined Stored browsing with 200 rows per page and domain-plus-client deduplication enabled. It included filter changes, automatic refreshes, and navigation through deep pages.
 
-| HAR measurement | Before |
+| HAR measurement | v1.10.1 baseline |
 | --- | ---: |
 | Browser stored-log fetches | 43 |
 | Completed network fetches | 43 |
@@ -37,11 +41,11 @@ Chrome recorded the page-to-service-worker fetch and Workbox-to-network fetch se
 
 The deepest requests overlapped. Pages 9 through 13 started within about one second; their durations ranged from 3,596 to 16,532 ms. Two requests spent about six seconds establishing a connection, including TLS, while synchronous SQLite work was active. This is evidence of request pile-up and event-loop starvation, not a single 16-second SQL execution.
 
-## Production-test after capture
+## Production-test v1.11.0 capture
 
-The accepted after capture observed 154 seconds against the same anonymized deployment database, with 200 rows and domain-plus-client deduplication. The analyzer identified direct browser routing and zero Workbox network fetches.
+The accepted v1.11.0 capture observed 154 seconds against the same anonymized deployment database, with 200 rows and domain-plus-client deduplication. The analyzer identified direct browser routing and zero Workbox network fetches.
 
-| Live measurement | Before | After | Change |
+| Live measurement | v1.10.1 behavior | v1.11.0 behavior | Change |
 | --- | ---: | ---: | ---: |
 | Completed backend requests per minute | 25.5 | 7.8 | 69.5% fewer |
 | Browser fetches per minute | 25.5 | 9.4 | 63.4% fewer |
@@ -51,11 +55,11 @@ The accepted after capture observed 154 seconds against the same anonymized depl
 | All completed requests: maximum | 16,532 ms | 5,505 ms | 66.7% lower |
 | HTTP errors | 0 | 0 | unchanged |
 
-The overall median mixes different request populations. The before capture contained 17 repeated requests and 14 sub-100 ms responses; the after capture contained no repeated exact queries and no sub-100 ms responses. The higher overall median therefore must not be interpreted as a like-for-like SQL regression.
+The overall median mixes different request populations. The v1.10.1-behavior capture contained 17 repeated requests and 14 sub-100 ms responses; the v1.11.0 capture contained no repeated exact queries and no sub-100 ms responses. The higher overall median therefore must not be interpreted as a like-for-like SQL regression.
 
 For a closer latency comparison, the analysis matched the ten exact query URLs present in both captures. This holds page number, row count, sort, deduplication, and filter values constant. Each URL is represented by its median when repeated within a capture.
 
-| Ten matched exact queries | Before | After | Change |
+| Ten matched exact queries | v1.10.1 behavior | v1.11.0 behavior | Change |
 | --- | ---: | ---: | ---: |
 | Median of query medians | 3,327 ms | 3,465 ms | 4.1% higher |
 | p90 of query medians | 7,012 ms | 4,835 ms | 31.0% lower |
@@ -85,7 +89,7 @@ The repository includes a secret-safe HAR analyzer. It reports aggregate request
 node apps/frontend/scripts/analyze-logs-har.mjs /path/to/capture.har
 ```
 
-Pass before and after HARs together to reproduce the normalized request rates and privacy-safe exact-query latency comparison:
+Pass the v1.10.1-behavior baseline and v1.11.0 HARs together to reproduce the normalized request rates and privacy-safe exact-query latency comparison:
 
 ```bash
 node apps/frontend/scripts/analyze-logs-har.mjs \
@@ -103,7 +107,7 @@ RUN_LOG_FILTER_BENCHMARKS=true \
 
 The benchmark executes the production routing and request-admission policies. The production HAR remains private because it contains DNS-log response bodies and internal identifiers; only anonymized aggregates are committed.
 
-### Comparable live after-capture
+### Comparable live v1.11.0 capture
 
 Use the deployed production-test build and the same authenticated browser profile as the baseline:
 
@@ -116,7 +120,7 @@ Use the deployed production-test build and the same authenticated browser profil
 
 The browser profile matters because Companion API requests require an authenticated session. Do not commit the HAR or session material.
 
-The first attempted after capture was rejected before comparison because the analyzer reported `routing: "service-worker"`; its open tab still used the previous application generation. After unregistering the old service worker and reopening the application, the accepted capture reported `routing: "direct"`. Rejected measurements are not included in the result tables.
+The first attempted v1.11.0 capture was rejected before comparison because the analyzer reported `routing: "service-worker"`; its open tab still used the previous application generation. After unregistering the old service worker and reopening the application, the accepted v1.11.0 capture reported `routing: "direct"`. Rejected measurements are not included in the result tables.
 
 ## Validation boundary
 

--- a/docs/performance/QUERY_LOG_SQLITE_BENCHMARKS.md
+++ b/docs/performance/QUERY_LOG_SQLITE_BENCHMARKS.md
@@ -4,9 +4,12 @@
 
 The final adaptive query path removes four multi-second SQLite hotspots on the DNS Logs page without slowing normal page-one browsing or selective filtered searches.
 
+The baseline models the query path shipped in Companion v1.10.1 and earlier.
+The final column is the optimized path released in Companion v1.11.0.
+
 ![Four small line charts showing unfiltered domain dedup falling from 2.98 seconds to 136 milliseconds, per-client dedup from 3.25 seconds to 196 milliseconds, unique-domain count from 1.68 seconds to 5 milliseconds, and blocked count from 1.30 seconds to 2 milliseconds.](./images/query-log-benchmark-iterations.svg)
 
-| DNS Logs operation | Baseline warm median | Final warm median | Reduction |
+| DNS Logs operation | v1.10.1 baseline warm median | v1.11.0 warm median | Reduction |
 | --- | ---: | ---: | ---: |
 | Unfiltered domain dedup | 2,980 ms | 136 ms | 95.4% |
 | Deep domain-dedup page (offset 2,500) | 2,920 ms | 145 ms | 95.0% |
@@ -94,7 +97,7 @@ A no-match substring search with deduplication disabled still takes approximatel
 
 The benchmark measures SQLite query execution only. It excludes hostname enrichment, JSON parsing, HTTP serialization, browser rendering, and the server's 15-second stored-response cache.
 
-Hostname enrichment was measured separately after deployment exposed a live-node dependency. See [DHCP Capability Discovery and Stored-Log Isolation](./DHCP_HOSTNAME_ENRICHMENT_BENCHMARKS.md) for the subsequent before/after series.
+Hostname enrichment was measured separately after deployment exposed a live-node dependency. See [DHCP Capability Discovery and Stored-Log Isolation](./DHCP_HOSTNAME_ENRICHMENT_BENCHMARKS.md) for the subsequent v1.10.1-to-v1.11.0 series.
 
 ## Reproducing the stages
 

--- a/docs/performance/index.md
+++ b/docs/performance/index.md
@@ -6,12 +6,18 @@ project includes deterministic benchmarks, anonymized deployment measurements,
 and reproducible test commands for the database, hostname-enrichment, and
 browser request paths.
 
+> **Version context:** Throughout this overview and the linked reports,
+> **Before** means the behavior shipped in Companion v1.10.1 (and earlier
+> releases using the same implementation). **After** means the optimized
+> implementation released in Companion v1.11.0. Named intermediate stages are
+> benchmark iterations between those two released versions.
+
 ## Results at a glance
 
 On a deterministic database containing 1,000,000 query-log rows, the final
 adaptive SQLite path produced these warm median results:
 
-| Stored DNS Logs operation | Before | After | Reduction |
+| Stored DNS Logs operation | v1.10.1 baseline | v1.11.0 | Reduction |
 | --- | ---: | ---: | ---: |
 | Unfiltered domain deduplication | 2,980 ms | 136 ms | 95.4% |
 | Unfiltered per-client deduplication | 3,250 ms | 196 ms | 94.0% |
@@ -57,11 +63,12 @@ continued through the service worker, admitted one request instead of five
 rapid page selections, and produced no automatic refreshes during a 30-second
 paginated dwell.
 
-In a production-derived before/after capture, completed backend requests fell
-from 25.5 to 7.8 per minute, a 69.5% reduction. Ten exact query URLs shared by
-both captures had a nearly flat median, while p90 and maximum latency fell by
-31.0% and 36.5%. This supports a reduction in request pile-up and tail latency;
-it is not presented as a median SQL speedup.
+In production-derived captures of the v1.10.1 behavior and the v1.11.0
+implementation, completed backend requests fell from 25.5 to 7.8 per minute, a
+69.5% reduction. Ten exact query URLs shared by both captures had a nearly flat
+median, while p90 and maximum latency fell by 31.0% and 36.5%. This supports a
+reduction in request pile-up and tail latency; it is not presented as a median
+SQL speedup.
 
 ![Paired charts showing fewer completed backend requests and lower p90 and maximum latency, with a nearly unchanged matched median.](./images/dns-logs-browser-live-results.svg)
 


### PR DESCRIPTION
## Summary

- define `Before` as the behavior shipped in v1.10.1 and earlier releases using the same paths
- define `After` as the optimized implementation released in v1.11.0
- replace ambiguous summary-table headings with explicit v1.10.1 and v1.11.0 labels
- carry the same context into the SQLite, DHCP enrichment, and browser request-control reports

The browser baseline is deliberately described as **v1.10.1 behavior** rather than claiming that the production-test capture itself was made from a tagged v1.10.1 binary.

## Validation

- `git diff --check`
- static check for required version context and unversioned comparison columns
- pre-push backend suite — 452 passed, 10 skipped
- pre-push frontend suite — 801 passed, 2 skipped